### PR TITLE
Update emit message costs for production chainspec

### DIFF
--- a/execution_engine/src/resolvers/v1_function_index.rs
+++ b/execution_engine/src/resolvers/v1_function_index.rs
@@ -50,8 +50,6 @@ pub(crate) enum FunctionIndex {
     ExtendContractUserGroupURefsIndex,
     RemoveContractUserGroupURefsIndex,
     Blake2b,
-    RecordTransfer,
-    RecordEraInfo,
     NewDictionaryFuncIndex,
     DictionaryGetFuncIndex,
     DictionaryPutFuncIndex,

--- a/execution_engine/src/resolvers/v1_resolver.rs
+++ b/execution_engine/src/resolvers/v1_resolver.rs
@@ -200,14 +200,6 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::Blake2b.into(),
             ),
-            "casper_record_transfer" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 10][..], Some(ValueType::I32)),
-                FunctionIndex::RecordTransfer.into(),
-            ),
-            "casper_record_era_info" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
-                FunctionIndex::RecordEraInfo.into(),
-            ),
             "casper_load_call_stack" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::LoadCallStack.into(),

--- a/execution_engine/src/runtime/externals.rs
+++ b/execution_engine/src/runtime/externals.rs
@@ -12,9 +12,7 @@ use casper_types::{
     api_error,
     bytesrepr::{self, ToBytes},
     contract_messages::MessageTopicOperation,
-    crypto,
-    system::auction::EraInfo,
-    AddressableEntityHash, ApiError, EntityVersion, EraId, Gas, Group, HostFunction,
+    crypto, AddressableEntityHash, ApiError, EntityVersion, Gas, Group, HostFunction,
     HostFunctionCost, Key, PackageHash, PackageStatus, StoredValue, URef,
     DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, U512, UREF_SERIALIZED_LENGTH,
 };
@@ -955,42 +953,6 @@ where
                 self.try_get_memory()?
                     .set(out_ptr, &digest)
                     .map_err(|error| ExecError::Interpreter(error.into()))?;
-                Ok(Some(RuntimeValue::I32(0)))
-            }
-
-            FunctionIndex::RecordTransfer => {
-                // RecordTransfer is a special cased internal host function only callable by the
-                // mint contract and for accounting purposes it isn't represented in protocol data.
-                let (
-                    maybe_to_ptr,
-                    maybe_to_size,
-                    source_ptr,
-                    source_size,
-                    target_ptr,
-                    target_size,
-                    amount_ptr,
-                    amount_size,
-                    id_ptr,
-                    id_size,
-                ): (u32, u32, u32, u32, u32, u32, u32, u32, u32, u32) = Args::parse(args)?;
-                let maybe_to: Option<AccountHash> = self.t_from_mem(maybe_to_ptr, maybe_to_size)?;
-                let source: URef = self.t_from_mem(source_ptr, source_size)?;
-                let target: URef = self.t_from_mem(target_ptr, target_size)?;
-                let amount: U512 = self.t_from_mem(amount_ptr, amount_size)?;
-                let id: Option<u64> = self.t_from_mem(id_ptr, id_size)?;
-                self.record_transfer(maybe_to, source, target, amount, id)?;
-                Ok(Some(RuntimeValue::I32(0)))
-            }
-
-            FunctionIndex::RecordEraInfo => {
-                // RecordEraInfo is a special cased internal host function only callable by the
-                // auction contract and for accounting purposes it isn't represented in protocol
-                // data.
-                let (era_id_ptr, era_id_size, era_info_ptr, era_info_size): (u32, u32, u32, u32) =
-                    Args::parse(args)?;
-                let _era_id: EraId = self.t_from_mem(era_id_ptr, era_id_size)?;
-                let era_info: EraInfo = self.t_from_mem(era_info_ptr, era_info_size)?;
-                self.record_era_info(era_info)?;
                 Ok(Some(RuntimeValue::I32(0)))
             }
 

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -926,7 +926,7 @@ fn faucet_costs() {
     // This test will fail if execution costs vary.  The expected costs should not be updated
     // without understanding why the cost has changed.  If the costs do change, it should be
     // reflected in the "Costs by Entry Point" section of the faucet crate's README.md.
-    const EXPECTED_FAUCET_INSTALL_COST: u64 = 89_243_134_240;
+    const EXPECTED_FAUCET_INSTALL_COST: u64 = 89_243_254_240;
     const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 111_263_840;
     const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_774_829_320;
     const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_619_720_120;

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -255,7 +255,7 @@ size_multiplier = 100
 [wasm.host_function_costs]
 add = { cost = 5_800, arguments = [0, 0, 0, 0] }
 add_associated_key = { cost = 9_000, arguments = [0, 0, 0] }
-add_contract_version = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
+add_contract_version = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 30_000, 0, 0] }
 blake2b = { cost = 200, arguments = [0, 0, 0, 0] }
 call_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 420, 0] }
 call_versioned_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 0, 0, 420, 0] }
