### PR TITLE
Add ItemsByPrefix request

### DIFF
--- a/binary_port/src/state_request.rs
+++ b/binary_port/src/state_request.rs
@@ -5,10 +5,10 @@ use rand::Rng;
 
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    Digest, GlobalStateIdentifier, Key, KeyPrefix, KeyTag,
+    Digest, GlobalStateIdentifier, Key, KeyTag,
 };
 
-use crate::PurseIdentifier;
+use crate::{KeyPrefix, PurseIdentifier};
 
 use super::dictionary_item_identifier::DictionaryItemIdentifier;
 

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -15,7 +15,6 @@ use casper_binary_port::{
     GlobalStateRequest, InformationRequest, InformationRequestTag, KeyPrefix, NodeStatus,
     PayloadType, PurseIdentifier, ReactorStateName, RecordId, TransactionWithExecutionInfo,
 };
-use casper_storage::KeyPrefix as StorageKeyPrefix;
 use casper_storage::{
     data_access_layer::{
         balance::BalanceHandling,
@@ -25,6 +24,7 @@ use casper_storage::{
         QueryRequest, QueryResult, TrieRequest,
     },
     global_state::trie::TrieRaw,
+    KeyPrefix as StorageKeyPrefix,
 };
 use casper_types::{
     addressable_entity::NamedKeyAddr,

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -271,6 +271,8 @@ where
         KeyPrefix::ProcessingBalanceHoldsByPurse(purse) => {
             StorageKeyPrefix::ProcessingBalanceHoldsByPurse(purse)
         }
+        KeyPrefix::EntryPointsV1ByEntity(addr) => StorageKeyPrefix::EntryPointsV1ByEntity(addr),
+        KeyPrefix::EntryPointsV2ByEntity(addr) => StorageKeyPrefix::EntryPointsV2ByEntity(addr),
     };
     let request = PrefixedValuesRequest::new(state_root_hash, storage_key_prefix);
     match effect_builder.get_prefixed_values(request).await {

--- a/node/src/components/binary_port/event.rs
+++ b/node/src/components/binary_port/event.rs
@@ -54,6 +54,9 @@ impl Display for Event {
                         GlobalStateRequest::Balance { .. } => {
                             write!(f, "get balance by state root",)
                         }
+                        GlobalStateRequest::ItemsByPrefix { .. } => {
+                            write!(f, "get items by prefix")
+                        }
                     },
                 },
                 BinaryRequest::TryAcceptTransaction { transaction, .. } => {

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -321,6 +321,23 @@ impl ContractRuntime {
                 }
                 .ignore()
             }
+            ContractRuntimeRequest::QueryByPrefix {
+                request: query_request,
+                responder,
+            } => {
+                trace!(?query_request, "query by prefix");
+                let metrics = Arc::clone(&self.metrics);
+                let data_access_layer = Arc::clone(&self.data_access_layer);
+                async move {
+                    let start = Instant::now();
+
+                    let result = data_access_layer.prefixed_values(query_request);
+                    metrics.run_query.observe(start.elapsed().as_secs_f64());
+                    trace!(?result, "query by prefix result");
+                    responder.respond(result).await
+                }
+                .ignore()
+            }
             ContractRuntimeRequest::GetBalance {
                 request: balance_request,
                 responder,

--- a/node/src/components/contract_runtime/metrics.rs
+++ b/node/src/components/contract_runtime/metrics.rs
@@ -41,6 +41,9 @@ const COMMIT_UPGRADE_HELP: &str = "time in seconds to commit an upgrade";
 const RUN_QUERY_NAME: &str = "contract_runtime_run_query";
 const RUN_QUERY_HELP: &str = "time in seconds to run a query in global state";
 
+const RUN_QUERY_BY_PREFIX_NAME: &str = "contract_runtime_run_query_by_prefix";
+const RUN_QUERY_BY_PREFIX_HELP: &str = "time in seconds to run a query by prefix in global state";
+
 const COMMIT_STEP_NAME: &str = "contract_runtime_commit_step";
 const COMMIT_STEP_HELP: &str = "time in seconds to commit the step at era end";
 
@@ -105,6 +108,7 @@ pub struct Metrics {
     pub(super) commit_genesis: Histogram,
     pub(super) commit_upgrade: Histogram,
     pub(super) run_query: Histogram,
+    pub(super) run_query_by_prefix: Histogram,
     pub(super) commit_step: Histogram,
     pub(super) get_balance: Histogram,
     pub(super) get_total_supply: Histogram,
@@ -183,6 +187,12 @@ impl Metrics {
                 registry,
                 RUN_QUERY_NAME,
                 RUN_QUERY_HELP,
+                common_buckets.clone(),
+            )?,
+            run_query_by_prefix: utils::register_histogram_metric(
+                registry,
+                RUN_QUERY_BY_PREFIX_NAME,
+                RUN_QUERY_BY_PREFIX_HELP,
                 common_buckets.clone(),
             )?,
             commit_step: utils::register_histogram_metric(
@@ -281,6 +291,7 @@ impl Drop for Metrics {
         unregister_metric!(self.registry, self.commit_genesis);
         unregister_metric!(self.registry, self.commit_upgrade);
         unregister_metric!(self.registry, self.run_query);
+        unregister_metric!(self.registry, self.run_query_by_prefix);
         unregister_metric!(self.registry, self.commit_step);
         unregister_metric!(self.registry, self.get_balance);
         unregister_metric!(self.registry, self.get_total_supply);

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -120,6 +120,7 @@ use casper_binary_port::{
 use casper_storage::{
     block_store::types::ApprovalsHashes,
     data_access_layer::{
+        prefixed_values::{PrefixedValuesRequest, PrefixedValuesResult},
         tagged_values::{TaggedValuesRequest, TaggedValuesResult},
         AddressableEntityResult, BalanceRequest, BalanceResult, EraValidatorsRequest,
         EraValidatorsResult, ExecutionResultsChecksumResult, PutTrieRequest, PutTrieResult,
@@ -2103,6 +2104,20 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetTaggedValues { request, responder },
+            QueueKind::ContractRuntime,
+        )
+        .await
+    }
+
+    pub(crate) async fn get_prefixed_values(
+        self,
+        request: PrefixedValuesRequest,
+    ) -> PrefixedValuesResult
+    where
+        REv: From<ContractRuntimeRequest>,
+    {
+        self.make_request(
+            |responder| ContractRuntimeRequest::QueryByPrefix { request, responder },
             QueueKind::ContractRuntime,
         )
         .await

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -21,6 +21,7 @@ use casper_binary_port::{
 use casper_storage::{
     block_store::types::ApprovalsHashes,
     data_access_layer::{
+        prefixed_values::{PrefixedValuesRequest, PrefixedValuesResult},
         tagged_values::{TaggedValuesRequest, TaggedValuesResult},
         AddressableEntityResult, BalanceRequest, BalanceResult, EntryPointsResult,
         EraValidatorsRequest, EraValidatorsResult, ExecutionResultsChecksumResult, PutTrieRequest,
@@ -769,6 +770,14 @@ pub(crate) enum ContractRuntimeRequest {
         /// Responder to call with the query result.
         responder: Responder<QueryResult>,
     },
+    /// A query by prefix request.
+    QueryByPrefix {
+        /// Query by prefix request.
+        #[serde(skip_serializing)]
+        request: PrefixedValuesRequest,
+        /// Responder to call with the query result.
+        responder: Responder<PrefixedValuesResult>,
+    },
     /// A balance request.
     GetBalance {
         /// Balance request.
@@ -860,6 +869,9 @@ impl Display for ContractRuntimeRequest {
                 ..
             } => {
                 write!(formatter, "query request: {:?}", query_request)
+            }
+            ContractRuntimeRequest::QueryByPrefix { request, .. } => {
+                write!(formatter, "query by prefix request: {:?}", request)
             }
             ContractRuntimeRequest::GetBalance {
                 request: balance_request,

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -11,8 +11,8 @@ use casper_binary_port::{
     BinaryResponse, BinaryResponseAndRequest, ConsensusStatus, ConsensusValidatorChanges,
     DictionaryItemIdentifier, DictionaryQueryResult, ErrorCode, GetRequest, GetTrieFullResult,
     GlobalStateQueryResult, GlobalStateRequest, InformationRequest, InformationRequestTag,
-    LastProgress, NetworkName, NodeStatus, PayloadType, PurseIdentifier, ReactorStateName,
-    RecordId, Uptime,
+    KeyPrefix, LastProgress, NetworkName, NodeStatus, PayloadType, PurseIdentifier,
+    ReactorStateName, RecordId, Uptime,
 };
 use casper_storage::global_state::state::CommitProvider;
 use casper_types::{
@@ -23,8 +23,8 @@ use casper_types::{
     testing::TestRng,
     Account, AvailableBlockRange, Block, BlockHash, BlockHeader, BlockIdentifier,
     BlockSynchronizerStatus, CLValue, CLValueDictionary, ChainspecRawBytes, DictionaryAddr, Digest,
-    EntityAddr, GlobalStateIdentifier, Key, KeyPrefix, KeyTag, NextUpgrade, Peers, ProtocolVersion,
-    SecretKey, SignedBlock, StoredValue, Transaction, TransactionV1Builder, Transfer, URef, U512,
+    EntityAddr, GlobalStateIdentifier, Key, KeyTag, NextUpgrade, Peers, ProtocolVersion, SecretKey,
+    SignedBlock, StoredValue, Transaction, TransactionV1Builder, Transfer, URef, U512,
 };
 use futures::{SinkExt, StreamExt};
 use rand::Rng;

--- a/storage/src/data_access_layer.rs
+++ b/storage/src/data_access_layer.rs
@@ -23,6 +23,7 @@ pub mod handle_fee;
 mod handle_refund;
 mod key_prefix;
 pub mod mint;
+pub mod prefixed_values;
 mod protocol_upgrade;
 pub mod prune;
 pub mod query;

--- a/storage/src/data_access_layer/prefixed_values.rs
+++ b/storage/src/data_access_layer/prefixed_values.rs
@@ -1,6 +1,6 @@
 //! Support for obtaining all values with a given key prefix.
-use crate::tracking_copy::TrackingCopyError;
-use casper_types::{Digest, KeyPrefix, StoredValue};
+use crate::{tracking_copy::TrackingCopyError, KeyPrefix};
+use casper_types::{Digest, StoredValue};
 
 /// Represents a request to obtain all values with a given key prefix.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/storage/src/data_access_layer/prefixed_values.rs
+++ b/storage/src/data_access_layer/prefixed_values.rs
@@ -1,0 +1,45 @@
+//! Support for obtaining all values with a given key prefix.
+use crate::tracking_copy::TrackingCopyError;
+use casper_types::{Digest, KeyPrefix, StoredValue};
+
+/// Represents a request to obtain all values with a given key prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrefixedValuesRequest {
+    state_hash: Digest,
+    key_prefix: KeyPrefix,
+}
+
+impl PrefixedValuesRequest {
+    /// Creates new request.
+    pub fn new(state_hash: Digest, key_prefix: KeyPrefix) -> Self {
+        Self {
+            state_hash,
+            key_prefix,
+        }
+    }
+
+    /// Returns state root hash.
+    pub fn state_hash(&self) -> Digest {
+        self.state_hash
+    }
+
+    /// Returns key prefix.
+    pub fn key_prefix(&self) -> &KeyPrefix {
+        &self.key_prefix
+    }
+}
+
+/// Represents a result of a `items_by_prefix` request.
+#[derive(Debug)]
+pub enum PrefixedValuesResult {
+    /// Invalid state root hash.
+    RootNotFound,
+    /// Contains values returned from the global state.
+    Success {
+        /// The requested prefix.
+        key_prefix: KeyPrefix,
+        /// Current values.
+        values: Vec<StoredValue>,
+    },
+    Failure(TrackingCopyError),
+}

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -45,6 +45,7 @@ use crate::{
         era_validators::EraValidatorsResult,
         handle_fee::{HandleFeeMode, HandleFeeRequest, HandleFeeResult},
         mint::{TransferRequest, TransferRequestArgs, TransferResult},
+        prefixed_values::{PrefixedValuesRequest, PrefixedValuesResult},
         tagged_values::{TaggedValuesRequest, TaggedValuesResult},
         AddressableEntityRequest, AddressableEntityResult, AuctionMethod, BalanceHoldError,
         BalanceHoldKind, BalanceHoldMode, BalanceHoldRequest, BalanceHoldResult, BalanceIdentifier,
@@ -72,8 +73,7 @@ use crate::{
         },
     },
     system::{
-        auction,
-        auction::Auction,
+        auction::{self, Auction},
         genesis::{GenesisError, GenesisInstaller},
         handle_payment::HandlePayment,
         mint::Mint,
@@ -1931,6 +1931,35 @@ pub trait StateProvider {
         TaggedValuesResult::Success {
             values,
             selection: request.selection(),
+        }
+    }
+
+    fn prefixed_values(&self, request: PrefixedValuesRequest) -> PrefixedValuesResult {
+        let mut tc = match self.tracking_copy(request.state_hash()) {
+            Ok(Some(tc)) => tc,
+            Ok(None) => return PrefixedValuesResult::RootNotFound,
+            Err(err) => return PrefixedValuesResult::Failure(TrackingCopyError::Storage(err)),
+        };
+        let byte_prefix = match request.key_prefix().to_bytes() {
+            Ok(prefix) => prefix,
+            Err(error) => return PrefixedValuesResult::Failure(error.into()),
+        };
+        match tc.reader().keys_with_prefix(&byte_prefix) {
+            Ok(keys) => {
+                let mut values = Vec::with_capacity(keys.len());
+                for key in keys {
+                    match tc.get(&key) {
+                        Ok(Some(value)) => values.push(value),
+                        Ok(None) => {}
+                        Err(error) => return PrefixedValuesResult::Failure(error.into()),
+                    }
+                }
+                PrefixedValuesResult::Success {
+                    values,
+                    key_prefix: request.key_prefix().clone(),
+                }
+            }
+            Err(error) => PrefixedValuesResult::Failure(error.into()),
         }
     }
 

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -1934,6 +1934,8 @@ pub trait StateProvider {
         }
     }
 
+    /// Gets all values under a given key prefix.
+    /// Currently, this ignores the cache and only provides values from the trie.
     fn prefixed_values(&self, request: PrefixedValuesRequest) -> PrefixedValuesResult {
         let mut tc = match self.tracking_copy(request.state_hash()) {
             Ok(Some(tc)) => tc,

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -1951,7 +1951,7 @@ pub trait StateProvider {
                     match tc.get(&key) {
                         Ok(Some(value)) => values.push(value),
                         Ok(None) => {}
-                        Err(error) => return PrefixedValuesResult::Failure(error.into()),
+                        Err(error) => return PrefixedValuesResult::Failure(error),
                     }
                 }
                 PrefixedValuesResult::Success {


### PR DESCRIPTION
Adds a new global state request type to the binary port - a request for all stored values with a provided key prefix.

The code added in this PR doesn't check the tracking copy cache for mutated/pruned keys, it just directly invokes `keys_with_prefix`. I think checking the cache is unnecessary for the purpose we  use this request for (binary port), but if we do want to check the cache it's going to be tricky because the query is by a key prefix while the cache uses `BTreeMap` keyed by `Key` and `KeyTag`. The optimal cache data structure here would be a radix trie.