### PR TITLE
Fix stalled block synchronizer test

### DIFF
--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -158,7 +158,7 @@ impl TestEnv {
     }
 
     fn random(rng: &mut TestRng) -> TestEnv {
-        let num_validators: usize = rng.gen_range(3..100);
+        let num_validators: usize = rng.gen_range(10..100);
         let validator_keys: Vec<_> = iter::repeat_with(|| Arc::new(SecretKey::random(rng)))
             .take(num_validators)
             .collect();

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -3687,7 +3687,7 @@ async fn fwd_sync_latch_should_not_decrement_for_old_responses() {
         );
     }
 
-    // Receive a deploy. This would make the synchonizer switch to HaveAllDeploys and continue
+    // Receive a deploy. This would make the synchronizer switch to HaveAllDeploys and continue
     // asking for more finality signatures in order to reach strict finality.
     {
         let effects = block_synchronizer.handle_event(


### PR DESCRIPTION
The problem turned out to be caused by the edge case in test setup, not the node code itself.

The test expects that after getting all deploys, the node switches back to fetching the finality signatures in order to reach the strict finality. However, with the provided random seed, the test environment was set up in a way that there were only six validators in the network and the strict finality was achieved earlier in the flow, changing the order of events.

Since the test is not testing the actual state transitions, but just the latching mechanism, the simplest fix is to prevent the unexpected flow from happening in this test.

Fixes https://github.com/casper-network/casper-node/issues/4503