@@ -297,8 +297,8 @@ update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
-manage_message_topic = { cost = 200, arguments = [0, 0, 0, 0] }
-emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
+manage_message_topic = { cost = 200, arguments = [0, 30_000, 0, 0] }
+emit_message = { cost = 200, arguments = [0, 30_000, 0, 120_000] }
 cost_increase_per_message = 50
 
 [wasm.messages_limits]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -265,7 +265,7 @@ size_multiplier = 100
 [wasm.host_function_costs]
 add = { cost = 5_800, arguments = [0, 0, 0, 0] }
 add_associated_key = { cost = 1_200_000, arguments = [0, 0, 0] }
-add_contract_version = { cost = 200, arguments = [0, 0, 0, 0, 120_000, 0, 0, 0, 0, 0, 0] }
+add_contract_version = { cost = 200, arguments = [0, 0, 0, 0, 120_000, 0, 0, 0, 30_000, 0, 0] }
 blake2b = { cost = 1_200_000, arguments = [0, 120_000, 0, 0] }
 call_contract = { cost = 300_000_000, arguments = [0, 0, 0, 120_000, 0, 120_000, 0] }
 call_versioned_contract = { cost = 300_000_000, arguments = [0, 0, 0, 0, 0, 120_000, 0, 120_000, 0] }
@@ -307,8 +307,8 @@ update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
 write = { cost = 14_000, arguments = [0, 0, 0, 980] }
 write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
 enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
-manage_message_topic = { cost = 200, arguments = [0, 0, 0, 0] }
-emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
+manage_message_topic = { cost = 200, arguments = [0, 30_000, 0, 0] }
+emit_message = { cost = 200, arguments = [0, 30_000, 0, 120_000] }
 cost_increase_per_message = 50
 
 [wasm.messages_limits]

--- a/smart_contracts/contract/src/contract_api/system.rs
+++ b/smart_contracts/contract/src/contract_api/system.rs
@@ -4,15 +4,9 @@ use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
 use casper_types::{
-    account::AccountHash,
-    addressable_entity::EntityKindTag,
-    api_error, bytesrepr,
-    system::{
-        auction::{self, EraInfo},
-        SystemEntityType,
-    },
-    AddressableEntityHash, ApiError, EraId, HashAddr, Key, PublicKey, TransferResult,
-    TransferredTo, URef, U512, UREF_SERIALIZED_LENGTH,
+    account::AccountHash, addressable_entity::EntityKindTag, api_error, bytesrepr,
+    system::SystemEntityType, AddressableEntityHash, ApiError, HashAddr, Key, PublicKey,
+    TransferResult, TransferredTo, URef, U512, UREF_SERIALIZED_LENGTH,
 };
 
 use crate::{
@@ -249,56 +243,4 @@ pub fn transfer_from_purse_to_purse(
         )
     };
     api_error::result_from(result)
