### PR TITLE
Use compile-time env rather than runtime for git hash

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -77,7 +77,7 @@ pub const MAX_THREAD_COUNT: usize = 512;
 
 fn version_string(color: bool) -> String {
     let mut version = env!("CARGO_PKG_VERSION").to_string();
-    if let Ok(git_sha) = env::var("NODE_GIT_SHA") {
+    if let Some(git_sha) = option_env!("NODE_GIT_SHA") {
         version = format!("{}-{}", version, git_sha);
     } else {
         warn!(


### PR DESCRIPTION
Discovered another issue with the version string, it was retrieving `NODE_GIT_SHA` with `env::var`, so it's searching for the variable at runtime which is incorrect. This actually causes a problem, because the build script only makes the variable available at compile time. Not sure why it was using `env::var` before, but that seems wrong, since the runtime environment shouldn't affect the version we output.