### PR TITLE
Add test counter to nightly tests script

### DIFF
--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -103,6 +103,8 @@ function run_soundness_test() {
     nctl-assets-teardown
 }
 
+CASPER_NCTL_NIGHTLY_TEST_COUNT=0
+
 source "$NCTL/sh/staging/set_override_tomls.sh"
 start_run_teardown "client.sh"
 start_run_teardown "itst01.sh"
@@ -136,3 +138,6 @@ start_run_teardown "itst06.sh"
 start_run_teardown "itst06_private_chain.sh"
 start_run_teardown "itst07.sh"
 start_run_teardown "itst07_private_chain.sh"
+
+echo "All tests passed. Test count: $CASPER_NCTL_NIGHTLY_TEST_COUNT"
+unset CASPER_NCTL_NIGHTLY_TEST_COUNT

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -76,19 +76,24 @@ function start_run_teardown() {
     sleep 1
 }
 
+function run_test_and_count {
+    CASPER_NCTL_NIGHTLY_TEST_COUNT=$((CASPER_NCTL_NIGHTLY_TEST_COUNT+1))
+    eval $1
+}
+
 function run_nightly_upgrade_test() {
     # setup only needed the first time
-    bash -c "./ci/nctl_upgrade.sh test_id=4"
-    bash -c "./ci/nctl_upgrade.sh test_id=5 skip_setup=true"
-    bash -c "./ci/nctl_upgrade.sh test_id=6 skip_setup=true"
-    bash -c "./ci/nctl_upgrade.sh test_id=7 skip_setup=true"
-    bash -c "./ci/nctl_upgrade.sh test_id=8 skip_setup=true"
-    bash -c "./ci/nctl_upgrade.sh test_id=9 skip_setup=true"
-    bash -c "./ci/nctl_upgrade.sh test_id=10"
-    bash -c "./ci/nctl_upgrade.sh test_id=11"
-    bash -c "./ci/nctl_upgrade.sh test_id=12"
-    bash -c "./ci/nctl_upgrade.sh test_id=13"
-    bash -c "./ci/nctl_upgrade.sh test_id=14"
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=4"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=5 skip_setup=true"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=6 skip_setup=true"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=7 skip_setup=true"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=8 skip_setup=true"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=9 skip_setup=true"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=10"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=11"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=12"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=13"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=14"'
 }
 
 function run_soundness_test() {
@@ -106,38 +111,37 @@ function run_soundness_test() {
 CASPER_NCTL_NIGHTLY_TEST_COUNT=0
 
 source "$NCTL/sh/staging/set_override_tomls.sh"
-start_run_teardown "client.sh"
-start_run_teardown "itst01.sh"
-start_run_teardown "itst01_private_chain.sh"
-start_run_teardown "itst02.sh"
-start_run_teardown "itst02_private_chain.sh"
-start_run_teardown "itst11.sh"
-start_run_teardown "itst11_private_chain.sh"
-start_run_teardown "itst13.sh"
-start_run_teardown "itst14.sh"
-start_run_teardown "itst14_private_chain.sh"
-start_run_teardown "bond_its.sh"
-start_run_teardown "emergency_upgrade_test.sh"
-start_run_teardown "emergency_upgrade_test_balances.sh"
-start_run_teardown "upgrade_after_emergency_upgrade_test.sh"
-start_run_teardown "sync_test.sh timeout=500"
-start_run_teardown "swap_validator_set.sh"
-start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"
-start_run_teardown "validators_disconnect.sh"
-start_run_teardown "event_stream.sh"
+run_test_and_count 'start_run_teardown "client.sh"'
+run_test_and_count 'start_run_teardown "itst01.sh"'
+run_test_and_count 'start_run_teardown "itst01_private_chain.sh"'
+run_test_and_count 'start_run_teardown "itst02.sh"'
+run_test_and_count 'start_run_teardown "itst02_private_chain.sh"'
+run_test_and_count 'start_run_teardown "itst11.sh"'
+run_test_and_count 'start_run_teardown "itst11_private_chain.sh"'
+run_test_and_count 'start_run_teardown "itst13.sh"'
+run_test_and_count 'start_run_teardown "itst14.sh"'
+run_test_and_count 'start_run_teardown "itst14_private_chain.sh"'
+run_test_and_count 'start_run_teardown "bond_its.sh"'
+run_test_and_count 'start_run_teardown "emergency_upgrade_test.sh"'
+run_test_and_count 'start_run_teardown "emergency_upgrade_test_balances.sh"'
+run_test_and_count 'start_run_teardown "upgrade_after_emergency_upgrade_test.sh"'
+run_test_and_count 'start_run_teardown "sync_test.sh timeout=500"'
+run_test_and_count 'start_run_teardown "swap_validator_set.sh"'
+run_test_and_count 'start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"'
+run_test_and_count 'start_run_teardown "validators_disconnect.sh"'
+run_test_and_count 'start_run_teardown "event_stream.sh"'
 # Without start_run_teardown - these ones perform their own assets setup, network start and teardown
-source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"
-source "$SCENARIOS_DIR/regression_3976.sh"
+run_test_and_count 'source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"'
+run_test_and_count 'source "$SCENARIOS_DIR/regression_3976.sh"'
 
 run_nightly_upgrade_test
 
-run_soundness_test
+run_test_and_count 'run_soundness_test'
 
 # Run these last as they occasionally fail (see https://github.com/casper-network/casper-node/issues/2973)
-start_run_teardown "itst06.sh"
-start_run_teardown "itst06_private_chain.sh"
-start_run_teardown "itst07.sh"
-start_run_teardown "itst07_private_chain.sh"
+run_test_and_count 'start_run_teardown "itst06.sh"'
+run_test_and_count 'start_run_teardown "itst06_private_chain.sh"'
+run_test_and_count 'start_run_teardown "itst07.sh"'
+run_test_and_count 'start_run_teardown "itst07_private_chain.sh"'
 
 echo "All tests passed. Test count: $CASPER_NCTL_NIGHTLY_TEST_COUNT"
-unset CASPER_NCTL_NIGHTLY_TEST_COUNT


### PR DESCRIPTION
This PR adds the counter for NCTL nightly tests.

If all tests finish successfully a summary line is printed at the end:

`All tests passed. Test count: 4`