-}
-
-/// Records a transfer.  Can only be called from within the mint contract.
-/// Needed to support system contract-based execution.
-#[doc(hidden)]
-pub fn record_transfer(
-    maybe_to: Option<AccountHash>,
-    source: URef,
-    target: URef,
-    amount: U512,
-    id: Option<u64>,
-) -> Result<(), ApiError> {
-    let (maybe_to_ptr, maybe_to_size, _bytes1) = contract_api::to_ptr(maybe_to);
-    let (source_ptr, source_size, _bytes2) = contract_api::to_ptr(source);
-    let (target_ptr, target_size, _bytes3) = contract_api::to_ptr(target);
-    let (amount_ptr, amount_size, _bytes4) = contract_api::to_ptr(amount);
-    let (id_ptr, id_size, _bytes5) = contract_api::to_ptr(id);
-    let result = unsafe {
-        ext_ffi::casper_record_transfer(
-            maybe_to_ptr,
-            maybe_to_size,
-            source_ptr,
-            source_size,
-            target_ptr,
-            target_size,
-            amount_ptr,
-            amount_size,
-            id_ptr,
-            id_size,
-        )
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(ApiError::Transfer)
-    }
-}
-
-/// Records era info.  Can only be called from within the auction contract.
-/// Needed to support system contract-based execution.
-#[doc(hidden)]
-pub fn record_era_info(era_id: EraId, era_info: EraInfo) -> Result<(), ApiError> {
-    let (era_id_ptr, era_id_size, _bytes1) = contract_api::to_ptr(era_id);
-    let (era_info_ptr, era_info_size, _bytes2) = contract_api::to_ptr(era_info);
-    let result = unsafe {
-        ext_ffi::casper_record_era_info(era_id_ptr, era_id_size, era_info_ptr, era_info_size)
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(auction::Error::RecordEraInfo.into())
-    }
 }

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -372,52 +372,6 @@ extern "C" {
         id_ptr: *const u8,
         id_size: usize,
     ) -> i32;
-    /// Records a transfer.  Can only be called from within the mint contract.
-    /// Needed to support system contract-based execution.
-    ///
-    /// # Arguments
-    ///
-    /// * `maybe_to_ptr` - pointer in wasm memory to bytes representing the recipient
-    ///   `Option<AccountHash>`
-    /// * `maybe_to_size` - size of the source `Option<AccountHash>` (in bytes)
-    /// * `source_ptr` - pointer in wasm memory to bytes representing the source `URef` to transfer
-    ///   from
-    /// * `source_size` - size of the source `URef` (in bytes)
-    /// * `target_ptr` - pointer in wasm memory to bytes representing the target `URef` to transfer
-    ///   to
-    /// * `target_size` - size of the target (in bytes)
-    /// * `amount_ptr` - pointer in wasm memory to bytes representing the amount to transfer to the
-    ///   target account
-    /// * `amount_size` - size of the amount (in bytes)
-    /// * `id_ptr` - pointer in wasm memory to bytes representing the user-defined transaction id
-    /// * `id_size` - size of the id (in bytes)
-    pub fn casper_record_transfer(
-        maybe_to_ptr: *const u8,
-        maybe_to_size: usize,
-        source_ptr: *const u8,
-        source_size: usize,
-        target_ptr: *const u8,
-        target_size: usize,
-        amount_ptr: *const u8,
-        amount_size: usize,
-        id_ptr: *const u8,
-        id_size: usize,
-    ) -> i32;
-    /// Records era info.  Can only be called from within the auction contract.
-    /// Needed to support system contract-based execution.
-    ///
-    /// # Arguments
-    ///
-    /// * `era_id_ptr` - pointer in wasm memory to bytes representing the `EraId`
-    /// * `era_id_size` - size of the `EraId` (in bytes)
-    /// * `era_info_ptr` - pointer in wasm memory to bytes representing the `EraInfo`
-    /// * `era_info_size` - size of the `EraInfo` (in bytes)
-    pub fn casper_record_era_info(
-        era_id_ptr: *const u8,
-        era_id_size: usize,
-        era_info_ptr: *const u8,
-        era_info_size: usize,
-    ) -> i32;
     /// This function uses the mint contract's balance function to get the balance
     /// of the specified purse. It causes a `Trap` if the bytes in wasm memory
     /// from `purse_ptr` to `purse_ptr + purse_size` cannot be

