### PR TITLE
Internalize block global and gas hold settings

### DIFF
--- a/binary_port/src/state_request.rs
+++ b/binary_port/src/state_request.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    BlockIdentifier, Digest, GlobalStateIdentifier, Key, KeyTag, Timestamp,
+    BlockIdentifier, Digest, GlobalStateIdentifier, Key, KeyTag,
 };
 
 use crate::PurseIdentifier;
@@ -63,8 +63,6 @@ pub enum GlobalStateRequest {
         state_identifier: Option<GlobalStateIdentifier>,
         /// Purse identifier.
         purse_identifier: PurseIdentifier,
-        /// Timestamp used for holds lookup.
-        timestamp: Timestamp,
     },
 }
 
@@ -108,7 +106,6 @@ impl GlobalStateRequest {
                     .gen::<bool>()
                     .then(|| GlobalStateIdentifier::random(rng)),
                 purse_identifier: PurseIdentifier::random(rng),
-                timestamp: Timestamp::random(rng),
             },
             _ => unreachable!(),
         }
@@ -165,12 +162,10 @@ impl ToBytes for GlobalStateRequest {
             GlobalStateRequest::BalanceByStateRoot {
                 state_identifier,
                 purse_identifier,
-                timestamp,
             } => {
                 BALANCE_BY_STATE_ROOT_TAG.write_bytes(writer)?;
                 state_identifier.write_bytes(writer)?;
-                purse_identifier.write_bytes(writer)?;
-                timestamp.write_bytes(writer)
+                purse_identifier.write_bytes(writer)
             }
         }
     }
@@ -203,12 +198,7 @@ impl ToBytes for GlobalStateRequest {
                 GlobalStateRequest::BalanceByStateRoot {
                     state_identifier,
                     purse_identifier,
-                    timestamp,
-                } => {
-                    state_identifier.serialized_length()
-                        + purse_identifier.serialized_length()
-                        + timestamp.serialized_length()
-                }
+                } => state_identifier.serialized_length() + purse_identifier.serialized_length(),
             }
     }
 }
@@ -270,12 +260,10 @@ impl FromBytes for GlobalStateRequest {
             BALANCE_BY_STATE_ROOT_TAG => {
                 let (state_identifier, remainder) = FromBytes::from_bytes(remainder)?;
                 let (purse_identifier, remainder) = FromBytes::from_bytes(remainder)?;
-                let (timestamp, remainder) = FromBytes::from_bytes(remainder)?;
                 Ok((
                     GlobalStateRequest::BalanceByStateRoot {
                         state_identifier,
                         purse_identifier,
-                        timestamp,
                     },
                     remainder,
                 ))

--- a/execution_engine/src/engine_state/engine_config.rs
+++ b/execution_engine/src/engine_state/engine_config.rs
@@ -81,8 +81,6 @@ pub struct EngineConfig {
     pub(crate) fee_handling: FeeHandling,
     /// Compute auction rewards.
     pub(crate) compute_rewards: bool,
-    /// The period over which balance holds decay.
-    pub(crate) balance_hold_interval: TimeDiff,
 }
 
 impl Default for EngineConfig {
@@ -103,7 +101,6 @@ impl Default for EngineConfig {
             fee_handling: DEFAULT_FEE_HANDLING,
             compute_rewards: DEFAULT_COMPUTE_REWARDS,
             protocol_version: DEFAULT_PROTOCOL_VERSION,
-            balance_hold_interval: DEFAULT_BALANCE_HOLD_INTERVAL,
         }
     }
 }
@@ -397,9 +394,6 @@ impl EngineConfigBuilder {
             .max_delegators_per_validator
             .unwrap_or(DEFAULT_MAX_DELEGATORS_PER_VALIDATOR);
         let compute_rewards = self.compute_rewards.unwrap_or(DEFAULT_COMPUTE_REWARDS);
-        let balance_hold_interval = self
-            .balance_hold_interval
-            .unwrap_or(DEFAULT_BALANCE_HOLD_INTERVAL);
 
         EngineConfig {
             max_associated_keys,
@@ -417,7 +411,6 @@ impl EngineConfigBuilder {
             vesting_schedule_period_millis,
             max_delegators_per_validator,
             compute_rewards,
-            balance_hold_interval,
         }
     }
 }

--- a/execution_engine/src/runtime/auction_internal.rs
+++ b/execution_engine/src/runtime/auction_internal.rs
@@ -16,7 +16,7 @@ use casper_types::{
         auction::{BidAddr, BidKind, EraInfo, Error, UnbondingPurse},
         mint,
     },
-    CLTyped, CLValue, HoldsEpoch, Key, KeyTag, PublicKey, RuntimeArgs, StoredValue, URef, U512,
+    CLTyped, CLValue, Key, KeyTag, PublicKey, RuntimeArgs, StoredValue, URef, U512,
 };
 
 use super::Runtime;
@@ -244,7 +244,6 @@ where
                     contract.main_purse(),
                     *unbonding_purse.amount(),
                     None,
-                    HoldsEpoch::NOT_APPLICABLE,
                 )
                 .map_err(|_| Error::Transfer)?
                 .map_err(|_| Error::Transfer)?;
@@ -265,7 +264,6 @@ where
         target: URef,
         amount: U512,
         id: Option<u64>,
-        _holds_epoch: HoldsEpoch,
     ) -> Result<Result<(), mint::Error>, Error> {
         if !(self.context.entity().main_purse().addr() == source.addr()
             || self.context.get_caller() == PublicKey::System.to_account_hash())
@@ -342,12 +340,8 @@ where
         })
     }
 
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error> {
-        Runtime::available_balance(self, purse, holds_epoch)
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
+        Runtime::available_balance(self, purse)
             .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::GetBalance))
     }
 

--- a/execution_engine/src/runtime/handle_payment_internal.rs
+++ b/execution_engine/src/runtime/handle_payment_internal.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 
 use casper_types::{
     account::AccountHash, addressable_entity::NamedKeyAddr, system::handle_payment::Error, CLValue,
-    FeeHandling, HoldsEpoch, Key, Phase, RefundHandling, StoredValue, TransferredTo, URef, U512,
+    FeeHandling, Key, Phase, RefundHandling, StoredValue, TransferredTo, URef, U512,
 };
 
 use casper_storage::system::handle_payment::{
@@ -63,12 +63,8 @@ where
         }
     }
 
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error> {
-        Runtime::available_balance(self, purse, holds_epoch)
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
+        Runtime::available_balance(self, purse)
             .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::GetBalance))
     }
 

--- a/execution_engine/src/runtime/mint_internal.rs
+++ b/execution_engine/src/runtime/mint_internal.rs
@@ -14,8 +14,7 @@ use casper_types::{
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     system::{mint::Error, Caller},
-    AddressableEntity, CLTyped, CLValue, HoldsEpoch, Key, Phase, StoredValue, SystemEntityRegistry,
-    URef, U512,
+    AddressableEntity, CLTyped, CLValue, Key, Phase, StoredValue, SystemEntityRegistry, URef, U512,
 };
 
 use super::Runtime;
@@ -46,6 +45,29 @@ where
         Runtime::<'a, R>::get_immediate_caller(self).cloned()
     }
 
+    fn is_called_from_standard_payment(&self) -> bool {
+        self.context.phase() == Phase::Payment && self.module.is_none()
+    }
+
+    fn get_system_entity_registry(&self) -> Result<SystemEntityRegistry, ProviderError> {
+        self.context.system_entity_registry().map_err(|err| {
+            error!(%err, "unable to obtain system entity registry during transfer");
+            ProviderError::SystemEntityRegistry
+        })
+    }
+
+    fn read_addressable_entity_by_account_hash(
+        &mut self,
+        account_hash: AccountHash,
+    ) -> Result<Option<AddressableEntity>, ProviderError> {
+        self.context
+            .read_addressable_entity_by_account_hash(account_hash)
+            .map_err(|err| {
+                error!(%err, "error reading addressable entity by account hash");
+                ProviderError::AddressableEntityByAccountHash(account_hash)
+            })
+    }
+
     fn get_phase(&self) -> Phase {
         self.context.phase()
     }
@@ -72,31 +94,8 @@ where
         self.context.engine_config().is_administrator(account_hash)
     }
 
-    fn get_system_entity_registry(&self) -> Result<SystemEntityRegistry, ProviderError> {
-        self.context.system_entity_registry().map_err(|err| {
-            error!(%err, "unable to obtain system entity registry during transfer");
-            ProviderError::SystemEntityRegistry
-        })
-    }
-
     fn allow_unrestricted_transfers(&self) -> bool {
         self.context.engine_config().allow_unrestricted_transfers()
-    }
-
-    fn is_called_from_standard_payment(&self) -> bool {
-        self.context.phase() == Phase::Payment && self.module.is_none()
-    }
-
-    fn read_addressable_entity_by_account_hash(
-        &mut self,
-        account_hash: AccountHash,
-    ) -> Result<Option<AddressableEntity>, ProviderError> {
-        self.context
-            .read_addressable_entity_by_account_hash(account_hash)
-            .map_err(|err| {
-                error!(%err, "error reading addressable entity by account hash");
-                ProviderError::AddressableEntityByAccountHash(account_hash)
-            })
     }
 }
 
@@ -146,12 +145,8 @@ where
             .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::Storage))
     }
 
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error> {
-        Runtime::available_balance(self, purse, holds_epoch)
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
+        Runtime::available_balance(self, purse)
             .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::Storage))
     }
 

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -48,12 +48,12 @@ use casper_types::{
         handle_payment, mint, Caller, SystemEntityType, AUCTION, HANDLE_PAYMENT, MINT,
         STANDARD_PAYMENT,
     },
-    AccessRights, ApiError, BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash, ByteCodeKind, CLTyped,
-    CLValue, ContextAccessRights, ContractWasm, EntityAddr, EntityKind, EntityVersion,
-    EntityVersionKey, EntityVersions, Gas, GrantedAccess, Group, Groups, HoldsEpoch, HostFunction,
-    HostFunctionCost, InitiatorAddr, Key, NamedArg, Package, PackageHash, PackageStatus, Phase,
-    PublicKey, RuntimeArgs, StoredValue, Tagged, Transfer, TransferResult, TransferV2,
-    TransferredTo, URef, DICTIONARY_ITEM_KEY_MAX_LENGTH, U512,
+    AccessRights, ApiError, BlockGlobalAddr, BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash,
+    ByteCodeKind, CLTyped, CLValue, ContextAccessRights, ContractWasm, EntityAddr, EntityKind,
+    EntityVersion, EntityVersionKey, EntityVersions, Gas, GrantedAccess, Group, Groups,
+    HostFunction, HostFunctionCost, InitiatorAddr, Key, NamedArg, Package, PackageHash,
+    PackageStatus, Phase, PublicKey, RuntimeArgs, StoredValue, Tagged, Transfer, TransferResult,
+    TransferV2, TransferredTo, URef, DICTIONARY_ITEM_KEY_MAX_LENGTH, U512,
 };
 
 use crate::{
@@ -554,14 +554,6 @@ where
         }
     }
 
-    /// Returns holds epoch.
-    fn holds_epoch(&self) -> HoldsEpoch {
-        HoldsEpoch::from_block_time(
-            self.context.get_blocktime(),
-            self.context.engine_config().balance_hold_interval,
-        )
-    }
-
     /// Calls host mint contract.
     fn call_host_mint(
         &mut self,
@@ -628,11 +620,9 @@ where
                 mint_runtime.charge_system_contract_call(mint_costs.balance)?;
 
                 let uref: URef = Self::get_named_argument(runtime_args, mint::ARG_PURSE)?;
-                let holds_epoch = self.holds_epoch();
 
-                let maybe_balance: Option<U512> = mint_runtime
-                    .balance(uref, holds_epoch)
-                    .map_err(Self::reverter)?;
+                let maybe_balance: Option<U512> =
+                    mint_runtime.balance(uref).map_err(Self::reverter)?;
                 CLValue::from_t(maybe_balance).map_err(Self::reverter)
             })(),
             // Type: `fn transfer(maybe_to: Option<AccountHash>, source: URef, target: URef, amount:
@@ -646,9 +636,8 @@ where
                 let target: URef = Self::get_named_argument(runtime_args, mint::ARG_TARGET)?;
                 let amount: U512 = Self::get_named_argument(runtime_args, mint::ARG_AMOUNT)?;
                 let id: Option<u64> = Self::get_named_argument(runtime_args, mint::ARG_ID)?;
-                let holds_epoch = self.holds_epoch();
                 let result: Result<(), mint::Error> =
-                    mint_runtime.transfer(maybe_to, source, target, amount, id, holds_epoch);
+                    mint_runtime.transfer(maybe_to, source, target, amount, id);
 
                 CLValue::from_t(result).map_err(Self::reverter)
             })(),
@@ -832,10 +821,8 @@ where
                 let delegation_rate =
                     Self::get_named_argument(runtime_args, auction::ARG_DELEGATION_RATE)?;
                 let amount = Self::get_named_argument(runtime_args, auction::ARG_AMOUNT)?;
-                let holds_epoch = self.holds_epoch();
-
                 let result = runtime
-                    .add_bid(account_hash, delegation_rate, amount, holds_epoch)
+                    .add_bid(account_hash, delegation_rate, amount)
                     .map_err(Self::reverter)?;
 
                 CLValue::from_t(result).map_err(Self::reverter)
@@ -864,7 +851,6 @@ where
                     self.context.engine_config().max_delegators_per_validator();
                 let minimum_delegation_amount =
                     self.context.engine_config().minimum_delegation_amount();
-                let holds_epoch = self.holds_epoch();
                 let result = runtime
                     .delegate(
                         delegator,
@@ -872,7 +858,6 @@ where
                         amount,
                         max_delegators_per_validator,
                         minimum_delegation_amount,
-                        holds_epoch,
                     )
                     .map_err(Self::reverter)?;
 
@@ -2435,14 +2420,9 @@ where
             return Err(ExecError::DisabledUnrestrictedTransfers);
         }
 
-        let holds_epoch = self.holds_epoch();
         // A precondition check that verifies that the transfer can be done
         // as the source purse has enough funds to cover the transfer.
