### PR TITLE
BUGFIX: Custom Payment / No Fee / No Refund interaction

### DIFF
--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -366,7 +366,7 @@ impl TestFixture {
         if era_duration != TimeDiff::from_millis(0) {
             chainspec.core_config.era_duration = era_duration;
         }
-        info!("Foooo {block_gas_limit}");
+        info!(?block_gas_limit);
         chainspec.core_config.minimum_block_time = minimum_block_time;
         chainspec.core_config.minimum_era_height = minimum_era_height;
         chainspec.core_config.unbonding_delay = unbonding_delay;
@@ -415,9 +415,9 @@ impl TestFixture {
             chainspec.core_config.gas_hold_balance_handling = gas_hold_balance_handling;
         }
 
-        let limit = chainspec.transaction_config.block_gas_limit;
+        let applied_block_gas_limit = chainspec.transaction_config.block_gas_limit;
 
-        info!("THE LIMIT {limit}");
+        info!(?applied_block_gas_limit);
 
         let mut fixture = TestFixture {
             rng,

--- a/storage/src/data_access_layer/balance.rs
+++ b/storage/src/data_access_layer/balance.rs
@@ -89,14 +89,14 @@ impl BalanceIdentifier {
             BalanceIdentifier::Public(public_key) => {
                 let account_hash = public_key.to_account_hash();
                 match tc.get_addressable_entity_by_account_hash(protocol_version, account_hash) {
-                    Ok(entity) => entity.main_purse(),
+                    Ok((_, entity)) => entity.main_purse(),
                     Err(tce) => return Err(tce),
                 }
             }
             BalanceIdentifier::Account(account_hash)
             | BalanceIdentifier::PenalizedAccount(account_hash) => {
                 match tc.get_addressable_entity_by_account_hash(protocol_version, *account_hash) {
-                    Ok(entity) => entity.main_purse(),
+                    Ok((_, entity)) => entity.main_purse(),
                     Err(tce) => return Err(tce),
                 }
             }

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -29,7 +29,7 @@ use casper_types::{
             BalanceHoldAddr, BalanceHoldAddrTag, ARG_AMOUNT, ROUND_SEIGNIORAGE_RATE_KEY,
             TOTAL_SUPPLY_KEY,
         },
-        AUCTION, MINT,
+        AUCTION, HANDLE_PAYMENT, MINT,
     },
     Account, AddressableEntity, BlockGlobalAddr, CLValue, Digest, EntityAddr, HoldsEpoch, Key,
     KeyTag, Phase, PublicKey, RuntimeArgs, StoredValue, U512,
@@ -1008,7 +1008,7 @@ pub trait StateProvider {
         };
 
         let source_account_hash = initiator.account_hash();
-        let (entity, entity_named_keys, entity_access_rights) =
+        let (entity_addr, entity, entity_named_keys, entity_access_rights) =
             match tc.borrow_mut().resolved_entity(
                 protocol_version,
                 source_account_hash,
@@ -1020,6 +1020,7 @@ pub trait StateProvider {
                     return BiddingResult::Failure(tce);
                 }
             };
+        let entity_key = Key::AddressableEntity(entity_addr);
 
         // IMPORTANT: this runtime _must_ use the payer's context.
         let mut runtime = RuntimeNative::new(
@@ -1028,6 +1029,7 @@ pub trait StateProvider {
             Id::Transaction(transaction_hash),
             Rc::clone(&tc),
             source_account_hash,
+            entity_key,
             entity,
             entity_named_keys,
             entity_access_rights,
@@ -1127,18 +1129,40 @@ pub trait StateProvider {
             Err(err) => return HandleRefundResult::Failure(TrackingCopyError::Storage(err)),
         };
 
-        // this runtime uses the system's context
-        let mut runtime = match RuntimeNative::new_system_runtime(
-            config,
-            protocol_version,
-            Id::Transaction(transaction_hash),
-            Rc::clone(&tc),
-            refund_mode.phase(),
-        ) {
-            Ok(rt) => rt,
-            Err(tce) => {
-                return HandleRefundResult::Failure(tce);
+        let phase = refund_mode.phase();
+        let mut runtime = match phase {
+            Phase::FinalizePayment => {
+                // this runtime uses the system's context
+                match RuntimeNative::new_system_runtime(
+                    config,
+                    protocol_version,
+                    Id::Transaction(transaction_hash),
+                    Rc::clone(&tc),
+                    phase,
+                ) {
+                    Ok(rt) => rt,
+                    Err(tce) => {
+                        return HandleRefundResult::Failure(tce);
+                    }
+                }
             }
+            Phase::Payment => {
+                // this runtime uses the handle payment contract's context
+                match RuntimeNative::new_system_contract_runtime(
+                    config,
+                    protocol_version,
+                    Id::Transaction(transaction_hash),
+                    Rc::clone(&tc),
+                    phase,
+                    HANDLE_PAYMENT,
+                ) {
+                    Ok(rt) => rt,
+                    Err(tce) => {
+                        return HandleRefundResult::Failure(tce);
+                    }
+                }
+            }
+            Phase::System | Phase::Session => return HandleRefundResult::InvalidPhase,
         };
 
         let result = match refund_mode {
@@ -1220,6 +1244,53 @@ pub trait StateProvider {
                     .map_err(|_| Error::Transfer)
                 {
                     Ok(_) => Ok(Some(refund_amount)),
+                    Err(err) => Err(err),
+                }
+            }
+            HandleRefundMode::CustomHold {
+                initiator_addr,
+                limit,
+                cost,
+                gas_price,
+            } => {
+                let source = BalanceIdentifier::Payment;
+                let source_purse = match source.purse_uref(&mut tc.borrow_mut(), protocol_version) {
+                    Ok(value) => value,
+                    Err(tce) => return HandleRefundResult::Failure(tce),
+                };
+                let consumed = U512::zero();
+                let ratio = Ratio::new_raw(U512::one(), U512::one());
+                let refund_amount = match runtime.calculate_overpayment_and_fee(
+                    limit,
+                    gas_price,
+                    cost,
+                    consumed,
+                    source_purse,
+                    ratio,
+                ) {
+                    Ok((refund, _)) => refund,
+                    Err(hpe) => {
+                        return HandleRefundResult::Failure(TrackingCopyError::SystemContract(
+                            system::Error::HandlePayment(hpe),
+                        ));
+                    }
+                };
+                let target = BalanceIdentifier::Refund;
+                let target_purse = match target.purse_uref(&mut tc.borrow_mut(), protocol_version) {
+                    Ok(value) => value,
+                    Err(tce) => return HandleRefundResult::Failure(tce),
+                };
+                match runtime
+                    .transfer(
+                        Some(initiator_addr.account_hash()),
+                        source_purse,
+                        target_purse,
+                        refund_amount,
+                        None,
+                    )
+                    .map_err(|_| Error::Transfer)
+                {
+                    Ok(_) => Ok(Some(U512::zero())), // return 0 in this mode
                     Err(err) => Err(err),
                 }
             }
@@ -1720,7 +1791,7 @@ pub trait StateProvider {
             }
         }
 
-        let (entity, entity_named_keys, entity_access_rights) =
+        let (entity_addr, entity, entity_named_keys, entity_access_rights) =
             match tc.borrow_mut().resolved_entity(
                 protocol_version,
                 source_account_hash,
@@ -1732,7 +1803,7 @@ pub trait StateProvider {
                     return TransferResult::Failure(TransferError::TrackingCopy(tce));
                 }
             };
-
+        let entity_key = Key::AddressableEntity(entity_addr);
         let id = Id::Transaction(request.transaction_hash());
         // IMPORTANT: this runtime _must_ use the payer's context.
         let mut runtime = RuntimeNative::new(
@@ -1741,6 +1812,7 @@ pub trait StateProvider {
             id,
             Rc::clone(&tc),
             source_account_hash,
+            entity_key,
             entity.clone(),
             entity_named_keys.clone(),
             entity_access_rights,

--- a/storage/src/system/handle_payment/handle_payment_native.rs
+++ b/storage/src/system/handle_payment/handle_payment_native.rs
@@ -142,19 +142,20 @@ where
 
     fn put_key(&mut self, name: &str, key: Key) -> Result<(), Error> {
         let name = name.to_string();
-        let entity = self.addressable_entity();
-        let addressable_entity_hash = AddressableEntityHash::new(self.address().value());
-        let entity_addr = entity.entity_addr(addressable_entity_hash);
+        let entity_addr = self
+            .entity_key()
+            .as_entity_addr()
+            .ok_or(Error::UnexpectedKeyVariant)?;
         let named_key_value = StoredValue::NamedKey(
             NamedKeyValue::from_concrete_values(key, name.clone()).map_err(|_| Error::PutKey)?,
         );
         let named_key_addr =
             NamedKeyAddr::new_from_string(entity_addr, name.clone()).map_err(|_| Error::PutKey)?;
-        let key = Key::NamedKey(named_key_addr);
+        let named_key = Key::NamedKey(named_key_addr);
         // write to both tracking copy and in-mem named keys cache
         self.tracking_copy()
             .borrow_mut()
-            .write(key, named_key_value);
+            .write(named_key, named_key_value);
         self.named_keys_mut().insert(name, key);
         Ok(())
     }

--- a/storage/src/system/mint/mint_native.rs
+++ b/storage/src/system/mint/mint_native.rs
@@ -58,7 +58,7 @@ where
             .borrow_mut()
             .get_addressable_entity_by_account_hash(self.protocol_version(), account_hash)
         {
-            Ok(entity) => Ok(Some(entity)),
+            Ok((_, entity)) => Ok(Some(entity)),
             Err(tce) => {
                 error!(%tce, "error reading addressable entity by account hash");
                 Err(ProviderError::AddressableEntityByAccountHash(account_hash))

--- a/storage/src/system/runtime_native.rs
+++ b/storage/src/system/runtime_native.rs
@@ -1,6 +1,6 @@
 use crate::{
     global_state::{error::Error as GlobalStateReader, state::StateReader},
-    tracking_copy::{TrackingCopyEntityExt, TrackingCopyError},
+    tracking_copy::{TrackingCopyEntityExt, TrackingCopyError, TrackingCopyExt},
     AddressGenerator, TrackingCopy,
 };
 use casper_types::{
@@ -9,6 +9,7 @@ use casper_types::{
     StoredValue, TransactionHash, Transfer, URef, U512,
 };
 use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
+use tracing::error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Config {
@@ -235,6 +236,7 @@ pub struct RuntimeNative<S> {
 
     tracking_copy: Rc<RefCell<TrackingCopy<S>>>,
     address: AccountHash,
+    entity_key: Key,
     addressable_entity: AddressableEntity,
     named_keys: NamedKeys,
     access_rights: ContextAccessRights,
@@ -254,6 +256,7 @@ where
         id: Id,
         tracking_copy: Rc<RefCell<TrackingCopy<S>>>,
         address: AccountHash,
+        entity_key: Key,
         addressable_entity: AddressableEntity,
         named_keys: NamedKeys,
         access_rights: ContextAccessRights,
@@ -271,6 +274,7 @@ where
 
             tracking_copy,
             address,
+            entity_key,
             addressable_entity,
             named_keys,
             access_rights,
@@ -281,7 +285,6 @@ where
     }
 
     /// Creates a runtime with elevated permissions for systemic behaviors.
-    #[allow(clippy::too_many_arguments)]
     pub fn new_system_runtime(
         config: Config,
         protocol_version: ProtocolVersion,
@@ -292,8 +295,60 @@ where
         let seed = id.seed();
         let address_generator = AddressGenerator::new(&seed, phase);
         let transfers = vec![];
-        let (addressable_entity, named_keys, access_rights) =
+        let (entity_addr, addressable_entity, named_keys, access_rights) =
             tracking_copy.borrow_mut().system_entity(protocol_version)?;
+        let address = PublicKey::System.to_account_hash();
+        let entity_key = Key::AddressableEntity(entity_addr);
+        let remaining_spending_limit = U512::MAX; // system has no spending limit
+        Ok(RuntimeNative {
+            config,
+            id,
+            address_generator,
+            protocol_version,
+
+            tracking_copy,
+            address,
+            entity_key,
+            addressable_entity,
+            named_keys,
+            access_rights,
+            remaining_spending_limit,
+            transfers,
+            phase,
+        })
+    }
+
+    /// Creates a runtime context for a system contract.
+    pub fn new_system_contract_runtime(
+        config: Config,
+        protocol_version: ProtocolVersion,
+        id: Id,
+        tracking_copy: Rc<RefCell<TrackingCopy<S>>>,
+        phase: Phase,
+        name: &str,
+    ) -> Result<Self, TrackingCopyError> {
+        let seed = id.seed();
+        let address_generator = AddressGenerator::new(&seed, phase);
+        let transfers = vec![];
+
+        let system_entity_registry = tracking_copy.borrow().get_system_entity_registry()?;
+        let hash = match system_entity_registry.get(name).copied() {
+            Some(hash) => hash,
+            None => {
+                error!("unexpected failure; system contract {} not found", name);
+                return Err(TrackingCopyError::MissingSystemContractHash(
+                    name.to_string(),
+                ));
+            }
+        };
+        let addressable_entity = tracking_copy
+            .borrow_mut()
+            .get_addressable_entity_by_hash(hash)?;
+        let entity_addr = addressable_entity.entity_addr(hash);
+        let entity_key = Key::AddressableEntity(entity_addr);
+        let named_keys = tracking_copy.borrow().get_named_keys(entity_addr)?;
+        let access_rights = addressable_entity.extract_access_rights(hash, &named_keys);
+
         let address = PublicKey::System.to_account_hash();
         let remaining_spending_limit = U512::MAX; // system has no spending limit
         Ok(RuntimeNative {
@@ -304,6 +359,7 @@ where
 
             tracking_copy,
             address,
+            entity_key,
             addressable_entity,
             named_keys,
             access_rights,
@@ -335,6 +391,10 @@ where
 
     pub fn address(&self) -> AccountHash {
         self.address
+    }
+
+    pub fn entity_key(&self) -> &Key {
+        &self.entity_key
     }
 
     pub fn addressable_entity(&self) -> &AddressableEntity {

--- a/storage/src/system/transfer.rs
+++ b/storage/src/system/transfer.rs
@@ -363,9 +363,8 @@ impl TransferRuntimeArgsBuilder {
             .borrow_mut()
             .get_addressable_entity_by_account_hash(protocol_version, account_hash)
         {
-            Ok(contract) => {
-                let main_purse_addable =
-                    contract.main_purse().with_access_rights(AccessRights::ADD);
+            Ok((_, entity)) => {
+                let main_purse_addable = entity.main_purse().with_access_rights(AccessRights::ADD);
                 Ok(NewTransferTargetMode::ExistingAccount {
                     target_account_hash: account_hash,
                     main_purse: main_purse_addable,

--- a/types/src/chainspec/fee_handling.rs
+++ b/types/src/chainspec/fee_handling.rs
@@ -36,7 +36,7 @@ impl FeeHandling {
     }
 
     /// Returns true if configured for no fees.
-    pub fn skip_fee_handling(&self) -> bool {
+    pub fn is_no_fee(&self) -> bool {
         matches!(self, FeeHandling::NoFee)
     }
 }

--- a/types/src/system/handle_payment/error.rs
+++ b/types/src/system/handle_payment/error.rs
@@ -261,6 +261,12 @@ pub enum Error {
     /// assert_eq!(38, Error::IncompatiblePaymentSettings as u8);
     /// ```
     IncompatiblePaymentSettings = 38,
+    /// Unexpected key variant.
+    /// ```
+    /// # use casper_types::system::handle_payment::Error;
+    /// assert_eq!(39, Error::UnexpectedKeyVariant as u8);
+    /// ```
+    UnexpectedKeyVariant = 39,
 }
 
 impl Display for Error {
@@ -335,6 +341,7 @@ impl Display for Error {
             Error::IncompatiblePaymentSettings => {
                 formatter.write_str("Incompatible payment settings")
             }
+            Error::UnexpectedKeyVariant => formatter.write_str("Unexpected key variant"),
         }
     }
 }
@@ -412,6 +419,7 @@ impl TryFrom<u8> for Error {
             v if v == Error::IncompatiblePaymentSettings as u8 => {
                 Error::IncompatiblePaymentSettings
             }
+            v if v == Error::UnexpectedKeyVariant as u8 => Error::UnexpectedKeyVariant,
             _ => return Err(()),
         };
         Ok(error)


### PR DESCRIPTION
This PR corrects the interaction between custom payment logic on a chain configured to use no fee + no refund. Under those particular settings, the prior logic placed a hold on the system _payment_ purse instead of the _payer_'s purse. The fixed logic first returns the paid amount to the refund purse and then puts a hold for that amount on that purse. 

A new test has also been added to hold down this particular combination.