### PR TITLE
BlockSynchronizer: turn down log level

### DIFF
--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -1231,7 +1231,7 @@ impl BlockAcquisitionState {
             | BlockAcquisitionState::HaveStrictFinalitySignatures(_, _)
             | BlockAcquisitionState::Failed(_, _)
             | BlockAcquisitionState::Complete(..) => {
-                warn!(
+                debug!(
                     ?txn_id,
                     "BlockAcquisition: invalid attempt to register deploy for: {}",
                     self.block_hash()


### PR DESCRIPTION
Per SRE request, dialing down log level in the `register_deploy` method of the BlockSynchronizer.