-        if amount
-            > self
-                .available_balance(source, holds_epoch)?
-                .unwrap_or_default()
-        {
+        if amount > self.available_balance(source)?.unwrap_or_default() {
             return Ok(Err(mint::Error::InsufficientFunds.into()));
         }
 
@@ -2698,12 +2678,8 @@ where
         }
     }
 
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, ExecError> {
-        match self.context.available_balance(&purse, holds_epoch) {
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, ExecError> {
+        match self.context.available_balance(&purse) {
             Ok(motes) => Ok(Some(motes.value())),
             Err(err) => Err(err),
         }
@@ -2728,7 +2704,7 @@ where
             }
         };
 
-        let balance = match self.available_balance(purse, self.holds_epoch())? {
+        let balance = match self.available_balance(purse)? {
             Some(balance) => balance,
             None => return Ok(Err(ApiError::InvalidPurse)),
         };
@@ -3442,7 +3418,10 @@ where
             prev_topic_summary.message_count()
         };
 
-        let block_message_index: u64 = match self.context.read_gs(&Key::BlockMessageCount)? {
+        let block_message_index: u64 = match self
+            .context
+            .read_gs(&Key::BlockGlobal(BlockGlobalAddr::MessageCount))?
+        {
             Some(stored_value) => {
                 let (prev_block_time, prev_count): (BlockTime, u64) = CLValue::into_t(
                     CLValue::try_from(stored_value).map_err(ExecError::TypeMismatch)?,

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -31,10 +31,10 @@ use casper_types::{
     handle_stored_dictionary_value,
     system::auction::EraInfo,
     AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, CLType, CLValue,
-    CLValueDictionary, ContextAccessRights, EntityAddr, EntryPointType, Gas, GrantedAccess,
-    HoldsEpoch, Key, KeyTag, Motes, Package, PackageHash, Phase, ProtocolVersion, PublicKey,
-    RuntimeArgs, StoredValue, StoredValueTypeMismatch, SystemEntityRegistry, TransactionHash,
-    Transfer, URef, URefAddr, DICTIONARY_ITEM_KEY_MAX_LENGTH, KEY_HASH_LENGTH, U512,
+    CLValueDictionary, ContextAccessRights, EntityAddr, EntryPointType, Gas, GrantedAccess, Key,
+    KeyTag, Motes, Package, PackageHash, Phase, ProtocolVersion, PublicKey, RuntimeArgs,
+    StoredValue, StoredValueTypeMismatch, SystemEntityRegistry, TransactionHash, Transfer, URef,
+    URefAddr, DICTIONARY_ITEM_KEY_MAX_LENGTH, KEY_HASH_LENGTH, U512,
 };
 
 use crate::{engine_state::EngineConfig, execution::ExecError};
@@ -438,25 +438,12 @@ where
     /// Reads the available balance of a purse [`URef`].
     ///
     /// Currently address of a purse [`URef`] is also a hash in the [`Key::Hash`] space.
-    pub(crate) fn available_balance(
-        &mut self,
-        purse_uref: &URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Motes, ExecError> {
+    pub(crate) fn available_balance(&mut self, purse_uref: &URef) -> Result<Motes, ExecError> {
         let key = Key::URef(*purse_uref);
         self.tracking_copy
             .borrow_mut()
-            .get_available_balance(key, holds_epoch)
+            .get_available_balance(key)
             .map_err(ExecError::TrackingCopy)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn write_balance(
-        &mut self,
-        purse_uref: URef,
-        cl_value: CLValue,
-    ) -> Result<(), ExecError> {
-        self.metered_write_gs_unsafe(Key::Balance(purse_uref.addr()), cl_value)
     }
 
     /// Read a stored value under a [`Key`].

--- a/execution_engine_testing/test_support/src/transfer_request_builder.rs
+++ b/execution_engine_testing/test_support/src/transfer_request_builder.rs
@@ -17,8 +17,8 @@ use casper_types::{
     account::AccountHash,
     bytesrepr::ToBytes,
     system::mint::{ARG_AMOUNT, ARG_ID, ARG_SOURCE, ARG_TARGET},
-    BlockTime, CLValue, Digest, FeeHandling, Gas, HoldsEpoch, InitiatorAddr, ProtocolVersion,
-    RefundHandling, RuntimeArgs, TransactionHash, TransactionV1Hash, TransferTarget, URef,
+    BlockTime, CLValue, Digest, FeeHandling, Gas, InitiatorAddr, ProtocolVersion, RefundHandling,
+    RuntimeArgs, TransactionHash, TransactionV1Hash, TransferTarget, URef,
     DEFAULT_GAS_HOLD_INTERVAL, U512,
 };
 
@@ -155,9 +155,6 @@ impl TransferRequestBuilder {
     /// that this generated hash is not the same as what would have been generated on an actual
     /// `Transaction` for an equivalent request.
     pub fn build(self) -> TransferRequest {
-        let holds_epoch =
-            HoldsEpoch::from_millis(self.block_time.value(), self.config.balance_hold_interval());
-
         let txn_hash = match self.transaction_hash {
             Some(txn_hash) => txn_hash,
             None => {
@@ -211,7 +208,6 @@ impl TransferRequestBuilder {
         TransferRequest::with_runtime_args(
             self.config,
             self.state_hash,
-            holds_epoch,
             self.protocol_version,
             txn_hash,
             self.initiator,

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -43,6 +43,7 @@ use casper_storage::{
     system::runtime_native::{Config as NativeRuntimeConfig, TransferConfig},
     tracking_copy::TrackingCopyExt,
 };
+
 use casper_types::{
     account::AccountHash,
     addressable_entity::{EntityKindTag, NamedKeyAddr, NamedKeys},
@@ -59,9 +60,9 @@ use casper_types::{
         },
         AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT,
     },
-    AddressableEntity, AddressableEntityHash, AuctionCosts, BlockTime, ByteCode, ByteCodeAddr,
-    ByteCodeHash, CLTyped, CLValue, Contract, Digest, EntityAddr, EraId, Gas, HandlePaymentCosts,
-    HoldsEpoch, InitiatorAddr, Key, KeyTag, MintCosts, Motes, Package, PackageHash,
+    AddressableEntity, AddressableEntityHash, AuctionCosts, BlockGlobalAddr, BlockTime, ByteCode,
+    ByteCodeAddr, ByteCodeHash, CLTyped, CLValue, Contract, Digest, EntityAddr, EraId, Gas,
+    HandlePaymentCosts, InitiatorAddr, Key, KeyTag, MintCosts, Motes, Package, PackageHash,
     ProtocolUpgradeConfig, ProtocolVersion, PublicKey, RefundHandling, StoredValue,
     SystemEntityRegistry, TransactionHash, TransactionV1Hash, URef, OS_PAGE_SIZE, U512,
 };
@@ -552,7 +553,8 @@ impl LmdbWasmTestBuilder {
         transfer_request.set_state_hash_and_config(pre_state_hash, self.native_runtime_config());
         let transfer_result = self.data_access_layer.transfer(transfer_request);
         let gas = Gas::new(self.chainspec.system_costs_config.mint_costs().transfer);
-        let execution_result = WasmV1Result::from_transfer_result(transfer_result, gas).unwrap();
+        let execution_result = WasmV1Result::from_transfer_result(transfer_result, gas)
+            .expect("transfer result should map to wasm v1 result");
         let effects = execution_result.effects().clone();
         self.effects.push(effects.clone());
         self.exec_results.push(execution_result);
@@ -963,10 +965,6 @@ where
         block_time: u64,
     ) -> FeeResult {
         let native_runtime_config = self.native_runtime_config();
-        let holds_epoch = HoldsEpoch::from_millis(
-            block_time,
-            self.chainspec.core_config.gas_hold_interval.millis(),
-        );
 
         let pre_state_hash = pre_state_hash.or(self.post_state_hash).unwrap();
         let fee_req = FeeRequest::new(
@@ -974,7 +972,6 @@ where
             pre_state_hash,
             protocol_version,
             block_time.into(),
-            holds_epoch,
         );
         let fee_result = self.data_access_layer.distribute_fees(fee_req);
 
@@ -1151,6 +1148,45 @@ where
         self
     }
 
+    /// Sets blocktime into global state.
+    pub fn with_block_time(&mut self, block_time: BlockTime) -> &mut Self {
+        if let Some(state_root_hash) = self.post_state_hash {
+            let mut tracking_copy = self
+                .data_access_layer
+                .tracking_copy(state_root_hash)
+                .expect("should not error on checkout")
+                .expect("should checkout tracking copy");
+
+            let cl_value = CLValue::from_t(block_time.value()).expect("should get cl value");
+            tracking_copy.write(
+                Key::BlockGlobal(BlockGlobalAddr::BlockTime),
+                StoredValue::CLValue(cl_value),
+            );
+            self.commit_transforms(state_root_hash, tracking_copy.effects());
+            //
+            // // reacquire root hash
+            // if let Some(new_state_root_hash) = self.post_state_hash {
+            //     assert_ne!(
+            //         state_root_hash, new_state_root_hash,
+            //         "root hash should have changed"
+            //     );
+            //     let mut tracking_copy = self
+            //         .data_access_layer
+            //         .tracking_copy(new_state_root_hash)
+            //         .expect("should not error on checkout")
+            //         .expect("should checkout tracking copy");
+            //     let value = tracking_copy
+            //         .read(&Key::BlockGlobal(BlockGlobalAddr::BlockTime))
+            //         .expect("should not error")
+            //         .expect("block time record should exist");
+            //
+            //     println!("{:?}", value);
+            // }
+        }
+
+        self
+    }
+
     /// Returns the engine state.
     pub fn get_engine_state(&self) -> &ExecutionEngineV1 {
         &self.execution_engine
@@ -1224,16 +1260,12 @@ where
         &self,
         protocol_version: ProtocolVersion,
         balance_identifier: BalanceIdentifier,
-        block_time: u64,
     ) -> BalanceResult {
-        let hold_interval = self.chainspec.core_config.gas_hold_interval;
-        let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval.millis());
-        let balance_handling = BalanceHandling::Available { holds_epoch };
+        let balance_handling = BalanceHandling::Available;
         let proof_handling = ProofHandling::Proofs;
         let state_root_hash: Digest = self.post_state_hash.expect("should have post_state_hash");
         let request = BalanceRequest::new(
             state_root_hash,
-            block_time.into(),
             protocol_version,
             balance_identifier,
             balance_handling,
@@ -1247,16 +1279,12 @@ where
         &self,
         protocol_version: ProtocolVersion,
         public_key: PublicKey,
-        block_time: u64,
     ) -> BalanceResult {
         let state_root_hash: Digest = self.post_state_hash.expect("should have post_state_hash");
-        let hold_interval = self.chainspec.core_config.gas_hold_interval;
-        let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval.millis());
-        let balance_handling = BalanceHandling::Available { holds_epoch };
+        let balance_handling = BalanceHandling::Available;
         let proof_handling = ProofHandling::Proofs;
         let request = BalanceRequest::from_public_key(
             state_root_hash,
-            block_time.into(),
             protocol_version,
             public_key,
             balance_handling,
@@ -1493,7 +1521,7 @@ where
     pub fn get_named_keys(&self, entity_addr: EntityAddr) -> NamedKeys {
         let state_root_hash = self.get_post_state_hash();
 
-        let mut tracking_copy = self
+        let tracking_copy = self
             .data_access_layer
             .tracking_copy(state_root_hash)
             .unwrap()

--- a/execution_engine_testing/tests/src/test/contract_messages.rs
+++ b/execution_engine_testing/tests/src/test/contract_messages.rs
@@ -8,10 +8,10 @@ use casper_engine_test_support::{
 use casper_types::{
     bytesrepr::ToBytes,
     contract_messages::{MessageChecksum, MessagePayload, MessageTopicSummary, TopicNameHash},
-    crypto, runtime_args, AddressableEntity, AddressableEntityHash, BlockTime, CLValue, CoreConfig,
-    Digest, EntityAddr, HostFunction, HostFunctionCosts, Key, MessageLimits, OpcodeCosts,
-    RuntimeArgs, StorageCosts, StoredValue, SystemConfig, WasmConfig, DEFAULT_MAX_STACK_HEIGHT,
-    DEFAULT_WASM_MAX_MEMORY, U512,
+    crypto, runtime_args, AddressableEntity, AddressableEntityHash, BlockGlobalAddr, BlockTime,
+    CLValue, CoreConfig, Digest, EntityAddr, HostFunction, HostFunctionCosts, Key, MessageLimits,
+    OpcodeCosts, RuntimeArgs, StorageCosts, StoredValue, SystemConfig, WasmConfig,
+    DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY, U512,
 };
 
 const MESSAGE_EMITTER_INSTALLER_WASM: &str = "contract_messages_emitter.wasm";
@@ -970,9 +970,10 @@ fn should_produce_per_block_message_ordering() {
     };
 
     let query_message_count = || -> Option<(BlockTime, u64)> {
-        let query_result = builder
-            .borrow_mut()
-            .query(None, Key::BlockMessageCount, &[]);
+        let query_result =
+            builder
+                .borrow_mut()
+                .query(None, Key::BlockGlobal(BlockGlobalAddr::MessageCount), &[]);
 
         match query_result {
             Ok(StoredValue::CLValue(cl_value)) => Some(cl_value.into_t().unwrap()),

--- a/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
@@ -102,11 +102,8 @@ fn should_charge_non_main_purse() {
         .expect_success()
         .commit();
 
-    let payment_purse_balance = builder.get_purse_balance_result_with_proofs(
-        DEFAULT_PROTOCOL_VERSION,
-        BalanceIdentifier::Payment,
-        block_time,
-    );
+    let payment_purse_balance = builder
+        .get_purse_balance_result_with_proofs(DEFAULT_PROTOCOL_VERSION, BalanceIdentifier::Payment);
 
     assert!(
         payment_purse_balance.is_success(),

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -926,10 +926,10 @@ fn faucet_costs() {
     // This test will fail if execution costs vary.  The expected costs should not be updated
     // without understanding why the cost has changed.  If the costs do change, it should be
     // reflected in the "Costs by Entry Point" section of the faucet crate's README.md.
-    const EXPECTED_FAUCET_INSTALL_COST: u64 = 88_784_431_090;
-    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 111_243_280;
-    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_774_813_900;
-    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_619_679_000;
+    const EXPECTED_FAUCET_INSTALL_COST: u64 = 89_243_134_240;
+    const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 111_263_840;
+    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_774_829_320;
+    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_619_720_120;
 
     let installer_account = AccountHash::new([1u8; 32]);
     let user_account: AccountHash = AccountHash::new([2u8; 32]);

--- a/execution_engine_testing/tests/src/test/get_balance.rs
+++ b/execution_engine_testing/tests/src/test/get_balance.rs
@@ -45,7 +45,6 @@ fn get_balance_should_work() {
     let alice_balance_result = builder.get_purse_balance_result_with_proofs(
         protocol_version,
         BalanceIdentifier::Purse(alice_main_purse),
-        block_time,
     );
 
     let alice_balance = alice_balance_result
@@ -140,11 +139,8 @@ fn get_balance_using_public_key_should_work() {
 
     let alice_main_purse = alice_account.main_purse();
 
-    let alice_balance_result = builder.get_public_key_balance_result_with_proofs(
-        protocol_version,
-        ALICE_KEY.clone(),
-        block_time,
-    );
+    let alice_balance_result =
+        builder.get_public_key_balance_result_with_proofs(protocol_version, ALICE_KEY.clone());
 
     let alice_balance = alice_balance_result
         .available_balance()

--- a/execution_engine_testing/tests/src/test/groups.rs
+++ b/execution_engine_testing/tests/src/test/groups.rs
@@ -9,7 +9,9 @@ use casper_engine_test_support::{
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
 use casper_execution_engine::{engine_state::Error, execution::ExecError};
-use casper_types::{account::AccountHash, runtime_args, Key, RuntimeArgs, U512};
+use casper_types::{
+    account::AccountHash, runtime_args, HoldBalanceHandling, Key, RuntimeArgs, Timestamp, U512,
+};
 
 use crate::{lmdb_fixture, wasm_utils};
 
@@ -35,8 +37,9 @@ static TRANSFER_1_AMOUNT: Lazy<U512> =
     Lazy::new(|| U512::from(MINIMUM_ACCOUNT_CREATION_BALANCE) + 1000);
 
 fn setup_from_lmdb_fixture() -> LmdbWasmTestBuilder {
-    let (builder, _, _) = lmdb_fixture::builder_from_global_state_fixture(GROUPS_FIXTURE);
-
+    let (mut builder, _, _) = lmdb_fixture::builder_from_global_state_fixture(GROUPS_FIXTURE);
+    builder.with_block_time(Timestamp::now().into());
+    builder.with_gas_hold_config(HoldBalanceHandling::default(), 1200u64);
     builder
 }
 

--- a/execution_engine_testing/tests/src/test/regression/gh_1470.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_1470.rs
@@ -10,9 +10,9 @@ use casper_types::{
     account::AccountHash,
     runtime_args,
     system::{auction, auction::DelegationRate},
-    AccessRights, AddressableEntityHash, CLTyped, CLValue, Digest, EraId, Key, PackageHash,
-    ProtocolVersion, RuntimeArgs, StoredValue, StoredValueTypeMismatch, SystemEntityRegistry, URef,
-    U512,
+    AccessRights, AddressableEntityHash, CLTyped, CLValue, Digest, EraId, HoldBalanceHandling, Key,
+    PackageHash, ProtocolVersion, RuntimeArgs, StoredValue, StoredValueTypeMismatch,
+    SystemEntityRegistry, Timestamp, URef, U512,
 };
 
 use crate::lmdb_fixture;
@@ -642,10 +642,13 @@ fn should_transfer_after_major_version_bump_from_1_2_0() {
             .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_global_state_update(global_state_update)
+            .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+            .with_new_gas_hold_interval(1200u64)
             .build()
     };
 
     builder
+        .with_block_time(Timestamp::now().into())
         .upgrade(&mut upgrade_request)
         .expect_upgrade_success();
 
@@ -679,10 +682,13 @@ fn should_transfer_after_minor_version_bump_from_1_2_0() {
             .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_global_state_update(global_state_update)
+            .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+            .with_new_gas_hold_interval(1200u64)
             .build()
     };
 
     builder
+        .with_block_time(Timestamp::now().into())
         .upgrade(&mut upgrade_request)
         .expect_upgrade_success();
 
@@ -712,10 +718,13 @@ fn should_add_bid_after_major_bump() {
             .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_global_state_update(global_state_update)
+            .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+            .with_new_gas_hold_interval(1200u64)
             .build()
     };
 
     builder
+        .with_block_time(Timestamp::now().into())
         .upgrade(&mut upgrade_request)
         .expect_upgrade_success();
 
@@ -760,10 +769,13 @@ fn should_add_bid_after_minor_bump() {
             .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_global_state_update(global_state_update)
+            .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+            .with_new_gas_hold_interval(1200u64)
             .build()
     };
 
     builder
+        .with_block_time(Timestamp::now().into())
         .upgrade(&mut upgrade_request)
         .expect_upgrade_success();
 
@@ -805,10 +817,13 @@ fn should_wasm_transfer_after_major_bump() {
             .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_global_state_update(global_state_update)
+            .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+            .with_new_gas_hold_interval(1200u64)
             .build()
     };
 
     builder
+        .with_block_time(Timestamp::now().into())
         .upgrade(&mut upgrade_request)
         .expect_upgrade_success();
 
@@ -852,10 +867,13 @@ fn should_wasm_transfer_after_minor_bump() {
             .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_global_state_update(global_state_update)
+            .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+            .with_new_gas_hold_interval(1200u64)
             .build()
     };
 
     builder
+        .with_block_time(Timestamp::now().into())
         .upgrade(&mut upgrade_request)
         .expect_upgrade_success();
 

--- a/execution_engine_testing/tests/src/test/regression/host_function_metrics_size_and_gas_cost.rs
+++ b/execution_engine_testing/tests/src/test/regression/host_function_metrics_size_and_gas_cost.rs
@@ -18,7 +18,7 @@ const CONTRACT_TRANSFER_TO_ACCOUNT_U512: &str = "transfer_to_account_u512.wasm";
 
 // This value is not systemic, as code is added the size of WASM will increase,
 // you can change this value to reflect the increase in WASM size.
-const HOST_FUNCTION_METRICS_STANDARD_SIZE: usize = 116_188;
+const HOST_FUNCTION_METRICS_STANDARD_SIZE: usize = 122_154;
 const HOST_FUNCTION_METRICS_STANDARD_GAS_COST: u64 = 422_402_224_490;
 
 /// Acceptable size regression/improvement in percentage.

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -22,7 +22,7 @@ use casper_types::{
         ARG_DELEGATOR, ARG_PUBLIC_KEY, ARG_REWARDS_MAP, ARG_VALIDATOR, DELEGATION_RATE_DENOMINATOR,
         METHOD_DISTRIBUTE, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
     },
-    EntityAddr, EraId, HoldsEpoch, Key, ProtocolVersion, PublicKey, SecretKey, Timestamp, U512,
+    EntityAddr, EraId, Key, ProtocolVersion, PublicKey, SecretKey, Timestamp, U512,
 };
 
 const ARG_ENTRY_POINT: &str = "entry_point";
@@ -1013,7 +1013,6 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
                 validator: VALIDATOR_1.clone(),
                 delegator: DELEGATOR_2.clone(),
                 amount: updelegate_amount,
-                holds_epoch: HoldsEpoch::NOT_APPLICABLE,
             },
         );
         assert!(updelegate_result.is_success(), "{:?}", updelegate_result);
@@ -1028,7 +1027,6 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
                     public_key: VALIDATOR_1.clone(),
                     amount,
                     delegation_rate: 0,
-                    holds_epoch: HoldsEpoch::NOT_APPLICABLE,
                 }
             } else {
                 AuctionMethod::WithdrawBid {

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -7,8 +7,8 @@ use casper_execution_engine::{engine_state, execution::ExecError};
 use casper_types::{
     account::AccountHash,
     addressable_entity::{AssociatedKeys, Weight},
-    runtime_args, AddressableEntityHash, CLValue, EntityVersion, EraId, PackageHash,
-    ProtocolVersion, RuntimeArgs, StoredValue, ENTITY_INITIAL_VERSION,
+    runtime_args, AddressableEntityHash, CLValue, EntityVersion, EraId, HoldBalanceHandling,
+    PackageHash, ProtocolVersion, RuntimeArgs, StoredValue, Timestamp, ENTITY_INITIAL_VERSION,
 };
 
 const DO_NOTHING_STORED_CONTRACT_NAME: &str = "do_nothing_stored";
@@ -857,16 +857,18 @@ fn setup_upgrade_threshold_state() -> (LmdbWasmTestBuilder, AccountHash) {
         .with_current_protocol_version(current_protocol_version)
         .with_new_protocol_version(new_protocol_version)
         .with_activation_point(activation_point)
+        .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+        .with_new_gas_hold_interval(24 * 60 * 60 * 60)
         .build();
 
     builder
+        .with_block_time(Timestamp::now().into())
         .upgrade_using_scratch(&mut upgrade_request)
         .expect_upgrade_success();
 
     let transfer = TransferRequestBuilder::new(MINIMUM_ACCOUNT_CREATION_BALANCE, ACCOUNT_1_ADDR)
         .with_transfer_id(42)
         .build();
-
     builder.transfer_and_commit(transfer).expect_success();
 
     (builder, ACCOUNT_1_ADDR)

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -28,8 +28,8 @@ use casper_storage::{
 use casper_types::{
     addressable_entity::NamedKeyAddr,
     bytesrepr::{self, FromBytes, ToBytes},
-    BlockHeader, BlockIdentifier, Chainspec, Digest, EntityAddr, GlobalStateIdentifier, HoldsEpoch,
-    Key, Peers, ProtocolVersion, SignedBlock, StoredValue, TimeDiff, Timestamp, Transaction,
+    BlockHeader, BlockIdentifier, Chainspec, Digest, EntityAddr, GlobalStateIdentifier, Key, Peers,
+    ProtocolVersion, SignedBlock, StoredValue, TimeDiff, Transaction,
 };
 
 use datasize::DataSize;
@@ -282,7 +282,7 @@ async fn handle_state_request<REv>(
     request: GlobalStateRequest,
     protocol_version: ProtocolVersion,
     config: &Config,
-    chainspec: &Chainspec,
+    _chainspec: &Chainspec,
 ) -> BinaryResponse
 where
     REv: From<Event>
@@ -415,17 +415,14 @@ where
             get_balance(
                 effect_builder,
                 *header.state_root_hash(),
-                header.timestamp(),
                 purse_identifier,
                 protocol_version,
-                chainspec.core_config.gas_hold_interval,
             )
             .await
         }
         GlobalStateRequest::BalanceByStateRoot {
             state_identifier,
             purse_identifier,
-            timestamp,
         } => {
             let Some(state_root_hash) = resolve_state_root_hash(effect_builder, state_identifier).await else {
                 return BinaryResponse::new_empty(protocol_version);
@@ -433,10 +430,8 @@ where
             get_balance(
                 effect_builder,
                 state_root_hash,
-                timestamp,
                 purse_identifier,
                 protocol_version,
-                chainspec.core_config.gas_hold_interval,
             )
             .await
         }
@@ -522,10 +517,8 @@ where
 async fn get_balance<REv>(
     effect_builder: EffectBuilder<REv>,
     state_root_hash: Digest,
-    timestamp: Timestamp,
     purse_identifier: PurseIdentifier,
     protocol_version: ProtocolVersion,
-    gas_hold_interval: TimeDiff,
 ) -> BinaryResponse
 where
     REv: From<Event>
@@ -541,13 +534,10 @@ where
         PurseIdentifier::Account(account) => BalanceIdentifier::Account(account),
         PurseIdentifier::Entity(entity) => BalanceIdentifier::Entity(entity),
     };
-    let balance_handling = BalanceHandling::Available {
-        holds_epoch: HoldsEpoch::from_timestamp(timestamp, gas_hold_interval),
-    };
+    let balance_handling = BalanceHandling::Available;
 
     let balance_req = BalanceRequest::new(
         state_root_hash,
-        timestamp.into(),
         protocol_version,
         balance_id,
         balance_handling,

--- a/node/src/components/contract_runtime/error.rs
+++ b/node/src/components/contract_runtime/error.rs
@@ -137,4 +137,7 @@ pub enum BlockExecutionError {
     // Payment error.
     #[error("Error while trying to set up payment for transaction: {0}")]
     PaymentError(String),
+    // Error attempting to set block global data.
+    #[error("Error while attempting to store block global data: {0}")]
+    BlockGlobal(String),
 }

--- a/node/src/components/storage/error.rs
+++ b/node/src/components/storage/error.rs
@@ -21,16 +21,6 @@ pub enum FatalStorageError {
     /// Failure to create the root database directory.
     #[error("failed to create database directory `{}`: {}", .0.display(), .1)]
     CreateDatabaseDirectory(PathBuf, io::Error),
-    /// Found a duplicate block-at-height index entry.
-    #[error("duplicate entries for block at height {height}: {first} / {second}")]
-    DuplicateBlockIndex {
-        /// Height at which duplicate was found.
-        height: u64,
-        /// First block hash encountered at `height`.
-        first: BlockHash,
-        /// Second block hash encountered at `height`.
-        second: BlockHash,
-    },
     /// Found a duplicate switch-block-at-era-id index entry.
     #[error("duplicate entries for switch block at era id {era_id}: {first} / {second}")]
     DuplicateEraIdIndex {
@@ -39,16 +29,6 @@ pub enum FatalStorageError {
         /// First block hash encountered at `era_id`.
         first: BlockHash,
         /// Second block hash encountered at `era_id`.
-        second: BlockHash,
-    },
-    /// Found a duplicate transaction index entry.
-    #[error("duplicate entries for blocks for transaction {transaction_hash}: {first} / {second}")]
-    DuplicateTransactionIndex {
-        /// Transaction hash at which duplicate was found.
-        transaction_hash: TransactionHash,
-        /// First block hash encountered at `transaction_hash`.
-        first: BlockHash,
-        /// Second block hash encountered at `transaction_hash`.
         second: BlockHash,
     },
     /// An internal DB error - blocks should be overwritten.

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -4,7 +4,7 @@ mod event;
 mod metrics;
 mod tests;
 
-use std::{collections::BTreeSet, fmt::Debug, sync::Arc, time::SystemTime};
+use std::{collections::BTreeSet, fmt::Debug, sync::Arc};
 
 use datasize::DataSize;
 use prometheus::Registry;
@@ -16,9 +16,9 @@ use casper_types::{
     account::AccountHash, addressable_entity::AddressableEntity, contracts::ContractHash,
     system::auction::ARG_AMOUNT, AddressableEntityHash, AddressableEntityIdentifier, BlockHeader,
     Chainspec, EntityAddr, EntityVersion, EntityVersionKey, ExecutableDeployItem,
-    ExecutableDeployItemIdentifier, HoldsEpoch, InitiatorAddr, Key, Package, PackageAddr,
-    PackageHash, PackageIdentifier, Transaction, TransactionEntryPoint,
-    TransactionInvocationTarget, TransactionTarget, U512,
+    ExecutableDeployItemIdentifier, InitiatorAddr, Key, Package, PackageAddr, PackageHash,
+    PackageIdentifier, Transaction, TransactionEntryPoint, TransactionInvocationTarget,
+    TransactionTarget, U512,
 };
 
 use crate::{
@@ -217,14 +217,10 @@ impl TransactionAcceptor {
                     return self.reject_transaction(effect_builder, *event_metadata, error);
                 }
                 let protocol_version = block_header.protocol_version();
-                let hold_interval = self.balance_hold_interval;
-                let block_time = SystemTime::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64;
-                let holds_epoch = HoldsEpoch::from_millis(block_time, hold_interval);
-                let balance_handling = BalanceHandling::Available { holds_epoch };
+                let balance_handling = BalanceHandling::Available;
                 let proof_handling = ProofHandling::NoProofs;
                 let balance_request = BalanceRequest::from_purse(
                     *block_header.state_root_hash(),
-                    block_header.timestamp().into(),
                     protocol_version,
                     entity.main_purse(),
                     balance_handling,

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -766,8 +766,7 @@ impl reactor::Reactor for Reactor {
                         BalanceIdentifier::Refund => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::NamedKeyNotFound("refund".to_string())
-                                        .into(),
+                                    TrackingCopyError::NamedKeyNotFound("refund".to_string()),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();
@@ -775,8 +774,7 @@ impl reactor::Reactor for Reactor {
                         BalanceIdentifier::Payment => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::NamedKeyNotFound("payment".to_string())
-                                        .into(),
+                                    TrackingCopyError::NamedKeyNotFound("payment".to_string()),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();
@@ -784,8 +782,7 @@ impl reactor::Reactor for Reactor {
                         BalanceIdentifier::Accumulate => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::NamedKeyNotFound("accumulate".to_string())
-                                        .into(),
+                                    TrackingCopyError::NamedKeyNotFound("accumulate".to_string()),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();
@@ -796,7 +793,7 @@ impl reactor::Reactor for Reactor {
                         None => {
                             responder
                                 .respond(BalanceResult::Failure(
-                                    TrackingCopyError::UnexpectedKeyVariant(key).into(),
+                                    TrackingCopyError::UnexpectedKeyVariant(key),
                                 ))
                                 .ignore::<Self::Event>();
                             return Effects::new();

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -22,7 +22,9 @@ use tracing::{error, info};
 
 use casper_storage::{
     data_access_layer::{
-        balance::{BalanceHandling, BalanceResult}, BalanceRequest, BidsRequest, BidsResult, ProofHandling, TotalSupplyRequest, TotalSupplyResult
+        balance::{BalanceHandling, BalanceResult},
+        BalanceRequest, BidsRequest, BidsResult, ProofHandling, TotalSupplyRequest,
+        TotalSupplyResult,
     },
     global_state::state::{StateProvider, StateReader},
 };
@@ -34,11 +36,11 @@ use casper_types::{
     },
     testing::TestRng,
     AccountConfig, AccountsConfig, ActivationPoint, AddressableEntityHash, AvailableBlockRange,
-    Block, BlockHash, BlockHeader, BlockV2, CLValue, Chainspec, ChainspecRawBytes, HoldBalanceHandling,
-    ConsensusProtocolName, Deploy, EraId, FeeHandling, Gas, Key, Motes, NextUpgrade,
-    PricingHandling, PricingMode, ProtocolVersion, PublicKey, RefundHandling, Rewards, SecretKey,
-    StoredValue, SystemEntityRegistry, TimeDiff, Timestamp, Transaction, TransactionHash,
-    TransactionV1Builder, ValidatorConfig, U512,
+    Block, BlockHash, BlockHeader, BlockV2, CLValue, Chainspec, ChainspecRawBytes,
+    ConsensusProtocolName, Deploy, EraId, FeeHandling, Gas, HoldBalanceHandling, Key,
+    Motes, NextUpgrade, PricingHandling, PricingMode, ProtocolVersion, PublicKey, RefundHandling,
+    Rewards, SecretKey, StoredValue, SystemEntityRegistry, TimeDiff, Timestamp, Transaction,
+    TransactionHash, TransactionV1Builder, ValidatorConfig, U512,
 };
 
 use crate::{
@@ -170,7 +172,10 @@ impl ConfigsOverride {
         self
     }
 
-    fn with_gas_hold_balance_handling(mut self, gas_hold_balance_handling: HoldBalanceHandling) -> Self {
+    fn with_gas_hold_balance_handling(
+        mut self,
+        gas_hold_balance_handling: HoldBalanceHandling,
+    ) -> Self {
         self.gas_hold_balance_handling = Some(gas_hold_balance_handling);
         self
     }

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -37,9 +37,9 @@ use casper_types::{
     testing::TestRng,
     AccountConfig, AccountsConfig, ActivationPoint, AddressableEntityHash, AvailableBlockRange,
     Block, BlockHash, BlockHeader, BlockV2, CLValue, Chainspec, ChainspecRawBytes,
-    ConsensusProtocolName, Deploy, EraId, FeeHandling, Gas, HoldBalanceHandling, Key,
-    Motes, NextUpgrade, PricingHandling, PricingMode, ProtocolVersion, PublicKey, RefundHandling,
-    Rewards, SecretKey, StoredValue, SystemEntityRegistry, TimeDiff, Timestamp, Transaction,
+    ConsensusProtocolName, Deploy, EraId, FeeHandling, Gas, HoldBalanceHandling, Key, Motes,
+    NextUpgrade, PricingHandling, PricingMode, ProtocolVersion, PublicKey, RefundHandling, Rewards,
+    SecretKey, StoredValue, SystemEntityRegistry, TimeDiff, Timestamp, Transaction,
     TransactionHash, TransactionV1Builder, ValidatorConfig, U512,
 };
 

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -39,7 +39,7 @@ use casper_types::{
     testing::TestRng,
     AccountConfig, AccountsConfig, ActivationPoint, AddressableEntityHash, AvailableBlockRange,
     Block, BlockHash, BlockHeader, BlockV2, CLValue, Chainspec, ChainspecRawBytes,
-    ConsensusProtocolName, Deploy, EraId, FeeHandling, Gas, HoldsEpoch, Key, Motes, NextUpgrade,
+    ConsensusProtocolName, Deploy, EraId, FeeHandling, Gas, Key, Motes, NextUpgrade,
     PricingHandling, PricingMode, ProtocolVersion, PublicKey, RefundHandling, Rewards, SecretKey,
     StoredValue, SystemEntityRegistry, TimeDiff, Timestamp, Transaction, TransactionHash,
     TransactionV1Builder, ValidatorConfig, U512,
@@ -813,17 +813,11 @@ impl TestFixture {
             .read_highest_block()
             .expect("should have block");
 
-        let block_time = highest_block.clone_header().timestamp();
-
-        let holds_epoch =
-            HoldsEpoch::from_timestamp(block_time, self.chainspec.core_config.gas_hold_interval);
-
         let balance_request = BalanceRequest::from_public_key(
             *highest_block.state_root_hash(),
-            block_time.into(),
             highest_block.protocol_version(),
             account_public_key,
-            BalanceHandling::Available { holds_epoch },
+            BalanceHandling::Available,
             ProofHandling::NoProofs,
         );
 

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -23,7 +23,7 @@ use casper_types::{
     Account, AvailableBlockRange, Block, BlockHash, BlockHeader, BlockIdentifier,
     BlockSynchronizerStatus, CLValue, CLValueDictionary, ChainspecRawBytes, DictionaryAddr, Digest,
     EntityAddr, GlobalStateIdentifier, Key, KeyTag, NextUpgrade, Peers, ProtocolVersion, SecretKey,
-    SignedBlock, StoredValue, Timestamp, Transaction, TransactionV1Builder, Transfer, URef, U512,
+    SignedBlock, StoredValue, Transaction, TransactionV1Builder, Transfer, URef, U512,
 };
 use juliet::{
     io::IoCoreBuilder,
@@ -881,7 +881,6 @@ fn get_balance_by_state_root(state_root_hash: Digest, account_hash: AccountHash)
             GlobalStateRequest::BalanceByStateRoot {
                 state_identifier: Some(GlobalStateIdentifier::StateRootHash(state_root_hash)),
                 purse_identifier: PurseIdentifier::Account(account_hash),
-                timestamp: Timestamp::now(),
             },
         ))),
         asserter: Box::new(|response| {

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -970,16 +970,10 @@ impl SingleTransactionTestCase {
             .expect("failure to read block header")
             .unwrap();
         let state_hash = *block_header.state_root_hash();
-        let block_time = block_header.timestamp().into();
         let balance_handling = if get_total {
             BalanceHandling::Total
         } else {
-            BalanceHandling::Available {
-                holds_epoch: HoldsEpoch::from_block_time(
-                    block_time,
-                    self.fixture.chainspec.core_config.gas_hold_interval,
-                ),
-            }
+            BalanceHandling::Available
         };
         runner
             .main_reactor()
@@ -987,7 +981,6 @@ impl SingleTransactionTestCase {
             .data_access_layer()
             .balance(BalanceRequest::new(
                 state_hash,
-                block_time,
                 protocol_version,
                 casper_storage::data_access_layer::BalanceIdentifier::Accumulate,
                 balance_handling,

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -117,16 +117,10 @@ fn get_balance(
         .expect("failure to read block header")
         .unwrap();
     let state_hash = *block_header.state_root_hash();
-    let block_time = block_header.timestamp().into();
     let balance_handling = if get_total {
         BalanceHandling::Total
     } else {
-        BalanceHandling::Available {
-            holds_epoch: HoldsEpoch::from_block_time(
-                block_time,
-                fixture.chainspec.core_config.gas_hold_interval,
-            ),
-        }
+        BalanceHandling::Available
     };
     runner
         .main_reactor()
@@ -134,7 +128,6 @@ fn get_balance(
         .data_access_layer()
         .balance(BalanceRequest::from_public_key(
             state_hash,
-            block_time,
             protocol_version,
             account_key.clone(),
             balance_handling,

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -775,13 +775,12 @@ struct BalanceAmount {
 
 impl SingleTransactionTestCase {
     fn default_test_config() -> ConfigsOverride {
-        let config = ConfigsOverride::default()
+        ConfigsOverride::default()
             .with_minimum_era_height(5) // make the era longer so that the transaction doesn't land in the switch block.
             .with_balance_hold_interval(TimeDiff::from_seconds(5))
             .with_min_gas_price(MIN_GAS_PRICE)
             .with_max_gas_price(MIN_GAS_PRICE)
-            .with_chain_name("single-transaction-test-net".to_string());
-        config
+            .with_chain_name("single-transaction-test-net".to_string())
     }
 
     async fn new(
@@ -1533,7 +1532,7 @@ async fn only_refunds_are_burnt_no_fee_custom_payment() {
             .build()
             .unwrap(),
     );
-    txn.sign(&*BOB_SECRET_KEY);
+    txn.sign(&BOB_SECRET_KEY);
 
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
@@ -1616,7 +1615,7 @@ async fn transfer_fee_is_burnt_no_refund(txn_pricing_mode: PricingMode) {
 
     let txn = transfer_txn(
         ALICE_SECRET_KEY.clone(),
-        &*CHARLIE_PUBLIC_KEY,
+        &CHARLIE_PUBLIC_KEY,
         txn_pricing_mode,
         transfer_amount,
     );
@@ -1720,7 +1719,7 @@ async fn fee_is_payed_to_proposer_no_refund(txn_pricing_mode: PricingMode) {
 
     let txn = transfer_txn(
         BOB_SECRET_KEY.clone(),
-        &*CHARLIE_PUBLIC_KEY,
+        &CHARLIE_PUBLIC_KEY,
         txn_pricing_mode,
         transfer_amount,
     );
@@ -1937,7 +1936,7 @@ async fn fee_is_accumulated_and_distributed_no_refund(txn_pricing_mode: PricingM
 
     let txn = transfer_txn(
         BOB_SECRET_KEY.clone(),
-        &*CHARLIE_PUBLIC_KEY,
+        &CHARLIE_PUBLIC_KEY,
         txn_pricing_mode,
         transfer_amount,
     );
@@ -2061,7 +2060,7 @@ fn transfer_txn<A: Into<U512>>(
             .build()
             .unwrap(),
     );
-    txn.sign(&*from);
+    txn.sign(&from);
     txn
 }
 
@@ -2078,7 +2077,7 @@ fn invalid_wasm_txn(initiator: Arc<SecretKey>, pricing_mode: PricingMode) -> Tra
         .build()
         .unwrap(),
     );
-    txn.sign(&*initiator);
+    txn.sign(&initiator);
     txn
 }
 
@@ -2143,7 +2142,7 @@ async fn holds_should_be_added_and_cleared(txn_pricing_mode: PricingMode) {
     // transfer from bob to charlie
     let txn = transfer_txn(
         BOB_SECRET_KEY.clone(),
-        &*CHARLIE_PUBLIC_KEY,
+        &CHARLIE_PUBLIC_KEY,
         txn_pricing_mode,
         transfer_amount,
     );
@@ -2184,7 +2183,7 @@ async fn holds_should_be_added_and_cleared(txn_pricing_mode: PricingMode) {
         charlie_balance
             .expect("Expected Charlie to have a balance")
             .total,
-        transfer_amount.into(),
+        transfer_amount,
         "charlie's balance should equal transfer amount"
     );
     assert_ne!(
@@ -2364,7 +2363,7 @@ async fn sufficient_balance_is_available_after_amortization() {
     let transfer_amount = min_transfer_amount * 2 + transfer_cost + half_transfer_cost;
     let txn = transfer_txn(
         BOB_SECRET_KEY.clone(),
-        &*CHARLIE_PUBLIC_KEY,
+        &CHARLIE_PUBLIC_KEY,
         PricingMode::Fixed {
             gas_price_tolerance: MIN_GAS_PRICE,
         },
@@ -2395,7 +2394,7 @@ async fn sufficient_balance_is_available_after_amortization() {
     // will allow him to do another transfer.
     let txn = transfer_txn(
         CHARLIE_SECRET_KEY.clone(),
-        &*BOB_PUBLIC_KEY,
+        &BOB_PUBLIC_KEY,
         PricingMode::Fixed {
             gas_price_tolerance: MIN_GAS_PRICE,
         },
@@ -2422,18 +2421,20 @@ async fn sufficient_balance_is_available_after_amortization() {
         .await;
     let charlie_balance = test.get_balances(Some(block_height + 5)).2.unwrap();
     assert!(
-        charlie_balance.available.clone() >= min_transfer_amount + transfer_cost, /* right now he should have enough to make a transfer. */
+        charlie_balance.available >= min_transfer_amount + transfer_cost, /* right now he should
+                                                                           * have enough to make
+                                                                           * a transfer. */
     );
     assert!(
-        charlie_balance.available.clone() < charlie_balance.total.clone(), /* some of the holds
-                                                                            * should still be in
-                                                                            * place. */
+        charlie_balance.available < charlie_balance.total, /* some of the holds
+                                                            * should still be in
+                                                            * place. */
     );
 
     // Send another transfer to Bob for `min_transfer_amount`.
     let txn = transfer_txn(
         CHARLIE_SECRET_KEY.clone(),
-        &*BOB_PUBLIC_KEY,
+        &BOB_PUBLIC_KEY,
         PricingMode::Fixed {
             gas_price_tolerance: MIN_GAS_PRICE,
         },

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -200,7 +200,6 @@ async fn transfer_cost_fixed_price_no_fee_no_refund() {
     let charlie_secret_key = Arc::new(SecretKey::random(&mut fixture.rng));
     let charlie_public_key = PublicKey::from(&*charlie_secret_key);
 
-    // Wait for all nodes to complete era 0.
     fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
 
     let alice_initial_balance = *get_balance(&mut fixture, &alice_public_key, None, true)
@@ -310,7 +309,6 @@ async fn should_accept_transfer_without_id() {
     let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
     let charlie_secret_key = Arc::new(SecretKey::random(&mut fixture.rng));
 
-    // Wait for all nodes to complete era 0.
     fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
 
     let (_, _, result) = transfer_to_account(
@@ -344,7 +342,6 @@ async fn failed_transfer_cost_fixed_price_no_fee_no_refund() {
     let charlie_secret_key = Arc::new(SecretKey::random(&mut fixture.rng));
     let charlie_public_key = PublicKey::from(&*charlie_secret_key);
 
-    // Wait for all nodes to complete era 0.
     fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
 
     let transfer_amount = fixture
@@ -426,7 +423,6 @@ async fn transfer_cost_classic_price_no_fee_no_refund() {
     let charlie_secret_key = Arc::new(SecretKey::random(&mut fixture.rng));
     let charlie_public_key = PublicKey::from(&*charlie_secret_key);
 
-    // Wait for all nodes to complete era 0.
     fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
 
     let alice_initial_balance = *get_balance(&mut fixture, &alice_public_key, None, true)
@@ -539,7 +535,6 @@ async fn transaction_with_low_threshold_should_not_get_included() {
     let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
     let charlie_secret_key = Arc::new(SecretKey::random(&mut fixture.rng));
 
-    // Wait for all nodes to complete era 0.
     fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
 
     // This transaction should NOT be included since the tolerance is below the min gas price.
@@ -580,7 +575,6 @@ async fn native_operations_fees_are_not_refunded() {
     let charlie_secret_key = Arc::new(SecretKey::random(&mut fixture.rng));
     let charlie_public_key = PublicKey::from(&*charlie_secret_key);
 
-    // Wait for all nodes to complete era 0.
     fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
 
     let bob_initial_balance = *get_balance(&mut fixture, &bob_public_key, None, true)
@@ -688,7 +682,6 @@ async fn wasm_transaction_fees_are_refunded() {
     let bob_secret_key = Arc::clone(&fixture.node_contexts[1].secret_key);
     let bob_public_key = PublicKey::from(&*bob_secret_key);
 
-    // Wait for all nodes to complete era 0.
     fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
 
     let bob_initial_balance = *get_balance(&mut fixture, &bob_public_key, None, true)
@@ -1022,12 +1015,10 @@ async fn wasm_transaction_refunds_are_burnt(txn_pricing_mode: PricingMode) {
 
     let txn = invalid_wasm_txn(BOB_SECRET_KEY.clone(), txn_pricing_mode);
 
-    // Wait for all nodes to complete era 0.
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _charlie_initial_balance) =
         test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
@@ -1126,12 +1117,10 @@ async fn only_refunds_are_burnt_no_fee(txn_pricing_mode: PricingMode) {
     .await;
     let txn = invalid_wasm_txn(BOB_SECRET_KEY.clone(), txn_pricing_mode);
 
-    // Wait for all nodes to complete era 0.
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _) = test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
 
@@ -1238,12 +1227,10 @@ async fn fees_and_refunds_are_burnt_separately(txn_pricing_mode: PricingMode) {
     );
     let expected_transaction_cost = expected_transaction_gas * min_gas_price as u64;
 
-    // Wait for all nodes to complete era 0.
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _) = test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
 
@@ -1340,7 +1327,6 @@ async fn refunds_are_payed_and_fees_are_burnt(txn_pricing_mode: PricingMode) {
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _) = test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
 
@@ -1439,7 +1425,6 @@ async fn refunds_are_payed_and_fees_are_on_hold(txn_pricing_mode: PricingMode) {
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _charlie_initial_balance) =
         test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
@@ -1561,7 +1546,6 @@ async fn only_refunds_are_burnt_no_fee_custom_payment() {
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _charlie_initial_balance) =
         test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
@@ -1644,12 +1628,10 @@ async fn transfer_fee_is_burnt_no_refund(txn_pricing_mode: PricingMode) {
         transfer_amount,
     );
 
-    // Wait for all nodes to complete era 0.
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, _, _) = test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
 
@@ -1750,12 +1732,10 @@ async fn fee_is_payed_to_proposer_no_refund(txn_pricing_mode: PricingMode) {
         transfer_amount,
     );
 
-    // Wait for all nodes to complete era 0.
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _charlie_initial_balance) =
         test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
@@ -1856,7 +1836,6 @@ async fn wasm_transaction_fees_are_refunded_to_proposer(txn_pricing_mode: Pricin
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _charlie_initial_balance) =
         test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
@@ -2185,12 +2164,10 @@ async fn holds_should_be_added_and_cleared(txn_pricing_mode: PricingMode) {
     );
     let expected_transfer_cost = expected_transfer_gas * min_gas_price as u64;
 
-    // Wait for all nodes to complete era 0.
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (_, bob_initial_balance, _) = test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
 
@@ -2242,12 +2219,11 @@ async fn holds_should_be_added_and_cleared(txn_pricing_mode: PricingMode) {
     );
 }
 
-async fn fee_holds_are_amortized(txn_pricing_mode: PricingMode) {
-    let (price_handling, min_gas_price, gas_limit) = match_pricing_mode(&txn_pricing_mode);
-
+#[tokio::test]
+async fn fee_holds_are_amortized() {
     let refund_ratio = Ratio::new(1, 2);
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(price_handling)
+        .with_pricing_handling(PricingHandling::Fixed)
         .with_refund_handling(RefundHandling::Burn { refund_ratio })
         .with_fee_handling(FeeHandling::NoFee)
         .with_gas_hold_balance_handling(HoldBalanceHandling::Amortized)
@@ -2260,26 +2236,29 @@ async fn fee_holds_are_amortized(txn_pricing_mode: PricingMode) {
         Some(config),
     )
     .await;
-    let txn = invalid_wasm_txn(BOB_SECRET_KEY.clone(), txn_pricing_mode);
+    let txn = invalid_wasm_txn(
+        BOB_SECRET_KEY.clone(),
+        PricingMode::Fixed {
+            gas_price_tolerance: MIN_GAS_PRICE,
+        },
+    );
 
-    // Wait for all nodes to complete era 0.
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
         .await;
 
-    // Initial balances before running the transaction.
     let (alice_initial_balance, bob_initial_balance, _) = test.get_balances(None);
     let initial_total_supply = test.get_total_supply(None);
 
     let (_txn_hash, block_height, exec_result) = test.send_transaction(txn).await;
 
     // Fixed transaction pricing.
-    let expected_transaction_gas: u64 = gas_limit.unwrap_or(
-        test.chainspec()
-            .system_costs_config
-            .standard_transaction_limit(),
-    );
-    let expected_transaction_cost = expected_transaction_gas * min_gas_price as u64;
+    let expected_transaction_gas: u64 = test
+        .chainspec()
+        .system_costs_config
+        .standard_transaction_limit();
+
+    let expected_transaction_cost = expected_transaction_gas * MIN_GAS_PRICE as u64;
 
     assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
     assert_exec_result_cost(
@@ -2362,9 +2341,116 @@ async fn fee_holds_are_amortized(txn_pricing_mode: PricingMode) {
 }
 
 #[tokio::test]
-async fn fee_holds_are_amortized_fixed_pricing() {
-    fee_holds_are_amortized(PricingMode::Fixed {
-        gas_price_tolerance: MIN_GAS_PRICE,
-    })
+async fn sufficient_balance_is_available_after_amortization() {
+    let config = SingleTransactionTestCase::default_test_config()
+        .with_pricing_handling(PricingHandling::Fixed)
+        .with_refund_handling(RefundHandling::NoRefund)
+        .with_fee_handling(FeeHandling::NoFee)
+        .with_gas_hold_balance_handling(HoldBalanceHandling::Amortized)
+        .with_balance_hold_interval(TimeDiff::from_seconds(10));
+
+    let mut test = SingleTransactionTestCase::new(
+        ALICE_SECRET_KEY.clone(),
+        BOB_SECRET_KEY.clone(),
+        CHARLIE_SECRET_KEY.clone(),
+        Some(config),
+    )
     .await;
+
+    let transfer_cost: U512 =
+        U512::from(test.chainspec().system_costs_config.mint_costs().transfer) * MIN_GAS_PRICE;
+    let min_transfer_amount = U512::from(
+        test.chainspec()
+            .transaction_config
+            .native_transfer_minimum_motes,
+    );
+    let half_transfer_cost =
+        (Ratio::new(U512::from(1), U512::from(2)) * transfer_cost).to_integer();
+
+    // Fund Charlie with some token.
+    let transfer_amount = min_transfer_amount * 2 + transfer_cost + half_transfer_cost;
+    let txn = transfer_txn(
+        BOB_SECRET_KEY.clone(),
+        &*CHARLIE_PUBLIC_KEY,
+        PricingMode::Fixed {
+            gas_price_tolerance: MIN_GAS_PRICE,
+        },
+        transfer_amount,
+    );
+
+    test.fixture
+        .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
+        .await;
+    let (_txn_hash, block_height, exec_result) = test.send_transaction(txn).await;
+    assert!(exec_result_is_success(&exec_result));
+
+    let charlie_balance = test.get_balances(Some(block_height)).2.unwrap();
+    assert_eq!(
+        charlie_balance.available.clone(),
+        charlie_balance.total.clone()
+    );
+    assert_eq!(charlie_balance.available.clone(), transfer_amount);
+
+    // Now Charlie has balance to do 2 transfers of the minimum amount but can't pay for both as the
+    // same time. Let's say the min transfer amount is 2_500_000_000 and the cost of a transfer
+    // is 50_000. Charlie now has 5_000_075_000 as set up above. He can transfer 2_500_000_000
+    // which will put a hold of 50_000. His available balance would be 2_500_025_000.
+    // He can't issue a new transfer of 2_500_000_000 right away because he doesn't have enough
+    // balance to pay for the transfer. He'll need to wait until at least half of the holds
+    // amortize. In this case he needs to wait half of the amortization time for 25_000 to
+    // become available to him. After this period, he will have 2_500_050_000 available which
+    // will allow him to do another transfer.
+    let txn = transfer_txn(
+        CHARLIE_SECRET_KEY.clone(),
+        &*BOB_PUBLIC_KEY,
+        PricingMode::Fixed {
+            gas_price_tolerance: MIN_GAS_PRICE,
+        },
+        min_transfer_amount,
+    );
+    let (_txn_hash, block_height, exec_result) = test.send_transaction(txn).await;
+    assert!(exec_result_is_success(&exec_result));
+
+    let charlie_balance = test.get_balances(Some(block_height)).2.unwrap();
+    assert_eq!(
+        charlie_balance.total.clone(),
+        min_transfer_amount + transfer_cost + half_transfer_cost, /* one `min_transfer_amount`
+                                                                   * should have gone to Bob. */
+    );
+    assert_eq!(
+        charlie_balance.available.clone(),
+        min_transfer_amount + half_transfer_cost, // transfer cost should be held.
+    );
+
+    // Let's wait for about 5 sec (5 blocks in this case) which should provide enough time for at
+    // half of the holds to get amortized.
+    test.fixture
+        .run_until_block_height(block_height + 5, ONE_MIN)
+        .await;
+    let charlie_balance = test.get_balances(Some(block_height + 5)).2.unwrap();
+    assert!(
+        charlie_balance.available.clone() >= min_transfer_amount + transfer_cost, /* right now he should have enough to make a transfer. */
+    );
+    assert!(
+        charlie_balance.available.clone() < charlie_balance.total.clone(), /* some of the holds
+                                                                            * should still be in
+                                                                            * place. */
+    );
+
+    // Send another transfer to Bob for `min_transfer_amount`.
+    let txn = transfer_txn(
+        CHARLIE_SECRET_KEY.clone(),
+        &*BOB_PUBLIC_KEY,
+        PricingMode::Fixed {
+            gas_price_tolerance: MIN_GAS_PRICE,
+        },
+        min_transfer_amount,
+    );
+    let (_txn_hash, block_height, exec_result) = test.send_transaction(txn).await;
+    assert!(exec_result_is_success(&exec_result)); // We expect this transfer to succeed since Charlie has enough balance.
+    let charlie_balance = test.get_balances(Some(block_height)).2.unwrap();
+    assert_eq!(
+        charlie_balance.total.clone(),
+        transfer_cost + half_transfer_cost, // two `min_transfer_amount` should have gone to Bob.
+    );
 }

--- a/storage/src/data_access_layer.rs
+++ b/storage/src/data_access_layer.rs
@@ -11,6 +11,7 @@ pub mod auction;
 pub mod balance;
 mod balance_hold;
 pub mod bids;
+mod block_global;
 pub mod block_rewards;
 pub mod era_validators;
 mod execution_results_checksum;
@@ -41,6 +42,7 @@ pub use balance_hold::{
     InsufficientBalanceHandling,
 };
 pub use bids::{BidsRequest, BidsResult};
+pub use block_global::{BlockGlobalKind, BlockGlobalRequest, BlockGlobalResult};
 pub use block_rewards::{BlockRewardsError, BlockRewardsRequest, BlockRewardsResult};
 pub use era_validators::{EraValidatorsRequest, EraValidatorsResult};
 pub use execution_results_checksum::{
@@ -120,8 +122,8 @@ where
         self.state.flush(request)
     }
 
-    fn checkout(&self, state_hash: Digest) -> Result<Option<Self::Reader>, GlobalStateError> {
-        self.state.checkout(state_hash)
+    fn empty_root(&self) -> Digest {
+        self.state.empty_root()
     }
 
     fn tracking_copy(
@@ -134,8 +136,8 @@ where
         }
     }
 
-    fn empty_root(&self) -> Digest {
-        self.state.empty_root()
+    fn checkout(&self, state_hash: Digest) -> Result<Option<Self::Reader>, GlobalStateError> {
+        self.state.checkout(state_hash)
     }
 
     fn trie(&self, request: TrieRequest) -> TrieResult {

--- a/storage/src/data_access_layer/balance.rs
+++ b/storage/src/data_access_layer/balance.rs
@@ -7,8 +7,8 @@ use casper_types::{
         mint::BalanceHoldAddrTag,
         HANDLE_PAYMENT,
     },
-    AccessRights, BlockTime, Digest, EntityAddr, HoldBalanceHandling, HoldsEpoch, InitiatorAddr,
-    Key, ProtocolVersion, PublicKey, StoredValue, TimeDiff, URef, URefAddr, U512,
+    AccessRights, BlockTime, Digest, EntityAddr, HoldBalanceHandling, InitiatorAddr, Key,
+    ProtocolVersion, PublicKey, StoredValue, TimeDiff, URef, URefAddr, U512,
 };
 use itertools::Itertools;
 use num_rational::Ratio;
@@ -32,7 +32,7 @@ pub enum BalanceHandling {
     #[default]
     Total,
     /// Adjust for balance holds (if any).
-    Available { holds_epoch: HoldsEpoch },
+    Available,
 }
 
 /// Merkle proof handling options.
@@ -254,7 +254,6 @@ impl From<(HoldBalanceHandling, u64)> for GasHoldBalanceHandling {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BalanceRequest {
     state_hash: Digest,
-    block_time: BlockTime,
     protocol_version: ProtocolVersion,
     identifier: BalanceIdentifier,
     balance_handling: BalanceHandling,
@@ -265,7 +264,6 @@ impl BalanceRequest {
     /// Creates a new [`BalanceRequest`].
     pub fn new(
         state_hash: Digest,
-        block_time: BlockTime,
         protocol_version: ProtocolVersion,
         identifier: BalanceIdentifier,
         balance_handling: BalanceHandling,
@@ -273,7 +271,6 @@ impl BalanceRequest {
     ) -> Self {
         BalanceRequest {
             state_hash,
-            block_time,
             protocol_version,
             identifier,
             balance_handling,
@@ -284,7 +281,6 @@ impl BalanceRequest {
     /// Creates a new [`BalanceRequest`].
     pub fn from_purse(
         state_hash: Digest,
-        block_time: BlockTime,
         protocol_version: ProtocolVersion,
         purse_uref: URef,
         balance_handling: BalanceHandling,
@@ -292,7 +288,6 @@ impl BalanceRequest {
     ) -> Self {
         BalanceRequest {
             state_hash,
-            block_time,
             protocol_version,
             identifier: BalanceIdentifier::Purse(purse_uref),
             balance_handling,
@@ -303,7 +298,6 @@ impl BalanceRequest {
     /// Creates a new [`BalanceRequest`].
     pub fn from_public_key(
         state_hash: Digest,
-        block_time: BlockTime,
         protocol_version: ProtocolVersion,
         public_key: PublicKey,
         balance_handling: BalanceHandling,
@@ -311,7 +305,6 @@ impl BalanceRequest {
     ) -> Self {
         BalanceRequest {
             state_hash,
-            block_time,
             protocol_version,
             identifier: BalanceIdentifier::Public(public_key),
             balance_handling,
@@ -322,7 +315,6 @@ impl BalanceRequest {
     /// Creates a new [`BalanceRequest`].
     pub fn from_account_hash(
         state_hash: Digest,
-        block_time: BlockTime,
         protocol_version: ProtocolVersion,
         account_hash: AccountHash,
         balance_handling: BalanceHandling,
@@ -330,7 +322,6 @@ impl BalanceRequest {
     ) -> Self {
         BalanceRequest {
             state_hash,
-            block_time,
             protocol_version,
             identifier: BalanceIdentifier::Account(account_hash),
             balance_handling,
@@ -341,7 +332,6 @@ impl BalanceRequest {
     /// Creates a new [`BalanceRequest`].
     pub fn from_entity_addr(
         state_hash: Digest,
-        block_time: BlockTime,
         protocol_version: ProtocolVersion,
         entity_addr: EntityAddr,
         balance_handling: BalanceHandling,
@@ -349,7 +339,6 @@ impl BalanceRequest {
     ) -> Self {
         BalanceRequest {
             state_hash,
-            block_time,
             protocol_version,
             identifier: BalanceIdentifier::Entity(entity_addr),
             balance_handling,
@@ -360,7 +349,6 @@ impl BalanceRequest {
     /// Creates a new [`BalanceRequest`].
     pub fn from_internal(
         state_hash: Digest,
-        block_time: BlockTime,
         protocol_version: ProtocolVersion,
         balance_addr: URefAddr,
         balance_handling: BalanceHandling,
@@ -368,7 +356,6 @@ impl BalanceRequest {
     ) -> Self {
         BalanceRequest {
             state_hash,
-            block_time,
             protocol_version,
             identifier: BalanceIdentifier::Internal(balance_addr),
             balance_handling,
@@ -379,11 +366,6 @@ impl BalanceRequest {
     /// Returns a state hash.
     pub fn state_hash(&self) -> Digest {
         self.state_hash
-    }
-
-    /// Returns block time.
-    pub fn block_time(&self) -> BlockTime {
-        self.block_time
     }
 
     /// Protocol version.

--- a/storage/src/data_access_layer/balance_hold.rs
+++ b/storage/src/data_access_layer/balance_hold.rs
@@ -1,15 +1,12 @@
 use crate::{
-    data_access_layer::{
-        balance::{BalanceError, GasHoldBalanceHandling},
-        BalanceIdentifier,
-    },
+    data_access_layer::{balance::BalanceError, BalanceIdentifier},
     tracking_copy::TrackingCopyError,
 };
 use casper_types::{
     account::AccountHash,
     execution::Effects,
     system::mint::{BalanceHoldAddr, BalanceHoldAddrTag},
-    BlockTime, Digest, HoldsEpoch, ProtocolVersion, U512,
+    Digest, ProtocolVersion, U512,
 };
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
@@ -36,12 +33,10 @@ pub enum BalanceHoldMode {
     Hold {
         identifier: BalanceIdentifier,
         hold_amount: U512,
-        holds_epoch: HoldsEpoch,
         insufficient_handling: InsufficientBalanceHandling,
     },
     Clear {
         identifier: BalanceIdentifier,
-        holds_epoch: HoldsEpoch,
     },
 }
 
@@ -51,7 +46,6 @@ impl Default for BalanceHoldMode {
             insufficient_handling: InsufficientBalanceHandling::HoldRemaining,
             hold_amount: U512::zero(),
             identifier: BalanceIdentifier::Account(AccountHash::default()),
-            holds_epoch: HoldsEpoch::default(),
         }
     }
 }
@@ -70,10 +64,8 @@ pub enum InsufficientBalanceHandling {
 pub struct BalanceHoldRequest {
     state_hash: Digest,
     protocol_version: ProtocolVersion,
-    block_time: BlockTime,
     hold_kind: BalanceHoldKind,
     hold_mode: BalanceHoldMode,
-    gas_hold_balance_handling: GasHoldBalanceHandling,
 }
 
 impl BalanceHoldRequest {
@@ -84,25 +76,19 @@ impl BalanceHoldRequest {
         protocol_version: ProtocolVersion,
         identifier: BalanceIdentifier,
         hold_amount: U512,
-        block_time: BlockTime,
-        holds_epoch: HoldsEpoch,
         insufficient_handling: InsufficientBalanceHandling,
-        gas_hold_balance_handling: GasHoldBalanceHandling,
     ) -> Self {
         let hold_kind = BalanceHoldKind::Tag(BalanceHoldAddrTag::Gas);
         let hold_mode = BalanceHoldMode::Hold {
             identifier,
             hold_amount,
-            holds_epoch,
             insufficient_handling,
         };
         BalanceHoldRequest {
             state_hash,
             protocol_version,
-            block_time,
             hold_kind,
             hold_mode,
-            gas_hold_balance_handling,
         }
     }
 
@@ -113,25 +99,19 @@ impl BalanceHoldRequest {
         protocol_version: ProtocolVersion,
         identifier: BalanceIdentifier,
         hold_amount: U512,
-        block_time: BlockTime,
-        holds_epoch: HoldsEpoch,
         insufficient_handling: InsufficientBalanceHandling,
-        gas_hold_balance_handling: GasHoldBalanceHandling,
     ) -> Self {
         let hold_kind = BalanceHoldKind::Tag(BalanceHoldAddrTag::Processing);
         let hold_mode = BalanceHoldMode::Hold {
             identifier,
             hold_amount,
-            holds_epoch,
             insufficient_handling,
         };
         BalanceHoldRequest {
             state_hash,
             protocol_version,
-            block_time,
             hold_kind,
             hold_mode,
-            gas_hold_balance_handling,
         }
     }
 
@@ -139,23 +119,15 @@ impl BalanceHoldRequest {
     pub fn new_clear(
         state_hash: Digest,
         protocol_version: ProtocolVersion,
-        block_time: BlockTime,
         hold_kind: BalanceHoldKind,
         identifier: BalanceIdentifier,
-        holds_epoch: HoldsEpoch,
-        gas_hold_balance_handling: GasHoldBalanceHandling,
     ) -> Self {
-        let hold_mode = BalanceHoldMode::Clear {
-            identifier,
-            holds_epoch,
-        };
+        let hold_mode = BalanceHoldMode::Clear { identifier };
         BalanceHoldRequest {
             state_hash,
             protocol_version,
-            block_time,
             hold_kind,
             hold_mode,
-            gas_hold_balance_handling,
         }
     }
 
@@ -169,11 +141,6 @@ impl BalanceHoldRequest {
         self.protocol_version
     }
 
-    /// Block time.
-    pub fn block_time(&self) -> BlockTime {
-        self.block_time
-    }
-
     /// Balance hold kind.
     pub fn balance_hold_kind(&self) -> BalanceHoldKind {
         self.hold_kind
@@ -182,11 +149,6 @@ impl BalanceHoldRequest {
     /// Balance hold mode.
     pub fn balance_hold_mode(&self) -> BalanceHoldMode {
         self.hold_mode.clone()
-    }
-
-    /// Gas hold balance handling.
-    pub fn gas_hold_balance_handling(&self) -> GasHoldBalanceHandling {
-        self.gas_hold_balance_handling
     }
 }
 
@@ -203,6 +165,12 @@ pub enum BalanceHoldError {
 impl From<BalanceError> for BalanceHoldError {
     fn from(be: BalanceError) -> Self {
         BalanceHoldError::Balance(be)
+    }
+}
+
+impl From<TrackingCopyError> for BalanceHoldError {
+    fn from(tce: TrackingCopyError) -> Self {
+        BalanceHoldError::TrackingCopy(tce)
     }
 }
 
@@ -360,5 +328,11 @@ impl BalanceHoldResult {
 impl From<BalanceError> for BalanceHoldResult {
     fn from(be: BalanceError) -> Self {
         BalanceHoldResult::Failure(be.into())
+    }
+}
+
+impl From<TrackingCopyError> for BalanceHoldResult {
+    fn from(tce: TrackingCopyError) -> Self {
+        BalanceHoldResult::Failure(tce.into())
     }
 }

--- a/storage/src/data_access_layer/balance_hold.rs
+++ b/storage/src/data_access_layer/balance_hold.rs
@@ -1,5 +1,5 @@
 use crate::{
-    data_access_layer::{balance::BalanceError, BalanceIdentifier},
+    data_access_layer::{balance::BalanceFailure, BalanceIdentifier},
     tracking_copy::TrackingCopyError,
 };
 use casper_types::{
@@ -157,13 +157,13 @@ impl BalanceHoldRequest {
 #[non_exhaustive]
 pub enum BalanceHoldError {
     TrackingCopy(TrackingCopyError),
-    Balance(BalanceError),
+    Balance(BalanceFailure),
     InsufficientBalance { remaining_balance: U512 },
     UnexpectedWildcardVariant, // programmer error
 }
 
-impl From<BalanceError> for BalanceHoldError {
-    fn from(be: BalanceError) -> Self {
+impl From<BalanceFailure> for BalanceHoldError {
+    fn from(be: BalanceFailure) -> Self {
         BalanceHoldError::Balance(be)
     }
 }
@@ -325,8 +325,8 @@ impl BalanceHoldResult {
     }
 }
 
-impl From<BalanceError> for BalanceHoldResult {
-    fn from(be: BalanceError) -> Self {
+impl From<BalanceFailure> for BalanceHoldResult {
+    fn from(be: BalanceFailure) -> Self {
         BalanceHoldResult::Failure(be.into())
     }
 }

--- a/storage/src/data_access_layer/balance_hold.rs
+++ b/storage/src/data_access_layer/balance_hold.rs
@@ -199,6 +199,8 @@ impl Display for BalanceHoldError {
 pub enum BalanceHoldResult {
     /// Returned if a passed state root hash is not found.
     RootNotFound,
+    /// Returned if global state does not have an entry for block time.
+    BlockTimeNotFound,
     /// Balance hold successfully placed.
     Success {
         /// Hold addresses, if any.
@@ -266,7 +268,9 @@ impl BalanceHoldResult {
     /// Hold address, if any.
     pub fn holds(&self) -> Option<Vec<BalanceHoldAddr>> {
         match self {
-            BalanceHoldResult::RootNotFound | BalanceHoldResult::Failure(_) => None,
+            BalanceHoldResult::RootNotFound
+            | BalanceHoldResult::BlockTimeNotFound
+            | BalanceHoldResult::Failure(_) => None,
             BalanceHoldResult::Success { holds, .. } => holds.clone(),
         }
     }
@@ -282,7 +286,9 @@ impl BalanceHoldResult {
     /// Was the hold fully covered?
     pub fn is_fully_covered(&self) -> bool {
         match self {
-            BalanceHoldResult::RootNotFound | BalanceHoldResult::Failure(_) => false,
+            BalanceHoldResult::RootNotFound
+            | BalanceHoldResult::BlockTimeNotFound
+            | BalanceHoldResult::Failure(_) => false,
             BalanceHoldResult::Success { hold, held, .. } => hold == held,
         }
     }
@@ -300,7 +306,9 @@ impl BalanceHoldResult {
     /// The effects, if any.
     pub fn effects(&self) -> Effects {
         match self {
-            BalanceHoldResult::RootNotFound | BalanceHoldResult::Failure(_) => Effects::new(),
+            BalanceHoldResult::RootNotFound
+            | BalanceHoldResult::BlockTimeNotFound
+            | BalanceHoldResult::Failure(_) => Effects::new(),
             BalanceHoldResult::Success { effects, .. } => *effects.clone(),
         }
     }
@@ -318,6 +326,7 @@ impl BalanceHoldResult {
                 }
             }
             BalanceHoldResult::RootNotFound => "root not found".to_string(),
+            BalanceHoldResult::BlockTimeNotFound => "block time not found".to_string(),
             BalanceHoldResult::Failure(bhe) => {
                 format!("{:?}", bhe)
             }

--- a/storage/src/data_access_layer/block_global.rs
+++ b/storage/src/data_access_layer/block_global.rs
@@ -1,0 +1,81 @@
+use crate::tracking_copy::TrackingCopyError;
+use casper_types::{execution::Effects, BlockTime, Digest, ProtocolVersion};
+use std::fmt::{Display, Formatter};
+use thiserror::Error;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum BlockGlobalKind {
+    BlockTime(BlockTime),
+    MessageCount(u64),
+}
+
+impl Default for BlockGlobalKind {
+    fn default() -> Self {
+        BlockGlobalKind::BlockTime(BlockTime::default())
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub struct BlockGlobalRequest {
+    state_hash: Digest,
+    protocol_version: ProtocolVersion,
+    block_global_kind: BlockGlobalKind,
+}
+
+impl BlockGlobalRequest {
+    /// Returns block time setting request.
+    pub fn block_time(
+        state_hash: Digest,
+        protocol_version: ProtocolVersion,
+        block_time: BlockTime,
+    ) -> Self {
+        let block_global_kind = BlockGlobalKind::BlockTime(block_time);
+        BlockGlobalRequest {
+            state_hash,
+            protocol_version,
+            block_global_kind,
+        }
+    }
+
+    /// Returns state hash.
+    pub fn state_hash(&self) -> Digest {
+        self.state_hash
+    }
+
+    /// Returns protocol version.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
+    /// Returns block global kind.
+    pub fn block_global_kind(&self) -> BlockGlobalKind {
+        self.block_global_kind
+    }
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum BlockGlobalResult {
+    /// Returned if a passed state root hash is not found.
+    RootNotFound,
+    /// Failed to store block global data.
+    Failure(TrackingCopyError),
+    /// Successfully stored block global data.
+    Success {
+        /// State hash after data committed to the global state.
+        post_state_hash: Digest,
+        /// The effects of putting the data to global state.
+        effects: Box<Effects>,
+    },
+}
+
+impl Display for BlockGlobalResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlockGlobalResult::RootNotFound => f.write_str("root not found"),
+            BlockGlobalResult::Failure(tce) => {
+                write!(f, "failed {}", tce)
+            }
+            BlockGlobalResult::Success { .. } => f.write_str("success"),
+        }
+    }
+}

--- a/storage/src/data_access_layer/fee.rs
+++ b/storage/src/data_access_layer/fee.rs
@@ -6,8 +6,8 @@ use crate::system::{
     transfer::TransferError,
 };
 use casper_types::{
-    account::AccountHash, execution::Effects, BlockTime, Digest, FeeHandling, HoldsEpoch,
-    ProtocolVersion, Transfer,
+    account::AccountHash, execution::Effects, BlockTime, Digest, FeeHandling, ProtocolVersion,
+    Transfer,
 };
 
 use crate::tracking_copy::TrackingCopyError;
@@ -18,7 +18,6 @@ pub struct FeeRequest {
     state_hash: Digest,
     protocol_version: ProtocolVersion,
     block_time: BlockTime,
-    holds_epoch: HoldsEpoch,
 }
 
 impl FeeRequest {
@@ -27,14 +26,12 @@ impl FeeRequest {
         state_hash: Digest,
         protocol_version: ProtocolVersion,
         block_time: BlockTime,
-        holds_epoch: HoldsEpoch,
     ) -> Self {
         FeeRequest {
             config,
             state_hash,
             protocol_version,
             block_time,
-            holds_epoch,
         }
     }
 
@@ -61,11 +58,6 @@ impl FeeRequest {
     /// Returns block time.
     pub fn block_time(&self) -> BlockTime {
         self.block_time
-    }
-
-    /// Returns holds epoch.
-    pub fn holds_epoch(&self) -> HoldsEpoch {
-        self.holds_epoch
     }
 
     /// Returns administrative accounts, if any.

--- a/storage/src/data_access_layer/handle_fee.rs
+++ b/storage/src/data_access_layer/handle_fee.rs
@@ -3,7 +3,7 @@ use crate::{
     tracking_copy::TrackingCopyError,
 };
 use casper_types::{
-    execution::Effects, Digest, HoldsEpoch, InitiatorAddr, ProtocolVersion, TransactionHash, U512,
+    execution::Effects, Digest, InitiatorAddr, ProtocolVersion, TransactionHash, U512,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,7 +13,6 @@ pub enum HandleFeeMode {
         source: Box<BalanceIdentifier>,
         target: Box<BalanceIdentifier>,
         amount: U512,
-        holds_epoch: HoldsEpoch,
     },
     Burn {
         source: BalanceIdentifier,
@@ -27,14 +26,12 @@ impl HandleFeeMode {
         source: BalanceIdentifier,
         target: BalanceIdentifier,
         amount: U512,
-        holds_epoch: HoldsEpoch,
     ) -> Self {
         HandleFeeMode::Pay {
             initiator_addr,
             source: Box::new(source),
             target: Box::new(target),
             amount,
-            holds_epoch,
         }
     }
 

--- a/storage/src/data_access_layer/mint.rs
+++ b/storage/src/data_access_layer/mint.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 
 use crate::system::runtime_native::{Config as NativeRuntimeConfig, TransferConfig};
 use casper_types::{
-    account::AccountHash, execution::Effects, Digest, HoldsEpoch, InitiatorAddr, ProtocolVersion,
-    RuntimeArgs, TransactionHash, Transfer,
+    account::AccountHash, execution::Effects, Digest, InitiatorAddr, ProtocolVersion, RuntimeArgs,
+    TransactionHash, Transfer,
 };
 
 use crate::system::transfer::{TransferArgs, TransferError};
@@ -22,8 +22,6 @@ pub struct TransferRequest {
     config: NativeRuntimeConfig,
     /// State root hash.
     state_hash: Digest,
-    /// Balance holds epoch.
-    holds_epoch: HoldsEpoch,
     /// Protocol version.
     protocol_version: ProtocolVersion,
     /// Transaction hash.
@@ -42,7 +40,6 @@ impl TransferRequest {
     pub fn new(
         config: NativeRuntimeConfig,
         state_hash: Digest,
-        holds_epoch: HoldsEpoch,
         protocol_version: ProtocolVersion,
         transaction_hash: TransactionHash,
         initiator: InitiatorAddr,
@@ -53,7 +50,6 @@ impl TransferRequest {
         Self {
             config,
             state_hash,
-            holds_epoch,
             protocol_version,
             transaction_hash,
             initiator,
@@ -67,7 +63,6 @@ impl TransferRequest {
     pub fn with_runtime_args(
         config: NativeRuntimeConfig,
         state_hash: Digest,
-        holds_epoch: HoldsEpoch,
         protocol_version: ProtocolVersion,
         transaction_hash: TransactionHash,
         initiator: InitiatorAddr,
@@ -78,7 +73,6 @@ impl TransferRequest {
         Self {
             config,
             state_hash,
-            holds_epoch,
             protocol_version,
             transaction_hash,
             initiator,
@@ -113,11 +107,6 @@ impl TransferRequest {
     /// Returns protocol version.
     pub fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_version
-    }
-
-    /// Returns holds epoch.
-    pub fn holds_epoch(&self) -> HoldsEpoch {
-        self.holds_epoch
     }
 
     /// Returns transaction hash.

--- a/storage/src/global_state/state/lmdb.rs
+++ b/storage/src/global_state/state/lmdb.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
 use lmdb::{DatabaseFlags, RwTransaction};
 
@@ -118,7 +118,7 @@ impl LmdbGlobalState {
     pub fn put_stored_values(
         &self,
         prestate_hash: Digest,
-        stored_values: HashMap<Key, StoredValue>,
+        stored_values: BTreeMap<Key, StoredValue>,
     ) -> Result<Digest, GlobalStateError> {
         let scratch_trie = self.get_scratch_store();
         let new_state_root = put_stored_values::<_, _, GlobalStateError>(

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -674,7 +674,7 @@ pub trait StateProvider {
             processing_hold_handling,
         ) {
             Ok(available_balance) => *available_balance,
-            Err(be) => return BalanceResult::Failure(be.clone()),
+            Err(be) => return BalanceResult::Failure(TrackingCopyError::Balance(be.clone())),
         };
 
         BalanceResult::Success {

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -9,7 +9,7 @@ pub mod scratch;
 use num_rational::Ratio;
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
     rc::Rc,
 };
@@ -1820,7 +1820,7 @@ pub fn put_stored_values<'a, R, S, E>(
     environment: &'a R,
     store: &S,
     prestate_hash: Digest,
-    stored_values: HashMap<Key, StoredValue>,
+    stored_values: BTreeMap<Key, StoredValue>,
 ) -> Result<Digest, E>
 where
     R: TransactionSource<'a, Handle = S::Handle>,

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -31,8 +31,8 @@ use casper_types::{
         },
         AUCTION, MINT,
     },
-    Account, AddressableEntity, CLValue, Digest, EntityAddr, HoldsEpoch, Key, KeyTag, Phase,
-    PublicKey, RuntimeArgs, StoredValue, TimeDiff, U512,
+    Account, AddressableEntity, BlockGlobalAddr, CLValue, Digest, EntityAddr, HoldsEpoch, Key,
+    KeyTag, Phase, PublicKey, RuntimeArgs, StoredValue, U512,
 };
 
 #[cfg(test)]
@@ -48,17 +48,18 @@ use crate::{
         tagged_values::{TaggedValuesRequest, TaggedValuesResult},
         AddressableEntityRequest, AddressableEntityResult, AuctionMethod, BalanceHoldError,
         BalanceHoldKind, BalanceHoldMode, BalanceHoldRequest, BalanceHoldResult, BalanceIdentifier,
-        BalanceRequest, BalanceResult, BidsRequest, BidsResult, BlockRewardsError,
-        BlockRewardsRequest, BlockRewardsResult, EraValidatorsRequest,
-        ExecutionResultsChecksumRequest, ExecutionResultsChecksumResult, FeeError, FeeRequest,
-        FeeResult, FlushRequest, FlushResult, GenesisRequest, GenesisResult, HandleRefundMode,
-        HandleRefundRequest, HandleRefundResult, InsufficientBalanceHandling, ProofHandling,
-        ProofsResult, ProtocolUpgradeRequest, ProtocolUpgradeResult, PruneRequest, PruneResult,
-        PutTrieRequest, PutTrieResult, QueryRequest, QueryResult, RoundSeigniorageRateRequest,
-        RoundSeigniorageRateResult, StepError, StepRequest, StepResult,
-        SystemEntityRegistryPayload, SystemEntityRegistryRequest, SystemEntityRegistryResult,
-        SystemEntityRegistrySelector, TotalSupplyRequest, TotalSupplyResult, TrieRequest,
-        TrieResult, EXECUTION_RESULTS_CHECKSUM_NAME,
+        BalanceRequest, BalanceResult, BidsRequest, BidsResult, BlockGlobalKind,
+        BlockGlobalRequest, BlockGlobalResult, BlockRewardsError, BlockRewardsRequest,
+        BlockRewardsResult, EraValidatorsRequest, ExecutionResultsChecksumRequest,
+        ExecutionResultsChecksumResult, FeeError, FeeRequest, FeeResult, FlushRequest, FlushResult,
+        GenesisRequest, GenesisResult, HandleRefundMode, HandleRefundRequest, HandleRefundResult,
+        InsufficientBalanceHandling, ProofHandling, ProofsResult, ProtocolUpgradeRequest,
+        ProtocolUpgradeResult, PruneRequest, PruneResult, PutTrieRequest, PutTrieResult,
+        QueryRequest, QueryResult, RoundSeigniorageRateRequest, RoundSeigniorageRateResult,
+        StepError, StepRequest, StepResult, SystemEntityRegistryPayload,
+        SystemEntityRegistryRequest, SystemEntityRegistryResult, SystemEntityRegistrySelector,
+        TotalSupplyRequest, TotalSupplyResult, TrieRequest, TrieResult,
+        EXECUTION_RESULTS_CHECKSUM_NAME,
     },
     global_state::{
         error::Error as GlobalStateError,
@@ -504,6 +505,56 @@ pub trait CommitProvider: StateProvider {
             )),
         }
     }
+
+    fn block_global(&self, request: BlockGlobalRequest) -> BlockGlobalResult {
+        let state_hash = request.state_hash();
+        let tc = match self.tracking_copy(state_hash) {
+            Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
+            Ok(None) => return BlockGlobalResult::RootNotFound,
+            Err(gse) => return BlockGlobalResult::Failure(TrackingCopyError::Storage(gse)),
+        };
+
+        // match request
+        match request.block_global_kind() {
+            BlockGlobalKind::BlockTime(block_time) => {
+                let cl_value =
+                    match CLValue::from_t(block_time.value()).map_err(TrackingCopyError::CLValue) {
+                        Ok(cl_value) => cl_value,
+                        Err(tce) => {
+                            return BlockGlobalResult::Failure(tce);
+                        }
+                    };
+                tc.borrow_mut().write(
+                    Key::BlockGlobal(BlockGlobalAddr::BlockTime),
+                    StoredValue::CLValue(cl_value),
+                );
+            }
+            BlockGlobalKind::MessageCount(count) => {
+                let cl_value = match CLValue::from_t(count).map_err(TrackingCopyError::CLValue) {
+                    Ok(cl_value) => cl_value,
+                    Err(tce) => {
+                        return BlockGlobalResult::Failure(tce);
+                    }
+                };
+                tc.borrow_mut().write(
+                    Key::BlockGlobal(BlockGlobalAddr::MessageCount),
+                    StoredValue::CLValue(cl_value),
+                );
+            }
+        }
+
+        let effects = tc.borrow_mut().effects();
+
+        let post_state_hash = match self.commit(state_hash, effects.clone()) {
+            Ok(post_state_hash) => post_state_hash,
+            Err(gse) => return BlockGlobalResult::Failure(TrackingCopyError::Storage(gse)),
+        };
+
+        BlockGlobalResult::Success {
+            post_state_hash,
+            effects: Box::new(effects),
+        }
+    }
 }
 
 /// A trait expressing operations over the trie.
@@ -570,12 +621,10 @@ pub trait StateProvider {
                 };
                 let balance_holds = match request.balance_handling() {
                     BalanceHandling::Total => BTreeMap::new(),
-                    BalanceHandling::Available { holds_epoch } => {
-                        match tc.get_balance_holds(purse_addr, holds_epoch) {
-                            Ok(holds) => holds,
-                            Err(tce) => return tce.into(),
-                        }
-                    }
+                    BalanceHandling::Available => match tc.get_balance_holds(purse_addr) {
+                        Ok(holds) => holds,
+                        Err(tce) => return tce.into(),
+                    },
                 };
                 (total_balance, ProofsResult::NotRequested { balance_holds })
             }
@@ -588,8 +637,8 @@ pub trait StateProvider {
 
                 let balance_holds = match request.balance_handling() {
                     BalanceHandling::Total => BTreeMap::new(),
-                    BalanceHandling::Available { holds_epoch } => {
-                        match tc.get_balance_holds_with_proof(purse_addr, holds_epoch) {
+                    BalanceHandling::Available => {
+                        match tc.get_balance_holds_with_proof(purse_addr) {
                             Ok(holds) => holds,
                             Err(tce) => return tce.into(),
                         }
@@ -606,19 +655,20 @@ pub trait StateProvider {
             }
         };
 
-        let gas_hold_handling = match tc.get_balance_hold_config(BalanceHoldAddrTag::Gas) {
-            Ok(ret) => ret.into(),
-            Err(tce) => return tce.into(),
-        };
+        let (block_time, gas_hold_handling) =
+            match tc.get_balance_hold_config(BalanceHoldAddrTag::Gas) {
+                Ok((block_time, handling, interval)) => (block_time, (handling, interval).into()),
+                Err(tce) => return tce.into(),
+            };
 
         let processing_hold_handling =
             match tc.get_balance_hold_config(BalanceHoldAddrTag::Processing) {
-                Ok(ret) => ret.into(),
+                Ok((_, handling, interval)) => (handling, interval).into(),
                 Err(tce) => return tce.into(),
             };
 
         let available_balance = match &proofs_result.available_balance(
-            request.block_time(),
+            block_time,
             total_balance,
             gas_hold_handling,
             processing_hold_handling,
@@ -651,9 +701,12 @@ pub trait StateProvider {
             BalanceHoldMode::Hold {
                 identifier,
                 hold_amount,
-                holds_epoch,
                 insufficient_handling,
             } => {
+                let block_time = match tc.get_block_time() {
+                    Ok(block_time) => block_time,
+                    Err(tce) => return tce.into(),
+                };
                 let tag = match request.balance_hold_kind() {
                     BalanceHoldKind::All => {
                         return BalanceHoldResult::Failure(
@@ -664,10 +717,9 @@ pub trait StateProvider {
                 };
                 let balance_request = BalanceRequest::new(
                     request.state_hash(),
-                    request.block_time(),
                     request.protocol_version(),
                     identifier,
-                    BalanceHandling::Available { holds_epoch },
+                    BalanceHandling::Available,
                     ProofHandling::NoProofs,
                 );
                 let balance_result = self.balance(balance_request);
@@ -714,7 +766,6 @@ pub trait StateProvider {
                     }
                 };
 
-                let block_time = request.block_time();
                 let balance_hold_addr = match tag {
                     BalanceHoldAddrTag::Gas => BalanceHoldAddr::Gas {
                         purse_addr,
@@ -741,10 +792,7 @@ pub trait StateProvider {
                     effects,
                 )
             }
-            BalanceHoldMode::Clear {
-                identifier,
-                holds_epoch,
-            } => {
+            BalanceHoldMode::Clear { identifier } => {
                 let purse_addr = match identifier.purse_uref(&mut tc, request.protocol_version()) {
                     Ok(source_purse) => source_purse.addr(),
                     Err(tce) => {
@@ -754,18 +802,31 @@ pub trait StateProvider {
 
                 {
                     // clear holds
-                    let bid_kind = request.balance_hold_kind();
+                    let hold_kind = request.balance_hold_kind();
                     let mut filter = vec![];
                     let tag = BalanceHoldAddrTag::Processing;
-                    if bid_kind.matches(tag) {
-                        filter.push((
-                            BalanceHoldAddrTag::Processing,
-                            HoldsEpoch::from_block_time(request.block_time(), TimeDiff::ZERO),
-                        ));
+                    if hold_kind.matches(tag) {
+                        let (block_time, interval) = match tc.get_balance_hold_config(tag) {
+                            Ok((block_time, _, interval)) => (block_time, interval),
+                            Err(tce) => {
+                                return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(
+                                    tce,
+                                ))
+                            }
+                        };
+                        filter.push((tag, HoldsEpoch::from_millis(block_time.value(), interval)));
                     }
                     let tag = BalanceHoldAddrTag::Gas;
-                    if bid_kind.matches(tag) {
-                        filter.push((tag, holds_epoch));
+                    if hold_kind.matches(tag) {
+                        let (block_time, interval) = match tc.get_balance_hold_config(tag) {
+                            Ok((block_time, _, interval)) => (block_time, interval),
+                            Err(tce) => {
+                                return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(
+                                    tce,
+                                ))
+                            }
+                        };
+                        filter.push((tag, HoldsEpoch::from_millis(block_time.value(), interval)));
                     }
                     if let Err(tce) = tc.clear_expired_balance_holds(purse_addr, filter) {
                         return BalanceHoldResult::Failure(BalanceHoldError::TrackingCopy(tce));
@@ -775,10 +836,9 @@ pub trait StateProvider {
                 // get updated balance
                 let balance_result = self.balance(BalanceRequest::new(
                     request.state_hash(),
-                    request.block_time(),
                     request.protocol_version(),
                     identifier,
-                    BalanceHandling::Available { holds_epoch },
+                    BalanceHandling::Available,
                     ProofHandling::NoProofs,
                 ));
                 let (total_balance, available_balance) = match balance_result {
@@ -813,7 +873,7 @@ pub trait StateProvider {
     /// Get the requested era validators.
     fn era_validators(&self, request: EraValidatorsRequest) -> EraValidatorsResult {
         let state_hash = request.state_hash();
-        let mut tc = match self.tracking_copy(state_hash) {
+        let tc = match self.tracking_copy(state_hash) {
             Ok(Some(tc)) => tc,
             Ok(None) => return EraValidatorsResult::RootNotFound,
             Err(err) => return EraValidatorsResult::Failure(TrackingCopyError::Storage(err)),
@@ -962,9 +1022,8 @@ pub trait StateProvider {
                 public_key,
                 delegation_rate,
                 amount,
-                holds_epoch,
             } => runtime
-                .add_bid(public_key, delegation_rate, amount, holds_epoch)
+                .add_bid(public_key, delegation_rate, amount)
                 .map(AuctionMethodRet::UpdatedAmount)
                 .map_err(TrackingCopyError::Api),
             AuctionMethod::WithdrawBid { public_key, amount } => runtime
@@ -979,7 +1038,6 @@ pub trait StateProvider {
                 amount,
                 max_delegators_per_validator,
                 minimum_delegation_amount,
-                holds_epoch,
             } => runtime
                 .delegate(
                     delegator,
@@ -987,7 +1045,6 @@ pub trait StateProvider {
                     amount,
                     max_delegators_per_validator,
                     minimum_delegation_amount,
-                    holds_epoch,
                 )
                 .map(AuctionMethodRet::UpdatedAmount)
                 .map_err(TrackingCopyError::Api),
@@ -1081,7 +1138,6 @@ pub trait StateProvider {
                     cost,
                     consumed,
                     source_purse,
-                    HoldsEpoch::NOT_APPLICABLE,
                     ratio,
                 ) {
                     Ok((refund, _)) => Some(refund),
@@ -1115,7 +1171,6 @@ pub trait StateProvider {
                     cost,
                     consumed,
                     source_purse,
-                    HoldsEpoch::NOT_APPLICABLE,
                     ratio,
                 ) {
                     Ok((refund, _)) => refund,
@@ -1137,7 +1192,6 @@ pub trait StateProvider {
                         target_purse,
                         refund_amount,
                         None,
-                        HoldsEpoch::NOT_APPLICABLE,
                     )
                     .map_err(|_| Error::Transfer)
                 {
@@ -1165,7 +1219,6 @@ pub trait StateProvider {
                     cost,
                     consumed,
                     source_purse,
-                    HoldsEpoch::NOT_APPLICABLE,
                     ratio,
                 ) {
                     Ok((amount, _)) => Some(amount),
@@ -1243,7 +1296,6 @@ pub trait StateProvider {
                 amount,
                 source,
                 target,
-                holds_epoch,
             } => {
                 let source_purse = match source.purse_uref(&mut tc.borrow_mut(), protocol_version) {
                     Ok(value) => value,
@@ -1260,7 +1312,6 @@ pub trait StateProvider {
                         target_purse,
                         amount,
                         None,
-                        holds_epoch,
                     )
                     .map_err(|_| Error::Transfer)
             }
@@ -1412,7 +1463,7 @@ pub trait StateProvider {
         request: SystemEntityRegistryRequest,
     ) -> SystemEntityRegistryResult {
         let state_hash = request.state_hash();
-        let mut tc = match self.tracking_copy(state_hash) {
+        let tc = match self.tracking_copy(state_hash) {
             Ok(Some(tc)) => tc,
             Ok(None) => return SystemEntityRegistryResult::RootNotFound,
             Err(err) => {
@@ -1456,7 +1507,7 @@ pub trait StateProvider {
     /// Gets total supply.
     fn total_supply(&self, request: TotalSupplyRequest) -> TotalSupplyResult {
         let state_hash = request.state_hash();
-        let mut tc = match self.tracking_copy(state_hash) {
+        let tc = match self.tracking_copy(state_hash) {
             Ok(Some(tc)) => tc,
             Ok(None) => return TotalSupplyResult::RootNotFound,
             Err(err) => return TotalSupplyResult::Failure(TrackingCopyError::Storage(err)),
@@ -1509,7 +1560,7 @@ pub trait StateProvider {
         request: RoundSeigniorageRateRequest,
     ) -> RoundSeigniorageRateResult {
         let state_hash = request.state_hash();
-        let mut tc = match self.tracking_copy(state_hash) {
+        let tc = match self.tracking_copy(state_hash) {
             Ok(Some(tc)) => tc,
             Ok(None) => return RoundSeigniorageRateResult::RootNotFound,
             Err(err) => {
@@ -1573,7 +1624,7 @@ pub trait StateProvider {
             Err(err) => {
                 return TransferResult::Failure(TransferError::TrackingCopy(
                     TrackingCopyError::Storage(err),
-                ))
+                ));
             }
         };
 
@@ -1682,7 +1733,7 @@ pub trait StateProvider {
                 let main_purse = match runtime.mint(U512::zero()) {
                     Ok(uref) => uref,
                     Err(mint_error) => {
-                        return TransferResult::Failure(TransferError::Mint(mint_error))
+                        return TransferResult::Failure(TransferError::Mint(mint_error));
                     }
                 };
                 // TODO: KARAN TO FIX: this should create a shiny new addressable entity instance,
@@ -1711,7 +1762,6 @@ pub trait StateProvider {
             transfer_args.target(),
             transfer_args.amount(),
             transfer_args.arg_id(),
-            request.holds_epoch(),
         ) {
             return TransferResult::Failure(TransferError::Mint(mint_error));
         }

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -18,7 +18,7 @@ use casper_types::{
         BidAddr, BidKind, DelegationRate, EraInfo, EraValidators, Error, SeigniorageRecipients,
         UnbondingPurse, ValidatorBid, ValidatorWeights, DELEGATION_RATE_DENOMINATOR,
     },
-    ApiError, EraId, HoldsEpoch, PublicKey, U512,
+    ApiError, EraId, PublicKey, U512,
 };
 
 use self::providers::{AccountProvider, MintProvider, RuntimeProvider, StorageProvider};
@@ -69,7 +69,6 @@ pub trait Auction:
         public_key: PublicKey,
         delegation_rate: DelegationRate,
         amount: U512,
-        holds_epoch: HoldsEpoch,
     ) -> Result<U512, ApiError> {
         if !self.allow_auction_bids() {
             // The validator set may be closed on some side chains,
@@ -115,7 +114,6 @@ pub trait Auction:
             target,
             amount,
             None,
-            holds_epoch,
         )
         .map_err(|_| Error::TransferToBidPurse)?
         .map_err(|mint_error| {
@@ -213,7 +211,6 @@ pub trait Auction:
         amount: U512,
         max_delegators_per_validator: u32,
         minimum_delegation_amount: u64,
-        holds_epoch: HoldsEpoch,
     ) -> Result<U512, ApiError> {
         if !self.allow_auction_bids() {
             // Validation set rotation might be disabled on some private chains and we should not
@@ -235,7 +232,6 @@ pub trait Auction:
             amount,
             max_delegators_per_validator,
             minimum_delegation_amount,
-            holds_epoch,
         )
     }
 

--- a/storage/src/system/auction/auction_native.rs
+++ b/storage/src/system/auction/auction_native.rs
@@ -18,7 +18,7 @@ use casper_types::{
         auction::{BidAddr, BidKind, EraInfo, Error, UnbondingPurse},
         mint,
     },
-    CLTyped, CLValue, HoldsEpoch, Key, KeyTag, PublicKey, StoredValue, URef, U512,
+    CLTyped, CLValue, Key, KeyTag, PublicKey, StoredValue, URef, U512,
 };
 use std::collections::BTreeSet;
 use tracing::error;
@@ -254,7 +254,6 @@ where
                     contract.main_purse(),
                     *unbonding_purse.amount(),
                     None,
-                    HoldsEpoch::NOT_APPLICABLE, // unbonding purses do not have holds on them
                 )
                 .map_err(|_| Error::Transfer)?
                 .map_err(|_| Error::Transfer)?;
@@ -272,7 +271,6 @@ where
         target: URef,
         amount: U512,
         id: Option<u64>,
-        holds_epoch: HoldsEpoch,
     ) -> Result<Result<(), mint::Error>, Error> {
         if !(self.addressable_entity().main_purse().addr() == source.addr()
             || self.get_caller() == PublicKey::System.to_account_hash())
@@ -283,7 +281,7 @@ where
         // let gas_counter = self.gas_counter();
         self.extend_access_rights(&[source, target.into_add()]);
 
-        match self.transfer(to, source, target, amount, id, holds_epoch) {
+        match self.transfer(to, source, target, amount, id) {
             Ok(ret) => {
                 // self.set_gas_counter(gas_counter);
                 Ok(Ok(ret))
@@ -304,12 +302,8 @@ where
             return Err(Error::InvalidCaller);
         }
 
-        // let gas_counter = self.gas_counter();
         match <Self as Mint>::mint_into_existing_purse(self, existing_purse, amount) {
-            Ok(ret) => {
-                // self.set_gas_counter(gas_counter);
-                Ok(ret)
-            }
+            Ok(ret) => Ok(ret),
             Err(err) => {
                 error!("{}", err);
                 Err(Error::MintError)
@@ -328,12 +322,8 @@ where
         }
     }
 
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error> {
-        match <Self as Mint>::balance(self, purse, holds_epoch) {
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
+        match <Self as Mint>::balance(self, purse) {
             Ok(ret) => Ok(ret),
             Err(err) => {
                 error!("{}", err);

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -11,7 +11,7 @@ use casper_types::{
         ValidatorBids, AUCTION_DELAY_KEY, ERA_END_TIMESTAMP_MILLIS_KEY, ERA_ID_KEY,
         SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY, UNBONDING_DELAY_KEY, VALIDATOR_SLOTS_KEY,
     },
-    ApiError, CLTyped, EraId, HoldsEpoch, Key, KeyTag, PublicKey, URef, U512,
+    ApiError, CLTyped, EraId, Key, KeyTag, PublicKey, URef, U512,
 };
 use tracing::{error, warn};
 
@@ -277,7 +277,7 @@ pub fn create_unbonding_purse<P: Auction + ?Sized>(
     new_validator: Option<PublicKey>,
 ) -> Result<(), Error> {
     if provider
-        .available_balance(bonding_purse, HoldsEpoch::NOT_APPLICABLE)?
+        .available_balance(bonding_purse)?
         .unwrap_or_default()
         < amount
     {
@@ -463,7 +463,6 @@ where
         *unbonding_purse.amount(),
         max_delegators_per_validator,
         minimum_delegation_amount,
-        HoldsEpoch::NOT_APPLICABLE,
     );
     match redelegation {
         Ok(_) => Ok(UnbondRedelegationOutcome::SuccessfullyRedelegated),
@@ -495,7 +494,6 @@ pub fn handle_delegation<P>(
     amount: U512,
     max_delegators_per_validator: u32,
     minimum_delegation_amount: u64,
-    holds_epoch: HoldsEpoch,
 ) -> Result<U512, ApiError>
 where
     P: StorageProvider + MintProvider + RuntimeProvider,
@@ -551,7 +549,6 @@ where
             target,
             amount,
             None,
-            holds_epoch,
         )
         .map_err(|_| Error::TransferToDelegatorPurse)?
         .map_err(|mint_error| {

--- a/storage/src/system/auction/providers.rs
+++ b/storage/src/system/auction/providers.rs
@@ -8,7 +8,7 @@ use casper_types::{
         auction::{BidAddr, BidKind, EraInfo, Error, UnbondingPurse},
         mint,
     },
-    CLTyped, HoldsEpoch, Key, KeyTag, URef, BLAKE2B_DIGEST_LENGTH, U512,
+    CLTyped, Key, KeyTag, URef, BLAKE2B_DIGEST_LENGTH, U512,
 };
 
 /// Provider of runtime host functionality.
@@ -91,7 +91,6 @@ pub trait MintProvider {
         target: URef,
         amount: U512,
         id: Option<u64>,
-        holds_epoch: HoldsEpoch,
     ) -> Result<Result<(), mint::Error>, Error>;
 
     /// Mint `amount` new token into `existing_purse`.
@@ -103,11 +102,7 @@ pub trait MintProvider {
     fn create_purse(&mut self) -> Result<URef, Error>;
 
     /// Gets purse balance.
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error>;
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error>;
 
     /// Reads the base round reward.
     fn read_base_round_reward(&mut self) -> Result<U512, Error>;

--- a/storage/src/system/handle_payment.rs
+++ b/storage/src/system/handle_payment.rs
@@ -6,7 +6,7 @@ pub mod storage_provider;
 
 use casper_types::{
     system::handle_payment::{Error, REFUND_PURSE_KEY},
-    AccessRights, HoldsEpoch, URef, U512,
+    AccessRights, URef, U512,
 };
 use num_rational::Ratio;
 
@@ -28,7 +28,7 @@ pub trait HandlePayment: MintProvider + RuntimeProvider + StorageProvider + Size
     fn set_refund_purse(&mut self, purse: URef) -> Result<(), Error> {
         // make sure the passed uref is actually a purse...
         // if it has a balance it is a purse and if not it isn't
-        let _balance = self.available_balance(purse, HoldsEpoch::NOT_APPLICABLE)?;
+        let _balance = self.available_balance(purse)?;
         internal::set_refund(self, purse)
     }
 
@@ -55,10 +55,9 @@ pub trait HandlePayment: MintProvider + RuntimeProvider + StorageProvider + Size
         cost: U512,
         consumed: U512,
         source_purse: URef,
-        holds_epoch: HoldsEpoch,
         refund_ratio: Ratio<U512>,
     ) -> Result<(U512, U512), Error> {
-        let available_balance = match self.available_balance(source_purse, holds_epoch)? {
+        let available_balance = match self.available_balance(source_purse)? {
             Some(balance) => balance,
             None => return Err(Error::PaymentPurseBalanceNotFound),
         };

--- a/storage/src/system/handle_payment/handle_payment_native.rs
+++ b/storage/src/system/handle_payment/handle_payment_native.rs
@@ -14,8 +14,8 @@ use casper_types::{
     account::AccountHash,
     addressable_entity::{NamedKeyAddr, NamedKeyValue},
     system::handle_payment::Error,
-    AccessRights, AddressableEntityHash, CLValue, FeeHandling, GrantedAccess, HoldsEpoch, Key,
-    Phase, RefundHandling, StoredValue, TransferredTo, URef, U512,
+    AccessRights, AddressableEntityHash, CLValue, FeeHandling, GrantedAccess, Key, Phase,
+    RefundHandling, StoredValue, TransferredTo, URef, U512,
 };
 use std::collections::BTreeSet;
 use tracing::error;
@@ -102,14 +102,7 @@ where
         amount: U512,
     ) -> Result<(), Error> {
         // system purses do not have holds on them
-        match self.transfer(
-            None,
-            source,
-            target,
-            amount,
-            None,
-            HoldsEpoch::NOT_APPLICABLE,
-        ) {
+        match self.transfer(None, source, target, amount, None) {
             Ok(ret) => Ok(ret),
             Err(err) => {
                 error!("{}", err);
@@ -118,12 +111,8 @@ where
         }
     }
 
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error> {
-        match <Self as Mint>::balance(self, purse, holds_epoch) {
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
+        match <Self as Mint>::balance(self, purse) {
             Ok(ret) => Ok(ret),
             Err(err) => {
                 error!("{}", err);

--- a/storage/src/system/handle_payment/internal.rs
+++ b/storage/src/system/handle_payment/internal.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use casper_types::{
     system::handle_payment::{Error, PAYMENT_PURSE_KEY, REFUND_PURSE_KEY},
-    HoldsEpoch, Key, Phase, PublicKey, URef, U512,
+    Key, Phase, PublicKey, URef, U512,
 };
 use num::CheckedMul;
 use num_rational::Ratio;
@@ -118,7 +118,7 @@ pub fn burn<P: MintProvider + RuntimeProvider + StorageProvider>(
     amount: Option<U512>,
 ) -> Result<(), Error> {
     // get the purse total balance (without holds)
-    let total_balance = match provider.available_balance(purse, HoldsEpoch::NOT_APPLICABLE)? {
+    let total_balance = match provider.available_balance(purse)? {
         Some(balance) => balance,
         None => return Err(Error::PaymentPurseBalanceNotFound),
     };
@@ -161,9 +161,7 @@ where
 
     let distribute_amount = match amount {
         Some(amount) => amount,
-        None => provider
-            .available_balance(source_uref, HoldsEpoch::NOT_APPLICABLE)?
-            .unwrap_or_default(),
+        None => provider.available_balance(source_uref)?.unwrap_or_default(),
     };
 
     if distribute_amount.is_zero() {

--- a/storage/src/system/handle_payment/mint_provider.rs
+++ b/storage/src/system/handle_payment/mint_provider.rs
@@ -1,5 +1,5 @@
 use casper_types::{
-    account::AccountHash, system::handle_payment::Error, HoldsEpoch, TransferredTo, URef, U512,
+    account::AccountHash, system::handle_payment::Error, TransferredTo, URef, U512,
 };
 
 /// Provides an access to mint.
@@ -27,11 +27,7 @@ pub trait MintProvider {
     ) -> Result<(), Error>;
 
     /// Checks balance of a `purse`. Returns `None` if given purse does not exist.
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error>;
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error>;
 
     /// Reduce total supply by `amount`.
     fn reduce_total_supply(&mut self, amount: U512) -> Result<(), Error>;

--- a/storage/src/system/mint/mint_native.rs
+++ b/storage/src/system/mint/mint_native.rs
@@ -16,8 +16,8 @@ use casper_types::{
     account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     system::{mint::Error, Caller},
-    AccessRights, AddressableEntity, CLTyped, CLValue, Gas, HoldsEpoch, InitiatorAddr, Key, Phase,
-    PublicKey, StoredValue, SystemEntityRegistry, Transfer, TransferV2, URef, U512,
+    AccessRights, AddressableEntity, CLTyped, CLValue, Gas, InitiatorAddr, Key, Phase, PublicKey,
+    StoredValue, SystemEntityRegistry, Transfer, TransferV2, URef, U512,
 };
 
 impl<S> RuntimeProvider for RuntimeNative<S>
@@ -183,18 +183,18 @@ where
         }
     }
 
-    fn available_balance(
-        &mut self,
-        purse: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error> {
+    fn available_balance(&mut self, purse: URef) -> Result<Option<U512>, Error> {
         match self
             .tracking_copy()
             .borrow_mut()
-            .get_available_balance(Key::Balance(purse.addr()), holds_epoch)
+            .get_available_balance(Key::Balance(purse.addr()))
         {
             Ok(motes) => Ok(Some(motes.value())),
-            Err(_) => Err(Error::Storage),
+            Err(err) => {
+                println!("{:?}", err);
+                error!(?err, "mint native available_balance");
+                Err(Error::Storage)
+            }
         }
     }
 

--- a/storage/src/system/mint/mint_native.rs
+++ b/storage/src/system/mint/mint_native.rs
@@ -191,7 +191,6 @@ where
         {
             Ok(motes) => Ok(Some(motes.value())),
             Err(err) => {
-                println!("{:?}", err);
                 error!(?err, "mint native available_balance");
                 Err(Error::Storage)
             }

--- a/storage/src/system/mint/storage_provider.rs
+++ b/storage/src/system/mint/storage_provider.rs
@@ -1,7 +1,7 @@
 use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     system::mint::Error,
-    CLTyped, HoldsEpoch, URef, U512,
+    CLTyped, URef, U512,
 };
 
 /// Provides functionality of a contract storage.
@@ -22,11 +22,7 @@ pub trait StorageProvider {
     fn total_balance(&mut self, uref: URef) -> Result<U512, Error>;
 
     /// Read balance.
-    fn available_balance(
-        &mut self,
-        uref: URef,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Option<U512>, Error>;
+    fn available_balance(&mut self, uref: URef) -> Result<Option<U512>, Error>;
 
     /// Write balance.
     fn write_balance(&mut self, uref: URef, balance: U512) -> Result<(), Error>;

--- a/storage/src/system/protocol_upgrade.rs
+++ b/storage/src/system/protocol_upgrade.rs
@@ -740,20 +740,17 @@ where
                     .borrow_mut()
                     .write(uref_key, stored_value);
                 // next, add the Key::URef to the mint's named keys
-                let entry_key = {
-                    let named_key_entry =
-                        NamedKeyAddr::new_from_string(entity_addr, name.to_string()).map_err(
-                            |_| {
-                                ProtocolUpgradeError::Bytesrepr("new_gas_hold_interval".to_string())
-                            },
-                        )?;
-                    Key::NamedKey(named_key_entry)
-                };
                 let entry_value = {
                     let named_key_value =
-                        NamedKeyValue::from_concrete_values(entry_key, name.to_string())
+                        NamedKeyValue::from_concrete_values(uref_key, name.to_string())
                             .map_err(|error| ProtocolUpgradeError::CLValue(error.to_string()))?;
                     StoredValue::NamedKey(named_key_value)
+                };
+                let entry_key = {
+                    let named_key_entry =
+                        NamedKeyAddr::new_from_string(entity_addr, name.to_string())
+                            .map_err(|_| ProtocolUpgradeError::Bytesrepr(name.to_string()))?;
+                    Key::NamedKey(named_key_entry)
                 };
 
                 self.tracking_copy

--- a/storage/src/system/protocol_upgrade.rs
+++ b/storage/src/system/protocol_upgrade.rs
@@ -31,7 +31,7 @@ use casper_types::{
 
 use crate::{
     global_state::state::StateProvider,
-    tracking_copy::{TrackingCopy, TrackingCopyExt},
+    tracking_copy::{TrackingCopy, TrackingCopyEntityExt, TrackingCopyExt},
     AddressGenerator,
 };
 
@@ -719,46 +719,24 @@ where
         named_keys: &NamedKeys,
         stored_value: StoredValue,
     ) -> Result<(), ProtocolUpgradeError> {
-        match named_keys.get(name) {
-            Some(key) => {
-                if let Key::URef(_) = key {
-                    // write current interval to URef
-                    self.tracking_copy.borrow_mut().write(*key, stored_value);
-                } else {
-                    return Err(ProtocolUpgradeError::UnexpectedKeyVariant);
-                }
-            }
-            None => {
-                // first put value into global state under a uref
-                let uref = self
+        let uref = {
+            match named_keys.get(name) {
+                Some(key) => match key.as_uref() {
+                    Some(uref) => *uref,
+                    None => {
+                        return Err(ProtocolUpgradeError::UnexpectedKeyVariant);
+                    }
+                },
+                None => self
                     .address_generator
                     .borrow_mut()
-                    .new_uref(AccessRights::READ_ADD_WRITE);
-
-                let uref_key = Key::URef(uref).normalize();
-                self.tracking_copy
-                    .borrow_mut()
-                    .write(uref_key, stored_value);
-                // next, add the Key::URef to the mint's named keys
-                let entry_value = {
-                    let named_key_value =
-                        NamedKeyValue::from_concrete_values(uref_key, name.to_string())
-                            .map_err(|error| ProtocolUpgradeError::CLValue(error.to_string()))?;
-                    StoredValue::NamedKey(named_key_value)
-                };
-                let entry_key = {
-                    let named_key_entry =
-                        NamedKeyAddr::new_from_string(entity_addr, name.to_string())
-                            .map_err(|_| ProtocolUpgradeError::Bytesrepr(name.to_string()))?;
-                    Key::NamedKey(named_key_entry)
-                };
-
-                self.tracking_copy
-                    .borrow_mut()
-                    .write(entry_key, entry_value);
+                    .new_uref(AccessRights::READ_ADD_WRITE),
             }
         };
-        Ok(())
+        self.tracking_copy
+            .borrow_mut()
+            .upsert_uref_to_named_keys(entity_addr, name, named_keys, uref, stored_value)
+            .map_err(ProtocolUpgradeError::TrackingCopy)
     }
 
     /// Handle new validator slots.

--- a/storage/src/system/transfer.rs
+++ b/storage/src/system/transfer.rs
@@ -6,8 +6,8 @@ use casper_types::{
     addressable_entity::NamedKeys,
     bytesrepr::FromBytes,
     system::{mint, mint::Error as MintError},
-    AccessRights, AddressableEntity, CLType, CLTyped, CLValue, CLValueError, HoldsEpoch, Key,
-    ProtocolVersion, RuntimeArgs, StoredValue, StoredValueTypeMismatch, URef, U512,
+    AccessRights, AddressableEntity, CLType, CLTyped, CLValue, CLValueError, Key, ProtocolVersion,
+    RuntimeArgs, StoredValue, StoredValueTypeMismatch, URef, U512,
 };
 
 use crate::{
@@ -232,7 +232,7 @@ impl TransferRuntimeArgsBuilder {
         };
         tracking_copy
             .borrow_mut()
-            .get_available_balance(key, HoldsEpoch::NOT_APPLICABLE)
+            .get_available_balance(key)
             .is_ok()
     }
 

--- a/storage/src/tracking_copy/error.rs
+++ b/storage/src/tracking_copy/error.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+use crate::data_access_layer::balance::BalanceFailure;
 use casper_types::{
     addressable_entity::{AddKeyFailure, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure},
     bytesrepr, system, ApiError, CLType, CLValueError, Key, StoredValueTypeMismatch,
@@ -78,6 +79,9 @@ pub enum Error {
     /// The value wasn't found.
     #[error("Value not found")]
     ValueNotFound(String),
+    /// Balance calculation failure.
+    #[error("Balance calculation failure")]
+    Balance(BalanceFailure),
 }
 
 impl Error {

--- a/storage/src/tracking_copy/ext.rs
+++ b/storage/src/tracking_copy/ext.rs
@@ -4,9 +4,10 @@ use std::{
 };
 use tracing::{error, warn};
 
-use crate::data_access_layer::balance::{AvailableBalanceChecker, ProcessingHoldBalanceHandling};
 use crate::{
-    data_access_layer::balance::{BalanceHolds, BalanceHoldsWithProof},
+    data_access_layer::balance::{
+        AvailableBalanceChecker, BalanceHolds, BalanceHoldsWithProof, ProcessingHoldBalanceHandling,
+    },
     global_state::{error::Error as GlobalStateError, state::StateReader},
     tracking_copy::{TrackingCopy, TrackingCopyError},
 };

--- a/storage/src/tracking_copy/ext.rs
+++ b/storage/src/tracking_copy/ext.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
     convert::TryInto,
 };
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     data_access_layer::balance::{BalanceHolds, BalanceHoldsWithProof},
@@ -20,9 +20,9 @@ use casper_types::{
         },
         MINT,
     },
-    BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash, CLValue, ChecksumRegistry, EntityAddr,
-    HoldBalanceHandling, HoldsEpoch, Key, KeyTag, Motes, Package, PackageHash, StoredValue,
-    StoredValueTypeMismatch, SystemEntityRegistry, URef, URefAddr, U512,
+    BlockGlobalAddr, BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash, CLValue, ChecksumRegistry,
+    EntityAddr, HoldBalanceHandling, HoldsEpoch, Key, KeyTag, Motes, Package, PackageHash,
+    StoredValue, StoredValueTypeMismatch, SystemEntityRegistry, URef, URefAddr, U512,
 };
 
 /// Higher-level operations on the state via a `TrackingCopy`.
@@ -33,11 +33,14 @@ pub trait TrackingCopyExt<R> {
     /// Reads the entity key for a given account hash.
     fn read_account_key(&mut self, account_hash: AccountHash) -> Result<Key, Self::Error>;
 
+    /// Returns block time associated with checked out root hash.
+    fn get_block_time(&self) -> Result<BlockTime, Self::Error>;
+
     /// Returns balance hold configuration settings for imputed kind of balance hold.
     fn get_balance_hold_config(
-        &mut self,
+        &self,
         hold_kind: BalanceHoldAddrTag,
-    ) -> Result<(HoldBalanceHandling, u64), Self::Error>;
+    ) -> Result<(BlockTime, HoldBalanceHandling, u64), Self::Error>;
 
     /// Gets the purse balance key for a given purse.
     fn get_purse_balance_key(&self, purse_key: Key) -> Result<Key, Self::Error>;
@@ -52,12 +55,7 @@ pub trait TrackingCopyExt<R> {
     fn get_total_balance(&self, key: Key) -> Result<Motes, Self::Error>;
 
     /// Returns the available balance, considering any holds from holds_epoch to now.
-    /// If holds_epoch is none, available balance == total balance.
-    fn get_available_balance(
-        &self,
-        balance_key: Key,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Motes, Self::Error>;
+    fn get_available_balance(&mut self, balance_key: Key) -> Result<Motes, Self::Error>;
 
     /// Gets the purse balance key for a given purse and provides a Merkle proof.
     fn get_purse_balance_key_with_proof(
@@ -80,26 +78,24 @@ pub trait TrackingCopyExt<R> {
 
     /// Gets the balance holds for a given balance, without Merkle proofs.
     fn get_balance_holds(
-        &self,
+        &mut self,
         purse_addr: URefAddr,
-        holds_epoch: HoldsEpoch,
     ) -> Result<BTreeMap<BlockTime, BalanceHolds>, Self::Error>;
 
     /// Gets the balance holds for a given balance, with Merkle proofs.
     fn get_balance_holds_with_proof(
         &self,
         purse_addr: URefAddr,
-        holds_epoch: HoldsEpoch,
     ) -> Result<BTreeMap<BlockTime, BalanceHoldsWithProof>, Self::Error>;
 
     /// Returns the collection of named keys for a given AddressableEntity.
-    fn get_named_keys(&mut self, entity_addr: EntityAddr) -> Result<NamedKeys, Self::Error>;
+    fn get_named_keys(&self, entity_addr: EntityAddr) -> Result<NamedKeys, Self::Error>;
 
     /// Gets a package by hash.
     fn get_package(&mut self, package_hash: PackageHash) -> Result<Package, Self::Error>;
 
     /// Gets the system entity registry.
-    fn get_system_entity_registry(&mut self) -> Result<SystemEntityRegistry, Self::Error>;
+    fn get_system_entity_registry(&self) -> Result<SystemEntityRegistry, Self::Error>;
 
     /// Gets the system checksum registry.
     fn get_checksum_registry(&mut self) -> Result<Option<ChecksumRegistry>, Self::Error>;
@@ -125,12 +121,32 @@ where
         }
     }
 
+    fn get_block_time(&self) -> Result<BlockTime, Self::Error> {
+        match self.read(&Key::BlockGlobal(BlockGlobalAddr::BlockTime))? {
+            Some(StoredValue::CLValue(cl_value)) => {
+                let block_time = cl_value.into_t().map_err(Self::Error::CLValue)?;
+                Ok(BlockTime::new(block_time))
+            }
+            Some(unexpected) => {
+                warn!(?unexpected, "block time stored as unexpected value type");
+                Err(Self::Error::UnexpectedStoredValueVariant)
+            }
+            None => {
+                error!("block time missing from global state");
+                Err(Self::Error::ValueNotFound("block time".to_string()))
+            }
+        }
+    }
+
     fn get_balance_hold_config(
-        &mut self,
+        &self,
         hold_kind: BalanceHoldAddrTag,
-    ) -> Result<(HoldBalanceHandling, u64), Self::Error> {
+    ) -> Result<(BlockTime, HoldBalanceHandling, u64), Self::Error> {
+        let block_time = self.get_block_time()?;
         let (handling_key, interval_key) = match hold_kind {
-            BalanceHoldAddrTag::Processing => return Ok((HoldBalanceHandling::Accrued, 0)),
+            BalanceHoldAddrTag::Processing => {
+                return Ok((block_time, HoldBalanceHandling::Accrued, 0))
+            }
             BalanceHoldAddrTag::Gas => (MINT_GAS_HOLD_HANDLING_KEY, MINT_GAS_HOLD_INTERVAL_KEY),
         };
 
@@ -155,7 +171,7 @@ where
                 .as_uref()
                 .ok_or(TrackingCopyError::UnexpectedKeyVariant(*named_key))?;
 
-            match self.read(named_key) {
+            match self.read(&named_key.normalize()) {
                 Ok(Some(StoredValue::CLValue(cl_value))) => {
                     let handling_tag = cl_value.into_t().map_err(TrackingCopyError::CLValue)?;
                     HoldBalanceHandling::from_tag(handling_tag).map_err(|_| {
@@ -164,8 +180,21 @@ where
                         )
                     })?
                 }
-                Ok(_) => return Err(TrackingCopyError::UnexpectedStoredValueVariant),
-                Err(tce) => return Err(tce),
+                Ok(Some(unexpected)) => {
+                    warn!(
+                        ?unexpected,
+                        "hold balance handling unexpected stored value variant"
+                    );
+                    return Err(TrackingCopyError::UnexpectedStoredValueVariant);
+                }
+                Ok(None) => {
+                    error!("hold balance handling missing from gs");
+                    return Err(TrackingCopyError::ValueNotFound(handling_key.to_string()));
+                }
+                Err(gse) => {
+                    error!(?gse, "hold balance handling read error");
+                    return Err(TrackingCopyError::Storage(gse));
+                }
             }
         };
 
@@ -181,16 +210,26 @@ where
                 .as_uref()
                 .ok_or(TrackingCopyError::UnexpectedKeyVariant(*named_key))?;
 
-            match self.read(named_key) {
+            match self.read(&named_key.normalize()) {
                 Ok(Some(StoredValue::CLValue(cl_value))) => {
                     cl_value.into_t().map_err(TrackingCopyError::CLValue)?
                 }
-                Ok(_) => return Err(TrackingCopyError::UnexpectedStoredValueVariant),
-                Err(tce) => return Err(tce),
+                Ok(Some(unexpected)) => {
+                    warn!(
+                        ?unexpected,
+                        "hold balance interval unexpected stored value variant"
+                    );
+                    return Err(TrackingCopyError::UnexpectedStoredValueVariant);
+                }
+                Ok(None) => {
+                    error!("hold balance interval missing from gs");
+                    return Err(TrackingCopyError::ValueNotFound(handling_key.to_string()));
+                }
+                Err(gse) => return Err(TrackingCopyError::Storage(gse)),
             }
         };
 
-        Ok((handling, interval))
+        Ok((block_time, handling, interval))
     }
 
     fn get_purse_balance_key(&self, purse_key: Key) -> Result<Key, Self::Error> {
@@ -200,30 +239,56 @@ where
         Ok(Key::Balance(balance_key.addr()))
     }
 
-    fn get_purse_balance_key_with_proof(
+    fn get_balance_hold_addresses(
         &self,
-        purse_key: Key,
-    ) -> Result<(Key, TrieMerkleProof<Key, StoredValue>), Self::Error> {
-        let balance_key: Key = purse_key
-            .uref_to_hash()
-            .ok_or(TrackingCopyError::UnexpectedKeyVariant(purse_key))?;
-        let proof: TrieMerkleProof<Key, StoredValue> = self
-            .read_with_proof(&balance_key)?
-            .ok_or(TrackingCopyError::KeyNotFound(purse_key))?;
-        let stored_value_ref: &StoredValue = proof.value();
-        let cl_value: CLValue = stored_value_ref
-            .to_owned()
-            .try_into()
-            .map_err(TrackingCopyError::TypeMismatch)?;
-        let balance_key: Key = cl_value.into_t()?;
-        Ok((balance_key, proof))
+        purse_addr: URefAddr,
+    ) -> Result<Vec<BalanceHoldAddr>, Self::Error> {
+        let tagged_keys = {
+            let mut ret: Vec<BalanceHoldAddr> = vec![];
+            let tag = BalanceHoldAddrTag::Gas;
+            let gas_prefix = tag.purse_prefix_by_tag(purse_addr)?;
+            for key in self.keys_with_prefix(&gas_prefix)? {
+                let addr = key
+                    .as_balance_hold()
+                    .ok_or(Self::Error::UnexpectedKeyVariant(key))?;
+                ret.push(*addr);
+            }
+            let tag = BalanceHoldAddrTag::Processing;
+            let processing_prefix = tag.purse_prefix_by_tag(purse_addr)?;
+            for key in self.keys_with_prefix(&processing_prefix)? {
+                let addr = key
+                    .as_balance_hold()
+                    .ok_or(Self::Error::UnexpectedKeyVariant(key))?;
+                ret.push(*addr);
+            }
+            ret
+        };
+        Ok(tagged_keys)
     }
 
-    fn get_available_balance(
-        &self,
-        key: Key,
-        holds_epoch: HoldsEpoch,
-    ) -> Result<Motes, Self::Error> {
+    fn get_total_balance(&self, key: Key) -> Result<Motes, Self::Error> {
+        let key = {
+            if let Key::URef(uref) = key {
+                Key::Balance(uref.addr())
+            } else {
+                key
+            }
+        };
+        if let Key::Balance(_) = key {
+            let stored_value: StoredValue = self
+                .read(&key)?
+                .ok_or(TrackingCopyError::KeyNotFound(key))?;
+            let cl_value: CLValue = stored_value
+                .try_into()
+                .map_err(TrackingCopyError::TypeMismatch)?;
+            let total_balance = cl_value.into_t::<U512>()?;
+            Ok(Motes::new(total_balance))
+        } else {
+            Err(Self::Error::UnexpectedKeyVariant(key))
+        }
+    }
+
+    fn get_available_balance(&mut self, key: Key) -> Result<Motes, Self::Error> {
         let key = {
             if let Key::URef(uref) = key {
                 Key::Balance(uref.addr())
@@ -232,6 +297,9 @@ where
             }
         };
 
+        let (block_time, _, interval) = self.get_balance_hold_config(BalanceHoldAddrTag::Gas)?;
+
+        let holds_epoch = HoldsEpoch::from_millis(block_time.value(), interval);
         if let Key::Balance(purse_addr) = key {
             let total_balance = self.get_total_balance(key)?;
             match holds_epoch.value() {
@@ -267,26 +335,23 @@ where
         }
     }
 
-    fn get_total_balance(&self, key: Key) -> Result<Motes, Self::Error> {
-        let key = {
-            if let Key::URef(uref) = key {
-                Key::Balance(uref.addr())
-            } else {
-                key
-            }
-        };
-        if let Key::Balance(_) = key {
-            let stored_value: StoredValue = self
-                .read(&key)?
-                .ok_or(TrackingCopyError::KeyNotFound(key))?;
-            let cl_value: CLValue = stored_value
-                .try_into()
-                .map_err(TrackingCopyError::TypeMismatch)?;
-            let total_balance = cl_value.into_t::<U512>()?;
-            Ok(Motes::new(total_balance))
-        } else {
-            Err(Self::Error::UnexpectedKeyVariant(key))
-        }
+    fn get_purse_balance_key_with_proof(
+        &self,
+        purse_key: Key,
+    ) -> Result<(Key, TrieMerkleProof<Key, StoredValue>), Self::Error> {
+        let balance_key: Key = purse_key
+            .uref_to_hash()
+            .ok_or(TrackingCopyError::UnexpectedKeyVariant(purse_key))?;
+        let proof: TrieMerkleProof<Key, StoredValue> = self
+            .read_with_proof(&balance_key)?
+            .ok_or(TrackingCopyError::KeyNotFound(purse_key))?;
+        let stored_value_ref: &StoredValue = proof.value();
+        let cl_value: CLValue = stored_value_ref
+            .to_owned()
+            .try_into()
+            .map_err(TrackingCopyError::TypeMismatch)?;
+        let balance_key: Key = cl_value.into_t()?;
+        Ok((balance_key, proof))
     }
 
     fn get_total_balance_with_proof(
@@ -316,38 +381,57 @@ where
         }
     }
 
-    fn get_balance_hold_addresses(
-        &self,
+    fn clear_expired_balance_holds(
+        &mut self,
         purse_addr: URefAddr,
-    ) -> Result<Vec<BalanceHoldAddr>, Self::Error> {
-        let tagged_keys = {
-            let mut ret: Vec<BalanceHoldAddr> = vec![];
-            let tag = BalanceHoldAddrTag::Gas;
-            let gas_prefix = tag.purse_prefix_by_tag(purse_addr)?;
-            for key in self.keys_with_prefix(&gas_prefix)? {
-                let addr = key
+        filter: Vec<(BalanceHoldAddrTag, HoldsEpoch)>,
+    ) -> Result<(), Self::Error> {
+        for (tag, holds_epoch) in filter {
+            let prefix = tag.purse_prefix_by_tag(purse_addr)?;
+            let immut: &_ = self;
+            let hold_keys = immut.keys_with_prefix(&prefix)?;
+            for hold_key in hold_keys {
+                let balance_hold_addr = hold_key
                     .as_balance_hold()
-                    .ok_or(Self::Error::UnexpectedKeyVariant(key))?;
-                ret.push(*addr);
+                    .ok_or(Self::Error::UnexpectedKeyVariant(hold_key))?;
+                let hold_block_time = balance_hold_addr.block_time();
+                if let Some(earliest_relevant_timestamp) = holds_epoch.value() {
+                    if hold_block_time.value() > earliest_relevant_timestamp {
+                        // skip still relevant holds
+                        //  the expectation is that holds are cleared after balance checks,
+                        //  and before payment settlement; if that ordering changes in the
+                        //  future this strategy should be reevaluated to determine if it
+                        //  remains correct.
+                        continue;
+                    }
+                }
+                // prune away holds with a timestamp newer than epoch timestamp
+                //  including holds with a timestamp == epoch timestamp
+                self.prune(hold_key)
             }
-            let tag = BalanceHoldAddrTag::Processing;
-            let processing_prefix = tag.purse_prefix_by_tag(purse_addr)?;
-            for key in self.keys_with_prefix(&processing_prefix)? {
-                let addr = key
-                    .as_balance_hold()
-                    .ok_or(Self::Error::UnexpectedKeyVariant(key))?;
-                ret.push(*addr);
-            }
-            ret
-        };
-        Ok(tagged_keys)
+        }
+        Ok(())
     }
 
     fn get_balance_holds(
-        &self,
+        &mut self,
         purse_addr: URefAddr,
-        holds_epoch: HoldsEpoch,
     ) -> Result<BTreeMap<BlockTime, BalanceHolds>, Self::Error> {
+        // NOTE: currently there are two kinds of holds, gas and processing.
+        // Processing holds only effect one block to prevent double spend and are always
+        // cleared at the end of processing each transaction. Gas holds persist for some
+        // interval, over many blocks and eras. Thus, using the holds_epoch for gas holds
+        // during transaction execution also picks up processing holds and call sites of
+        // this method currently pass the holds epoch for gas holds. This works fine for
+        // now, but if one or more other kinds of holds with differing periods are added
+        // in the future, this logic will need to be tweaked to take get the holds epoch
+        // for each hold kind and process each kind discretely in order and collate the
+        // non-expired hold total at the end.
+        let holds_epoch = {
+            let (block_time, _, interval) =
+                self.get_balance_hold_config(BalanceHoldAddrTag::Gas)?;
+            HoldsEpoch::from_millis(block_time.value(), interval)
+        };
         let holds = self.get_balance_hold_addresses(purse_addr)?;
         let mut ret: BTreeMap<BlockTime, BalanceHolds> = BTreeMap::new();
         for balance_hold_addr in holds {
@@ -367,7 +451,7 @@ where
                 },
                 Ok(Some(_)) => return Err(Self::Error::UnexpectedStoredValueVariant),
                 Ok(None) => return Err(Self::Error::KeyNotFound(hold_key)),
-                Err(gse) => return Err(Self::Error::Storage(gse)),
+                Err(tce) => return Err(tce),
             };
             match ret.entry(block_time) {
                 Entry::Vacant(entry) => {
@@ -396,8 +480,22 @@ where
     fn get_balance_holds_with_proof(
         &self,
         purse_addr: URefAddr,
-        holds_epoch: HoldsEpoch,
     ) -> Result<BTreeMap<BlockTime, BalanceHoldsWithProof>, Self::Error> {
+        // NOTE: currently there are two kinds of holds, gas and processing.
+        // Processing holds only effect one block to prevent double spend and are always
+        // cleared at the end of processing each transaction. Gas holds persist for some
+        // interval, over many blocks and eras. Thus, using the holds_epoch for gas holds
+        // during transaction execution also picks up processing holds and call sites of
+        // this method currently pass the holds epoch for gas holds. This works fine for
+        // now, but if one or more other kinds of holds with differing periods are added
+        // in the future, this logic will need to be tweaked to take get the holds epoch
+        // for each hold kind and process each kind discretely in order and collate the
+        // non-expired hold total at the end.
+        let holds_epoch = {
+            let (block_time, _, interval) =
+                self.get_balance_hold_config(BalanceHoldAddrTag::Gas)?;
+            HoldsEpoch::from_millis(block_time.value(), interval)
+        };
         let holds = self.get_balance_hold_addresses(purse_addr)?;
         let mut ret: BTreeMap<BlockTime, BalanceHoldsWithProof> = BTreeMap::new();
         for balance_hold_addr in holds {
@@ -443,50 +541,7 @@ where
         Ok(ret)
     }
 
-    fn clear_expired_balance_holds(
-        &mut self,
-        purse_addr: URefAddr,
-        filter: Vec<(BalanceHoldAddrTag, HoldsEpoch)>,
-    ) -> Result<(), Self::Error> {
-        for (tag, holds_epoch) in filter {
-            let prefix = tag.purse_prefix_by_tag(purse_addr)?;
-            let immut: &_ = self;
-            let hold_keys = immut.keys_with_prefix(&prefix)?;
-            for hold_key in hold_keys {
-                let balance_hold_addr = hold_key
-                    .as_balance_hold()
-                    .ok_or(Self::Error::UnexpectedKeyVariant(hold_key))?;
-                let hold_block_time = balance_hold_addr.block_time();
-                if let Some(earliest_relevant_timestamp) = holds_epoch.value() {
-                    if hold_block_time.value() > earliest_relevant_timestamp {
-                        // skip still relevant holds
-                        //  the expectation is that holds are cleared after balance checks,
-                        //  and before payment settlement; if that ordering changes in the
-                        //  future this strategy should be reevaluated to determine if it
-                        //  remains correct.
-                        continue;
-                    }
-                }
-                // prune away holds with a timestamp newer than epoch timestamp
-                //  including holds with a timestamp == epoch timestamp
-                self.prune(hold_key)
-            }
-        }
-        Ok(())
-    }
-
-    fn get_byte_code(&mut self, byte_code_hash: ByteCodeHash) -> Result<ByteCode, Self::Error> {
-        let key = Key::ByteCode(ByteCodeAddr::V1CasperWasm(byte_code_hash.value()));
-        match self.get(&key)? {
-            Some(StoredValue::ByteCode(byte_code)) => Ok(byte_code),
-            Some(other) => Err(TrackingCopyError::TypeMismatch(
-                StoredValueTypeMismatch::new("ContractWasm".to_string(), other.type_name()),
-            )),
-            None => Err(TrackingCopyError::KeyNotFound(key)),
-        }
-    }
-
-    fn get_named_keys(&mut self, entity_addr: EntityAddr) -> Result<NamedKeys, Self::Error> {
+    fn get_named_keys(&self, entity_addr: EntityAddr) -> Result<NamedKeys, Self::Error> {
         let prefix = entity_addr
             .named_keys_prefix()
             .map_err(Self::Error::BytesRepr)?;
@@ -575,8 +630,8 @@ where
         }
     }
 
-    fn get_system_entity_registry(&mut self) -> Result<SystemEntityRegistry, Self::Error> {
-        match self.get(&Key::SystemEntityRegistry)? {
+    fn get_system_entity_registry(&self) -> Result<SystemEntityRegistry, Self::Error> {
+        match self.read(&Key::SystemEntityRegistry)? {
             Some(StoredValue::CLValue(registry)) => {
                 let registry: SystemEntityRegistry =
                     CLValue::into_t(registry).map_err(Self::Error::from)?;
@@ -600,6 +655,17 @@ where
                 StoredValueTypeMismatch::new("CLValue".to_string(), other.type_name()),
             )),
             None => Ok(None),
+        }
+    }
+
+    fn get_byte_code(&mut self, byte_code_hash: ByteCodeHash) -> Result<ByteCode, Self::Error> {
+        let key = Key::ByteCode(ByteCodeAddr::V1CasperWasm(byte_code_hash.value()));
+        match self.get(&key)? {
+            Some(StoredValue::ByteCode(byte_code)) => Ok(byte_code),
+            Some(other) => Err(TrackingCopyError::TypeMismatch(
+                StoredValueTypeMismatch::new("ContractWasm".to_string(), other.type_name()),
+            )),
+            None => Err(TrackingCopyError::KeyNotFound(key)),
         }
     }
 }

--- a/storage/src/tracking_copy/ext_entity.rs
+++ b/storage/src/tracking_copy/ext_entity.rs
@@ -76,11 +76,22 @@ pub trait TrackingCopyEntityExt<R> {
         named_keys: NamedKeys,
     ) -> Result<(), Self::Error>;
 
+    /// Upsert uref value to global state and imputed entity's named keys.
+    fn upsert_uref_to_named_keys(
+        &mut self,
+        entity_addr: EntityAddr,
+        name: &str,
+        named_keys: &NamedKeys,
+        uref: URef,
+        stored_value: StoredValue,
+    ) -> Result<(), Self::Error>;
+
     fn migrate_account(
         &mut self,
         account_hash: AccountHash,
         protocol_version: ProtocolVersion,
     ) -> Result<(), Self::Error>;
+
     fn create_new_addressable_entity_on_transfer(
         &mut self,
         account_hash: AccountHash,
@@ -313,6 +324,45 @@ where
             self.write(entry_key, named_key_value)
         }
 
+        Ok(())
+    }
+
+    fn upsert_uref_to_named_keys(
+        &mut self,
+        entity_addr: EntityAddr,
+        name: &str,
+        named_keys: &NamedKeys,
+        uref: URef,
+        stored_value: StoredValue,
+    ) -> Result<(), Self::Error> {
+        match named_keys.get(name) {
+            Some(key) => {
+                if let Key::URef(_) = key {
+                    self.write(*key, stored_value);
+                } else {
+                    return Err(Self::Error::UnexpectedKeyVariant(*key));
+                }
+            }
+            None => {
+                let uref_key = Key::URef(uref).normalize();
+                self.write(uref_key, stored_value);
+
+                let entry_value = {
+                    let named_key_value =
+                        NamedKeyValue::from_concrete_values(uref_key, name.to_string())
+                            .map_err(Self::Error::CLValue)?;
+                    StoredValue::NamedKey(named_key_value)
+                };
+                let entry_key = {
+                    let named_key_entry =
+                        NamedKeyAddr::new_from_string(entity_addr, name.to_string())
+                            .map_err(Self::Error::BytesRepr)?;
+                    Key::NamedKey(named_key_entry)
+                };
+
+                self.write(entry_key, entry_value);
+            }
+        };
         Ok(())
     }
 

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -27,8 +27,8 @@ use casper_types::{
     contract_messages::{Message, Messages},
     execution::{Effects, TransformError, TransformInstruction, TransformKindV2, TransformV2},
     global_state::TrieMerkleProof,
-    handle_stored_dictionary_value, CLType, CLValue, CLValueError, Digest, Key, KeyTag,
-    StoredValue, StoredValueTypeMismatch, Tagged, U512,
+    handle_stored_dictionary_value, BlockGlobalAddr, CLType, CLValue, CLValueError, Digest, Key,
+    KeyTag, StoredValue, StoredValueTypeMismatch, Tagged, U512,
 };
 
 use self::meter::{heap_meter::HeapSize, Meter};
@@ -69,7 +69,7 @@ impl TrackingCopyQueryResult {
     }
 
     /// As result.
-    pub fn as_result(self) -> Result<StoredValue, TrackingCopyError> {
+    pub fn into_result(self) -> Result<StoredValue, TrackingCopyError> {
         match self {
             TrackingCopyQueryResult::RootNotFound => {
                 Err(TrackingCopyError::Storage(Error::RootNotFound))
@@ -243,7 +243,7 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
     }
 
     /// Gets the set of mutated keys in the cache by `KeyTag`.
-    pub fn get_key_tag_muts_cached(&mut self, key_tag: &KeyTag) -> Option<BTreeSet<Key>> {
+    pub fn get_key_tag_muts_cached(&self, key_tag: &KeyTag) -> Option<BTreeSet<Key>> {
         let pruned = &self.prunes_cached;
         if let Some(keys) = self.key_tag_muts_cached.get(key_tag) {
             let mut ret = BTreeSet::new();
@@ -422,7 +422,10 @@ where
     ) {
         self.write(message_key, message_value);
         self.write(message_topic_key, message_topic_summary);
-        self.write(Key::BlockMessageCount, block_message_count_value);
+        self.write(
+            Key::BlockGlobal(BlockGlobalAddr::MessageCount),
+            block_message_count_value,
+        );
         self.messages.push(message);
     }
 

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -1,5 +1,6 @@
 mod available_block_range;
 mod block_body;
+mod block_global;
 mod block_hash;
 mod block_hash_and_height;
 mod block_header;
@@ -45,6 +46,7 @@ use crate::{
 };
 pub use available_block_range::AvailableBlockRange;
 pub use block_body::{BlockBody, BlockBodyV1, BlockBodyV2};
+pub use block_global::{BlockGlobalAddr, BlockGlobalAddrTag};
 pub use block_hash::BlockHash;
 pub use block_hash_and_height::BlockHashAndHeight;
 pub use block_header::{BlockHeader, BlockHeaderV1, BlockHeaderV2};

--- a/types/src/block/block_global.rs
+++ b/types/src/block/block_global.rs
@@ -1,0 +1,267 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use crate::{
+    bytesrepr,
+    bytesrepr::{FromBytes, ToBytes},
+    checksummed_hex,
+    key::FromStrError,
+    Key,
+};
+
+use core::{
+    convert::TryFrom,
+    fmt::{Debug, Display, Formatter},
+};
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
+#[cfg(any(feature = "testing", test))]
+use rand::distributions::{Distribution, Standard};
+#[cfg(any(feature = "testing", test))]
+use rand::Rng;
+#[cfg(feature = "json-schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+const BLOCK_TIME_TAG: u8 = 0;
+const MESSAGE_COUNT_TAG: u8 = 1;
+
+/// Serialization tag for BlockGlobalAddr variants.
+#[derive(
+    Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize,
+)]
+#[repr(u8)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub enum BlockGlobalAddrTag {
+    #[default]
+    /// Tag for block time variant.
+    BlockTime = BLOCK_TIME_TAG,
+    /// Tag for processing variant.
+    MessageCount = MESSAGE_COUNT_TAG,
+}
+
+impl BlockGlobalAddrTag {
+    /// The length in bytes of a [`BlockGlobalAddrTag`].
+    pub const BLOCK_GLOBAL_ADDR_TAG_LENGTH: usize = 1;
+
+    /// Attempts to map `BalanceHoldAddrTag` from a u8.
+    pub fn try_from_u8(value: u8) -> Option<Self> {
+        // TryFrom requires std, so doing this instead.
+        if value == BLOCK_TIME_TAG {
+            return Some(BlockGlobalAddrTag::BlockTime);
+        }
+        if value == MESSAGE_COUNT_TAG {
+            return Some(BlockGlobalAddrTag::MessageCount);
+        }
+        None
+    }
+}
+
+impl Display for BlockGlobalAddrTag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let tag = match self {
+            BlockGlobalAddrTag::BlockTime => BLOCK_TIME_TAG,
+            BlockGlobalAddrTag::MessageCount => MESSAGE_COUNT_TAG,
+        };
+        write!(f, "{}", base16::encode_lower(&[tag]))
+    }
+}
+
+impl ToBytes for BlockGlobalAddrTag {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        Self::BLOCK_GLOBAL_ADDR_TAG_LENGTH
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.push(*self as u8);
+        Ok(())
+    }
+}
+
+impl FromBytes for BlockGlobalAddrTag {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        if let Some((byte, rem)) = bytes.split_first() {
+            let tag = BlockGlobalAddrTag::try_from_u8(*byte).ok_or(bytesrepr::Error::Formatting)?;
+            Ok((tag, rem))
+        } else {
+            Err(bytesrepr::Error::Formatting)
+        }
+    }
+}
+
+/// Address for singleton values associated to specific block. These are values which are
+/// calculated or set during the execution of a block such as the block timestamp, or the
+/// total count of messages emitted during the execution of the block, and so on.
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "datasize", derive(DataSize))]
+#[cfg_attr(feature = "json-schema", derive(JsonSchema))]
+pub enum BlockGlobalAddr {
+    /// Block time variant
+    #[default]
+    BlockTime,
+    /// Message count variant.
+    MessageCount,
+}
+
+impl BlockGlobalAddr {
+    /// The length in bytes of a [`BlockGlobalAddr`].
+    pub const BLOCK_GLOBAL_ADDR_LENGTH: usize = BlockGlobalAddrTag::BLOCK_GLOBAL_ADDR_TAG_LENGTH;
+
+    /// How long is be the serialized value for this instance.
+    pub fn serialized_length(&self) -> usize {
+        Self::BLOCK_GLOBAL_ADDR_LENGTH
+    }
+
+    /// Returns the tag of this instance.
+    pub fn tag(&self) -> BlockGlobalAddrTag {
+        match self {
+            BlockGlobalAddr::MessageCount => BlockGlobalAddrTag::MessageCount,
+            BlockGlobalAddr::BlockTime => BlockGlobalAddrTag::BlockTime,
+        }
+    }
+
+    /// To formatted string.
+    pub fn to_formatted_string(self) -> String {
+        match self {
+            BlockGlobalAddr::BlockTime => base16::encode_lower(&BLOCK_TIME_TAG.to_le_bytes()),
+            BlockGlobalAddr::MessageCount => base16::encode_lower(&MESSAGE_COUNT_TAG.to_le_bytes()),
+        }
+    }
+
+    /// From formatted string.
+    pub fn from_formatted_string(hex: &str) -> Result<Self, FromStrError> {
+        let bytes = checksummed_hex::decode(hex)
+            .map_err(|error| FromStrError::BlockGlobal(error.to_string()))?;
+        if bytes.is_empty() {
+            return Err(FromStrError::BlockGlobal(
+                "bytes should not be 0 len".to_string(),
+            ));
+        }
+        let tag_bytes = <[u8; BlockGlobalAddrTag::BLOCK_GLOBAL_ADDR_TAG_LENGTH]>::try_from(
+            bytes[0..BlockGlobalAddrTag::BLOCK_GLOBAL_ADDR_TAG_LENGTH].as_ref(),
+        )
+        .map_err(|err| FromStrError::BlockGlobal(err.to_string()))?;
+        let tag = <u8>::from_le_bytes(tag_bytes);
+        let tag = BlockGlobalAddrTag::try_from_u8(tag).ok_or_else(|| {
+            FromStrError::BlockGlobal("failed to parse block global addr tag".to_string())
+        })?;
+
+        // if more tags are added, extend the below logic to handle every case.
+        if tag == BlockGlobalAddrTag::BlockTime {
+            Ok(BlockGlobalAddr::BlockTime)
+        } else if tag == BlockGlobalAddrTag::MessageCount {
+            Ok(BlockGlobalAddr::MessageCount)
+        } else {
+            Err(FromStrError::BlockGlobal("invalid tag".to_string()))
+        }
+    }
+}
+
+impl ToBytes for BlockGlobalAddr {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        buffer.push(self.tag() as u8);
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.serialized_length()
+    }
+}
+
+impl FromBytes for BlockGlobalAddr {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            tag if tag == BlockGlobalAddrTag::BlockTime as u8 => {
+                Ok((BlockGlobalAddr::BlockTime, remainder))
+            }
+            tag if tag == BlockGlobalAddrTag::MessageCount as u8 => {
+                Ok((BlockGlobalAddr::MessageCount, remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+impl From<BlockGlobalAddr> for Key {
+    fn from(block_global_addr: BlockGlobalAddr) -> Self {
+        Key::BlockGlobal(block_global_addr)
+    }
+}
+
+#[cfg(any(feature = "std", test))]
+impl TryFrom<Key> for BlockGlobalAddr {
+    type Error = ();
+
+    fn try_from(value: Key) -> Result<Self, Self::Error> {
+        if let Key::BlockGlobal(block_global_addr) = value {
+            Ok(block_global_addr)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl Display for BlockGlobalAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let tag = self.tag();
+        write!(f, "{}", tag,)
+    }
+}
+
+impl Debug for BlockGlobalAddr {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        match self {
+            BlockGlobalAddr::BlockTime => write!(f, "BlockTime",),
+            BlockGlobalAddr::MessageCount => write!(f, "MessageCount",),
+        }
+    }
+}
+
+#[cfg(any(feature = "testing", test))]
+impl Distribution<BlockGlobalAddr> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> BlockGlobalAddr {
+        match rng.gen_range(BLOCK_TIME_TAG..=MESSAGE_COUNT_TAG) {
+            BLOCK_TIME_TAG => BlockGlobalAddr::BlockTime,
+            MESSAGE_COUNT_TAG => BlockGlobalAddr::MessageCount,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{block::block_global::BlockGlobalAddr, bytesrepr};
+
+    #[test]
+    fn serialization_roundtrip() {
+        let addr = BlockGlobalAddr::BlockTime;
+        bytesrepr::test_serialization_roundtrip(&addr);
+        let addr = BlockGlobalAddr::MessageCount;
+        bytesrepr::test_serialization_roundtrip(&addr);
+    }
+}
+
+#[cfg(test)]
+mod prop_test_gas {
+    use proptest::prelude::*;
+
+    use crate::{bytesrepr, gens};
+
+    proptest! {
+        #[test]
+        fn test_variant_gas(addr in gens::balance_hold_addr_arb()) {
+            bytesrepr::test_serialization_roundtrip(&addr);
+        }
+    }
+}

--- a/types/src/chainspec/genesis_config.rs
+++ b/types/src/chainspec/genesis_config.rs
@@ -311,6 +311,15 @@ impl GenesisConfigBuilder {
         self
     }
 
+    /// Sets the gas hold balance handling.
+    pub fn with_gas_hold_balance_handling(
+        mut self,
+        gas_hold_balance_handling: HoldBalanceHandling,
+    ) -> Self {
+        self.gas_hold_balance_handling = Some(gas_hold_balance_handling);
+        self
+    }
+
     /// Builds a new [`GenesisConfig`] object.
     pub fn build(self) -> GenesisConfig {
         GenesisConfig {
@@ -348,6 +357,7 @@ impl From<&Chainspec> for GenesisConfig {
             .map_or(0, |timestamp| timestamp.millis());
         let gas_hold_balance_handling = chainspec.core_config.gas_hold_balance_handling;
         let gas_hold_interval_millis = chainspec.core_config.gas_hold_interval.millis();
+        let gas_hold_balance_handling = chainspec.core_config.gas_hold_balance_handling;
 
         // TODO: maybe construct this instead of accreting the values
         //GenesisConfigBuilder::new(account,..)
@@ -363,6 +373,7 @@ impl From<&Chainspec> for GenesisConfig {
             .with_genesis_timestamp_millis(genesis_timestamp_millis)
             .with_gas_hold_balance_handling(gas_hold_balance_handling)
             .with_gas_hold_interval_millis(gas_hold_interval_millis)
+            .with_gas_hold_balance_handling(gas_hold_balance_handling)
             .build()
     }
 }

--- a/types/src/chainspec/genesis_config.rs
+++ b/types/src/chainspec/genesis_config.rs
@@ -346,8 +346,11 @@ impl From<&Chainspec> for GenesisConfig {
             .activation_point
             .genesis_timestamp()
             .map_or(0, |timestamp| timestamp.millis());
+        let gas_hold_balance_handling = chainspec.core_config.gas_hold_balance_handling;
         let gas_hold_interval_millis = chainspec.core_config.gas_hold_interval.millis();
 
+        // TODO: maybe construct this instead of accreting the values
+        //GenesisConfigBuilder::new(account,..)
         GenesisConfigBuilder::default()
             .with_accounts(chainspec.network_config.accounts_config.clone().into())
             .with_wasm_config(chainspec.wasm_config)
@@ -358,6 +361,7 @@ impl From<&Chainspec> for GenesisConfig {
             .with_round_seigniorage_rate(chainspec.core_config.round_seigniorage_rate)
             .with_unbonding_delay(chainspec.core_config.unbonding_delay)
             .with_genesis_timestamp_millis(genesis_timestamp_millis)
+            .with_gas_hold_balance_handling(gas_hold_balance_handling)
             .with_gas_hold_interval_millis(gas_hold_interval_millis)
             .build()
     }

--- a/types/src/chainspec/genesis_config.rs
+++ b/types/src/chainspec/genesis_config.rs
@@ -355,7 +355,6 @@ impl From<&Chainspec> for GenesisConfig {
             .activation_point
             .genesis_timestamp()
             .map_or(0, |timestamp| timestamp.millis());
-        let gas_hold_balance_handling = chainspec.core_config.gas_hold_balance_handling;
         let gas_hold_interval_millis = chainspec.core_config.gas_hold_interval.millis();
         let gas_hold_balance_handling = chainspec.core_config.gas_hold_balance_handling;
 

--- a/types/src/chainspec/genesis_config.rs
+++ b/types/src/chainspec/genesis_config.rs
@@ -372,7 +372,6 @@ impl From<&Chainspec> for GenesisConfig {
             .with_genesis_timestamp_millis(genesis_timestamp_millis)
             .with_gas_hold_balance_handling(gas_hold_balance_handling)
             .with_gas_hold_interval_millis(gas_hold_interval_millis)
-            .with_gas_hold_balance_handling(gas_hold_balance_handling)
             .build()
     }
 }

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -26,6 +26,7 @@ use crate::{
         action_thresholds::gens::action_thresholds_arb, associated_keys::gens::associated_keys_arb,
         MessageTopics, NamedKeyValue, NamedKeys, Parameters, Weight,
     },
+    block::BlockGlobalAddr,
     byte_code::ByteCodeKind,
     contract_messages::{MessageChecksum, MessageTopicSummary, TopicNameHash},
     contracts::{
@@ -151,6 +152,13 @@ pub fn balance_hold_addr_arb() -> impl Strategy<Value = BalanceHoldAddr> {
     let x = uref_arb().prop_map(|uref| uref.addr());
     let y = any::<u64>();
     (x, y).prop_map(|(x, y)| BalanceHoldAddr::new_gas(x, BlockTime::new(y)))
+}
+
+pub fn block_global_addr_arb() -> impl Strategy<Value = BlockGlobalAddr> {
+    prop_oneof![
+        0 => Just(BlockGlobalAddr::BlockTime),
+        1 => Just(BlockGlobalAddr::MessageCount)
+    ]
 }
 
 pub fn weight_arb() -> impl Strategy<Value = Weight> {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -37,6 +37,7 @@ use crate::{
     account::{AccountHash, ACCOUNT_HASH_LENGTH},
     addressable_entity,
     addressable_entity::{AddressableEntityHash, EntityAddr, EntityKindTag, NamedKeyAddr},
+    block::BlockGlobalAddr,
     byte_code,
     bytesrepr::{
         self, Error, FromBytes, ToBytes, U32_SERIALIZED_LENGTH, U64_SERIALIZED_LENGTH,
@@ -72,7 +73,8 @@ const CHAINSPEC_REGISTRY_PREFIX: &str = "chainspec-registry-";
 const CHECKSUM_REGISTRY_PREFIX: &str = "checksum-registry-";
 const BID_ADDR_PREFIX: &str = "bid-addr-";
 const PACKAGE_PREFIX: &str = "package-";
-const BLOCK_MESSAGE_COUNT_PREFIX: &str = "block-message-count-";
+const BLOCK_GLOBAL_TIME_PREFIX: &str = "block-time-";
+const BLOCK_GLOBAL_MESSAGE_COUNT_PREFIX: &str = "block-message-count-";
 
 /// The number of bytes in a Blake2b hash
 pub const BLAKE2B_DIGEST_LENGTH: usize = 32;
@@ -89,6 +91,7 @@ pub const DICTIONARY_ITEM_KEY_MAX_LENGTH: usize = 128;
 /// The maximum length for an `Addr`.
 pub const ADDR_LENGTH: usize = 32;
 const PADDING_BYTES: [u8; 32] = [0u8; 32];
+const BLOCK_GLOBAL_PADDING_BYTES: [u8; 31] = [0u8; 31];
 const KEY_ID_SERIALIZED_LENGTH: usize = 1;
 // u8 used to determine the ID
 const KEY_HASH_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_HASH_LENGTH;
@@ -104,8 +107,6 @@ const KEY_DICTIONARY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_D
 const KEY_SYSTEM_ENTITY_REGISTRY_SERIALIZED_LENGTH: usize =
     KEY_ID_SERIALIZED_LENGTH + PADDING_BYTES.len();
 const KEY_ERA_SUMMARY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + PADDING_BYTES.len();
-const KEY_BLOCK_MESSAGE_COUNT_SERIALIZED_LENGTH: usize =
-    KEY_ID_SERIALIZED_LENGTH + PADDING_BYTES.len();
 const KEY_CHAINSPEC_REGISTRY_SERIALIZED_LENGTH: usize =
     KEY_ID_SERIALIZED_LENGTH + PADDING_BYTES.len();
 const KEY_CHECKSUM_REGISTRY_SERIALIZED_LENGTH: usize =
@@ -153,7 +154,7 @@ pub enum KeyTag {
     ByteCode = 18,
     Message = 19,
     NamedKey = 20,
-    BlockMessageCount = 21,
+    BlockGlobal = 21,
     BalanceHold = 22,
 }
 
@@ -183,7 +184,7 @@ impl KeyTag {
             18 => KeyTag::ByteCode,
             19 => KeyTag::Message,
             20 => KeyTag::NamedKey,
-            21 => KeyTag::BlockMessageCount,
+            21 => KeyTag::BlockGlobal,
             22 => KeyTag::BalanceHold,
             _ => panic!(),
         }
@@ -214,7 +215,7 @@ impl Display for KeyTag {
             KeyTag::ByteCode => write!(f, "ByteCode"),
             KeyTag::Message => write!(f, "Message"),
             KeyTag::NamedKey => write!(f, "NamedKey"),
-            KeyTag::BlockMessageCount => write!(f, "BlockMessageCount"),
+            KeyTag::BlockGlobal => write!(f, "BlockGlobal"),
             KeyTag::BalanceHold => write!(f, "BalanceHold"),
         }
     }
@@ -262,7 +263,7 @@ impl FromBytes for KeyTag {
             tag if tag == KeyTag::ByteCode as u8 => KeyTag::ByteCode,
             tag if tag == KeyTag::Message as u8 => KeyTag::Message,
             tag if tag == KeyTag::NamedKey as u8 => KeyTag::NamedKey,
-            tag if tag == KeyTag::BlockMessageCount as u8 => KeyTag::BlockMessageCount,
+            tag if tag == KeyTag::BlockGlobal as u8 => KeyTag::BlockGlobal,
             tag if tag == KeyTag::BalanceHold as u8 => KeyTag::BalanceHold,
             _ => return Err(Error::Formatting),
         };
@@ -320,8 +321,8 @@ pub enum Key {
     Message(MessageAddr),
     /// A `Key` under which a single named key entry is stored.
     NamedKey(NamedKeyAddr),
-    /// A `Key` under which the total number of emitted messages in the last block is stored.
-    BlockMessageCount,
+    /// A `Key` under which per-block details are stored to global state.
+    BlockGlobal(BlockGlobalAddr),
     /// A `Key` under which a hold on a purse balance is stored.
     BalanceHold(BalanceHoldAddr),
 }
@@ -390,8 +391,8 @@ pub enum FromStrError {
     Message(contract_messages::FromStrError),
     /// Named key parse error.
     NamedKey(String),
-    /// BlockMessageCount key parse error.
-    BlockMessageCount(String),
+    /// BlockGlobal key parse error.
+    BlockGlobal(String),
     /// Balance hold parse error.
     BalanceHold(String),
     /// Unknown prefix.
@@ -468,7 +469,7 @@ impl Display for FromStrError {
             FromStrError::NamedKey(error) => {
                 write!(f, "named-key from string error: {}", error)
             }
-            FromStrError::BlockMessageCount(error) => {
+            FromStrError::BlockGlobal(error) => {
                 write!(f, "block-message-count-key form string error: {}", error)
             }
             FromStrError::BalanceHold(error) => {
@@ -505,7 +506,7 @@ impl Key {
             Key::ByteCode(_) => String::from("Key::ByteCode"),
             Key::Message(_) => String::from("Key::Message"),
             Key::NamedKey(_) => String::from("Key::NamedKey"),
-            Key::BlockMessageCount => String::from("Key::BlockMessageCount"),
+            Key::BlockGlobal(_) => String::from("Key::BlockGlobal"),
             Key::BalanceHold(_) => String::from("Key::BalanceHold"),
         }
     }
@@ -612,11 +613,15 @@ impl Key {
             Key::NamedKey(named_key) => {
                 format!("{}", named_key)
             }
-            Key::BlockMessageCount => {
+            Key::BlockGlobal(addr) => {
+                let prefix = match addr {
+                    BlockGlobalAddr::BlockTime => BLOCK_GLOBAL_TIME_PREFIX,
+                    BlockGlobalAddr::MessageCount => BLOCK_GLOBAL_MESSAGE_COUNT_PREFIX,
+                };
                 format!(
                     "{}{}",
-                    BLOCK_MESSAGE_COUNT_PREFIX,
-                    base16::encode_lower(&PADDING_BYTES)
+                    prefix,
+                    base16::encode_lower(&BLOCK_GLOBAL_PADDING_BYTES)
                 )
             }
             Key::BalanceHold(balance_hold_addr) => {
@@ -828,15 +833,24 @@ impl Key {
             Err(error) => return Err(FromStrError::NamedKey(error.to_string())),
         }
 
-        if let Some(message_count) = input.strip_prefix(BLOCK_MESSAGE_COUNT_PREFIX) {
+        if let Some(block_time) = input.strip_prefix(BLOCK_GLOBAL_TIME_PREFIX) {
+            let padded_bytes = checksummed_hex::decode(block_time)
+                .map_err(|error| FromStrError::BlockGlobal(error.to_string()))?;
+            let _padding: [u8; 31] = TryFrom::try_from(padded_bytes.as_ref()).map_err(|_| {
+                FromStrError::BlockGlobal("Failed to deserialize global block time key".to_string())
+            })?;
+            return Ok(BlockGlobalAddr::BlockTime.into());
+        }
+
+        if let Some(message_count) = input.strip_prefix(BLOCK_GLOBAL_MESSAGE_COUNT_PREFIX) {
             let padded_bytes = checksummed_hex::decode(message_count)
-                .map_err(|error| FromStrError::BlockMessageCount(error.to_string()))?;
-            let _padding: [u8; 32] = TryFrom::try_from(padded_bytes.as_ref()).map_err(|_| {
-                FromStrError::SystemEntityRegistry(
-                    "Failed to deserialize block message count key".to_string(),
+                .map_err(|error| FromStrError::BlockGlobal(error.to_string()))?;
+            let _padding: [u8; 31] = TryFrom::try_from(padded_bytes.as_ref()).map_err(|_| {
+                FromStrError::BlockGlobal(
+                    "Failed to deserialize global block message count key".to_string(),
                 )
             })?;
-            return Ok(Key::BlockMessageCount);
+            return Ok(BlockGlobalAddr::MessageCount.into());
         }
 
         Err(FromStrError::UnknownPrefix)
@@ -1148,7 +1162,7 @@ impl Key {
             | Key::BalanceHold(_)
             | Key::Dictionary(_)
             | Key::Message(_)
-            | Key::BlockMessageCount => true,
+            | Key::BlockGlobal(_) => true,
             _ => false,
         };
         if !ret {
@@ -1276,11 +1290,12 @@ impl Display for Key {
             Key::NamedKey(named_key_addr) => {
                 write!(f, "Key::NamedKey({})", named_key_addr)
             }
-            Key::BlockMessageCount => {
+            Key::BlockGlobal(addr) => {
                 write!(
                     f,
-                    "Key::BlockMessageCount({})",
-                    base16::encode_lower(&PADDING_BYTES)
+                    "Key::BlockGlobal({}-{})",
+                    addr,
+                    base16::encode_lower(&BLOCK_GLOBAL_PADDING_BYTES)
                 )
             }
             Key::BalanceHold(balance_hold_addr) => {
@@ -1320,7 +1335,7 @@ impl Tagged<KeyTag> for Key {
             Key::ByteCode(..) => KeyTag::ByteCode,
             Key::Message(_) => KeyTag::Message,
             Key::NamedKey(_) => KeyTag::NamedKey,
-            Key::BlockMessageCount => KeyTag::BlockMessageCount,
+            Key::BlockGlobal(_) => KeyTag::BlockGlobal,
             Key::BalanceHold(_) => KeyTag::BalanceHold,
         }
     }
@@ -1427,7 +1442,11 @@ impl ToBytes for Key {
             Key::NamedKey(named_key_addr) => {
                 KEY_ID_SERIALIZED_LENGTH + named_key_addr.serialized_length()
             }
-            Key::BlockMessageCount => KEY_BLOCK_MESSAGE_COUNT_SERIALIZED_LENGTH,
+            Key::BlockGlobal(addr) => {
+                KEY_ID_SERIALIZED_LENGTH
+                    + addr.serialized_length()
+                    + BLOCK_GLOBAL_PADDING_BYTES.len()
+            }
             Key::BalanceHold(balance_hold_addr) => {
                 U8_SERIALIZED_LENGTH + balance_hold_addr.serialized_length()
             }
@@ -1451,8 +1470,11 @@ impl ToBytes for Key {
             Key::SystemEntityRegistry
             | Key::EraSummary
             | Key::ChainspecRegistry
-            | Key::ChecksumRegistry
-            | Key::BlockMessageCount => PADDING_BYTES.write_bytes(writer),
+            | Key::ChecksumRegistry => PADDING_BYTES.write_bytes(writer),
+            Key::BlockGlobal(addr) => {
+                addr.write_bytes(writer)?;
+                BLOCK_GLOBAL_PADDING_BYTES.write_bytes(writer)
+            }
             Key::BidAddr(bid_addr) => bid_addr.write_bytes(writer),
             Key::Package(package_addr) => package_addr.write_bytes(writer),
             Key::AddressableEntity(entity_addr) => entity_addr.write_bytes(writer),
@@ -1552,9 +1574,10 @@ impl FromBytes for Key {
                 let (named_key_addr, rem) = NamedKeyAddr::from_bytes(remainder)?;
                 Ok((Key::NamedKey(named_key_addr), rem))
             }
-            KeyTag::BlockMessageCount => {
-                let (_, rem) = <[u8; 32]>::from_bytes(remainder)?;
-                Ok((Key::BlockMessageCount, rem))
+            KeyTag::BlockGlobal => {
+                let (addr, rem) = BlockGlobalAddr::from_bytes(remainder)?;
+                let (_, rem) = <[u8; 31]>::from_bytes(rem)?; // strip padding
+                Ok((Key::BlockGlobal(addr), rem))
             }
             KeyTag::BalanceHold => {
                 let (balance_hold_addr, rem) = BalanceHoldAddr::from_bytes(remainder)?;
@@ -1590,7 +1613,7 @@ fn please_add_to_distribution_impl(key: Key) {
         Key::ByteCode(..) => unimplemented!(),
         Key::Message(_) => unimplemented!(),
         Key::NamedKey(_) => unimplemented!(),
-        Key::BlockMessageCount => unimplemented!(),
+        Key::BlockGlobal(_) => unimplemented!(),
         Key::BalanceHold(_) => unimplemented!(),
     }
 }
@@ -1620,7 +1643,7 @@ impl Distribution<Key> for Standard {
             18 => Key::ByteCode(rng.gen()),
             19 => Key::Message(rng.gen()),
             20 => Key::NamedKey(NamedKeyAddr::new_named_key_entry(rng.gen(), rng.gen())),
-            21 => Key::BlockMessageCount,
+            21 => Key::BlockGlobal(rng.gen()),
             22 => Key::BalanceHold(rng.gen()),
             _ => unreachable!(),
         }
@@ -1654,7 +1677,7 @@ mod serde_helpers {
         ByteCode(&'a ByteCodeAddr),
         Message(&'a MessageAddr),
         NamedKey(&'a NamedKeyAddr),
-        BlockMessageCount,
+        BlockGlobal(&'a BlockGlobalAddr),
         BalanceHold(&'a BalanceHoldAddr),
     }
 
@@ -1682,7 +1705,7 @@ mod serde_helpers {
         ByteCode(ByteCodeAddr),
         Message(MessageAddr),
         NamedKey(NamedKeyAddr),
-        BlockMessageCount,
+        BlockGlobal(BlockGlobalAddr),
         BalanceHold(BalanceHoldAddr),
     }
 
@@ -1712,7 +1735,7 @@ mod serde_helpers {
                 }
                 Key::ByteCode(byte_code_addr) => BinarySerHelper::ByteCode(byte_code_addr),
                 Key::NamedKey(named_key_addr) => BinarySerHelper::NamedKey(named_key_addr),
-                Key::BlockMessageCount => BinarySerHelper::BlockMessageCount,
+                Key::BlockGlobal(addr) => BinarySerHelper::BlockGlobal(addr),
                 Key::BalanceHold(balance_hold_addr) => {
                     BinarySerHelper::BalanceHold(balance_hold_addr)
                 }
@@ -1746,7 +1769,7 @@ mod serde_helpers {
                 }
                 BinaryDeserHelper::ByteCode(byte_code_addr) => Key::ByteCode(byte_code_addr),
                 BinaryDeserHelper::NamedKey(named_key_addr) => Key::NamedKey(named_key_addr),
-                BinaryDeserHelper::BlockMessageCount => Key::BlockMessageCount,
+                BinaryDeserHelper::BlockGlobal(addr) => Key::BlockGlobal(addr),
                 BinaryDeserHelper::BalanceHold(balance_hold_addr) => {
                     Key::BalanceHold(balance_hold_addr)
                 }
@@ -1836,7 +1859,8 @@ mod tests {
         EntityAddr::new_smart_contract([42; 32]),
         [43; 32],
     ));
-    const BLOCK_MESSAGE_COUNT: Key = Key::BlockMessageCount;
+    const BLOCK_TIME_KEY: Key = Key::BlockGlobal(BlockGlobalAddr::BlockTime);
+    const BLOCK_MESSAGE_COUNT_KEY: Key = Key::BlockGlobal(BlockGlobalAddr::MessageCount);
     const BALANCE_HOLD: Key =
         Key::BalanceHold(BalanceHoldAddr::new_gas([42; 32], BlockTime::new(100)));
     const KEYS: &[Key] = &[
@@ -1867,7 +1891,8 @@ mod tests {
         MESSAGE_TOPIC_KEY,
         MESSAGE_KEY,
         NAMED_KEY,
-        BLOCK_MESSAGE_COUNT,
+        BLOCK_TIME_KEY,
+        BLOCK_MESSAGE_COUNT_KEY,
         BALANCE_HOLD,
     ];
     const HEX_STRING: &str = "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a";
@@ -2048,10 +2073,19 @@ mod tests {
             )
         );
         assert_eq!(
-            format!("{}", BLOCK_MESSAGE_COUNT),
+            format!("{}", BLOCK_TIME_KEY),
             format!(
-                "Key::BlockMessageCount({})",
-                base16::encode_lower(&PADDING_BYTES)
+                "Key::BlockGlobal({}-{})",
+                BlockGlobalAddr::BlockTime,
+                base16::encode_lower(&BLOCK_GLOBAL_PADDING_BYTES)
+            )
+        );
+        assert_eq!(
+            format!("{}", BLOCK_MESSAGE_COUNT_KEY),
+            format!(
+                "Key::BlockGlobal({}-{})",
+                BlockGlobalAddr::MessageCount,
+                base16::encode_lower(&BLOCK_GLOBAL_PADDING_BYTES)
             )
         );
     }
@@ -2421,7 +2455,8 @@ mod tests {
             1,
         )));
         round_trip(&Key::NamedKey(NamedKeyAddr::default()));
-        round_trip(&Key::BlockMessageCount);
+        round_trip(&Key::BlockGlobal(BlockGlobalAddr::BlockTime));
+        round_trip(&Key::BlockGlobal(BlockGlobalAddr::MessageCount));
         round_trip(&Key::BalanceHold(BalanceHoldAddr::default()));
     }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -22,7 +22,6 @@
 extern crate alloc;
 
 extern crate core;
-
 mod access_rights;
 pub mod account;
 pub mod addressable_entity;
@@ -96,13 +95,14 @@ pub use auction_state::{AuctionState, JsonEraValidators, JsonValidatorWeights};
 #[cfg(all(feature = "std", feature = "json-schema"))]
 pub use block::JsonBlockWithSignatures;
 pub use block::{
-    AvailableBlockRange, Block, BlockBody, BlockBodyV1, BlockBodyV2, BlockHash, BlockHashAndHeight,
-    BlockHeader, BlockHeaderV1, BlockHeaderV2, BlockIdentifier, BlockSignatures,
-    BlockSignaturesMergeError, BlockSignaturesV1, BlockSignaturesV2, BlockSyncStatus,
-    BlockSynchronizerStatus, BlockV1, BlockV2, BlockValidationError, ChainNameDigest, EraEnd,
-    EraEndV1, EraEndV2, EraReport, FinalitySignature, FinalitySignatureId, FinalitySignatureV1,
-    FinalitySignatureV2, RewardedSignatures, Rewards, SignedBlock, SignedBlockHeader,
-    SignedBlockHeaderValidationError, SingleBlockRewardedSignatures,
+    AvailableBlockRange, Block, BlockBody, BlockBodyV1, BlockBodyV2, BlockGlobalAddr,
+    BlockGlobalAddrTag, BlockHash, BlockHashAndHeight, BlockHeader, BlockHeaderV1, BlockHeaderV2,
+    BlockIdentifier, BlockSignatures, BlockSignaturesMergeError, BlockSignaturesV1,
+    BlockSignaturesV2, BlockSyncStatus, BlockSynchronizerStatus, BlockV1, BlockV2,
+    BlockValidationError, ChainNameDigest, EraEnd, EraEndV1, EraEndV2, EraReport,
+    FinalitySignature, FinalitySignatureId, FinalitySignatureV1, FinalitySignatureV2,
+    RewardedSignatures, Rewards, SignedBlock, SignedBlockHeader, SignedBlockHeaderValidationError,
+    SingleBlockRewardedSignatures,
 };
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub use block::{TestBlockBuilder, TestBlockV1Builder};

--- a/types/src/system/mint/balance_hold.rs
+++ b/types/src/system/mint/balance_hold.rs
@@ -88,13 +88,13 @@ impl ToBytes for BalanceHoldAddrTag {
         Ok(buffer)
     }
 
+    fn serialized_length(&self) -> usize {
+        Self::BALANCE_HOLD_ADDR_TAG_LENGTH
+    }
+
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
         writer.push(*self as u8);
         Ok(())
-    }
-
-    fn serialized_length(&self) -> usize {
-        Self::BALANCE_HOLD_ADDR_TAG_LENGTH
     }
 }
 


### PR DESCRIPTION
this PR introduces a new behavior where the block time for each block is written to global state (GS) at the beginning of block execution. 
1. empty blocks will no longer carry forward their parent's root hash due to no GS change occurring; this addresses a quirk that while not problematic has confused people in the past.
2. in 1.x, runtime contexts within the EE are told the block time and retain it in mem, and will provide that info to VM bound processes via an ffi, and to native function via self inspection. 2.0 continues to support the VM-bound portion of that, but as native function has been moved out of the EE, native logic that needed that information had to be told by its caller via argument which polluted various interfaces, and also required the programmer to pass the correct block time for a given root hash with no way for the receiving logic to verify correctness. also given 1) above, multiple block times could apply to the same root hash in the case of empty blocks which also created ambiguity. putting the value to GS allows the relevant logic to read the always correct value for a given root hash.
3. due to the balance holds introduced in 2.0, balance checks must consider expiry of holds to give the correct answer, which is all based on block times. given 1) and 2) above this placed a burden upon the calling logic to produce the correct block time for a given root hash to provide it to the balance calculation, which was cumbersome and potentially error prone. putting the value to GS allows the relevant logic to read the always correct value for a given root hash at time of calculation.
4. global state / tracking copy bound operations that require block time in general are able, now and in the future, to always and exclusively rely on the value from global state, which simplifies their implementation.
5. off chain consumers of global state data can easily correlate a given root hash to its corresponding block via block time, which previously was not possible (you had to go the other way, start with the block to identify its root hash). this simplifies certain indexing and syncing processes. 

similarly, gas handling settings are also being put to global state as uref values held by the mint. these settings, along with the aforementioned block time put to global state, allows historical balance queries at earlier block heights to provide the correct-per-the-settings-from-that-time responses. for instance, if for a period of time on a given network gas holds had an interval of 24 hours and were accrued, but a later upgrade switched the interval to 36 hours and amortized any balance query at a block height where the previous settings were in effect will properly use the contemporaneous settings of 24 hours / accrued while balance queries at block heights during the period where 36 hours / amortized are in effect will properly use those settings. relying only on the current chainspec settings as was originally wired up would produce temporally anomalous results in the historical case. also, pushing the values to GS greatly simplified calling logic which previously was required to retrieve those settings, calculate an expiry epoch, and pass all of that around which was cumbersome and error prone...now all that behavior is internalized to the calculating process itself, checked, and is always self consistent.  

the genesis process has been modified to associate the gas handling settings with the mint contract so that new networks are set up properly from the jump, and the protocol upgrade process has been modified to associate the settings to the mint on pre-existing networks and also handle any future protocol upgrades if the settings are changed on that network.

incidentally, some useful convenience logic as been added to the tracking copy. also, the new 2.0 key variant of MessageCount has been collated together with BlockTime as Key::BlockGlobal(BlockGlobalAddr), the addr of which is a padded u8 tag indicating record kind. if any further singleton-per-block values are useful to write to GS in the future, they should be tagged appropriately and stored under this key variant. 

finally, there was some parallel implementation for balance checks initiated by the node vs those initiated from VM based logic which had begun to diverge. the logic has been refactored a bit so that both flows share the same calculation logic rather than independently implement it.