--- a/types/src/chainspec/vm_config/host_function_costs.rs
+++ b/types/src/chainspec/vm_config/host_function_costs.rs
@@ -93,6 +93,9 @@ pub const DEFAULT_HOST_FUNCTION_NEW_DICTIONARY: HostFunction<[Cost; 1]> =
 /// emitted within an execution.
 pub const DEFAULT_COST_INCREASE_PER_MESSAGE_EMITTED: u32 = 50;
 
+const DEFAULT_MESSAGE_TOPIC_NAME_SIZE_WEIGHT: u32 = 30_000;
+const DEFAULT_MESSAGE_PAYLOAD_SIZE_WEIGHT: u32 = 120_000;
+
 /// Representation of a host function cost.
 ///
 /// The total gas cost is equal to `cost` + sum of each argument weight multiplied by the byte size
@@ -577,7 +580,22 @@ impl Default for HostFunctionCosts {
             ),
             create_contract_package_at_hash: HostFunction::default(),
             create_contract_user_group: HostFunction::default(),
-            add_contract_version: HostFunction::default(),
+            add_contract_version: HostFunction::new(
+                DEFAULT_FIXED_COST,
+                [
+                    NOT_USED,
+                    NOT_USED,
+                    NOT_USED,
+                    NOT_USED,
+                    NOT_USED,
+                    NOT_USED,
+                    NOT_USED,
+                    NOT_USED,
+                    DEFAULT_MESSAGE_TOPIC_NAME_SIZE_WEIGHT,
+                    NOT_USED,
+                    NOT_USED,
+                ],
+            ),
             disable_contract_version: HostFunction::default(),
             call_contract: HostFunction::new(
                 DEFAULT_CALL_CONTRACT_COST,
@@ -617,8 +635,24 @@ impl Default for HostFunctionCosts {
             blake2b: HostFunction::default(),
             random_bytes: HostFunction::default(),
             enable_contract_version: HostFunction::default(),
-            manage_message_topic: HostFunction::default(),
-            emit_message: HostFunction::default(),
+            manage_message_topic: HostFunction::new(
+                DEFAULT_FIXED_COST,
+                [
+                    NOT_USED,
+                    DEFAULT_MESSAGE_TOPIC_NAME_SIZE_WEIGHT,
+                    NOT_USED,
+                    NOT_USED,
+                ],
+            ),
+            emit_message: HostFunction::new(
+                DEFAULT_FIXED_COST,
+                [
+                    NOT_USED,
+                    DEFAULT_MESSAGE_TOPIC_NAME_SIZE_WEIGHT,
+                    NOT_USED,
+                    DEFAULT_MESSAGE_PAYLOAD_SIZE_WEIGHT,
+                ],
+            ),
             cost_increase_per_message: DEFAULT_COST_INCREASE_PER_MESSAGE_EMITTED,
         }
     }


### PR DESCRIPTION
Because `emit_message` and `manage_message_topic` perform operations in the backend that may be expensive (e.g. hashing a topic name or the message payload), we set non-zero default values for costs related to parameters involved in these types of operations. For example emitting a message of a small payload size (e.g. 10 bytes) is cheaper than emitting a message with larger payload (e.g. 1000 bytes) since these bytes need to be hashed and checked.

Also remove the unused `record_transfer` and `record_era_info` FFIs.