### PR TITLE
Fix a bug in bid adjustment in global-state-update-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit
+	$(CARGO) audit --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0019 --ignore RUSTSEC-2023-0072 --ignore RUSTSEC-2023-0045 --ignore RUSTSEC-2022-0092 --ignore RUSTSEC-2022-0054 --ignore RUSTSEC-2022-0041 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2021-0127 --ignore RUSTSEC-2020-0168
 
 .PHONY: audit-as
 audit-as:

--- a/utils/global-state-update-gen/src/generic/state_reader.rs
+++ b/utils/global-state-update-gen/src/generic/state_reader.rs
@@ -109,8 +109,17 @@ impl StateReader for LmdbWasmTestBuilder {
         // Find the hash of the auction contract.
         let auction_contract_hash = self.get_system_auction_hash();
 
-        self.get_contract(auction_contract_hash)
+        let unbonding_delay_key = self
+            .get_contract(auction_contract_hash)
             .expect("auction should exist")
-            .named_keys()[UNBONDING_DELAY_KEY]
+            .named_keys()[UNBONDING_DELAY_KEY];
+
+        self.query(unbonding_delay_key)
+            .expect("should query")
+            .as_cl_value()
+            .cloned()
+            .expect("should be cl value")
+            .into_t()
+            .expect("should be u64")
     }
 }

--- a/utils/global-state-update-gen/src/generic/state_reader.rs
+++ b/utils/global-state-update-gen/src/generic/state_reader.rs
@@ -2,7 +2,10 @@ use casper_engine_test_support::LmdbWasmTestBuilder;
 use casper_types::{
     account::{Account, AccountHash},
     system::{
-        auction::{Bids, UnbondingPurses, WithdrawPurses, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY},
+        auction::{
+            Bids, UnbondingPurses, WithdrawPurses, SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
+            UNBONDING_DELAY_KEY,
+        },
         mint::TOTAL_SUPPLY_KEY,
     },
     Key, StoredValue,
@@ -22,6 +25,8 @@ pub trait StateReader {
     fn get_withdraws(&mut self) -> WithdrawPurses;
 
     fn get_unbonds(&mut self) -> UnbondingPurses;
+
+    fn get_unbonding_delay(&mut self) -> u64;
 }
 
 impl<'a, T> StateReader for &'a mut T
@@ -54,6 +59,10 @@ where
 
     fn get_unbonds(&mut self) -> UnbondingPurses {
         T::get_unbonds(self)
+    }
+
+    fn get_unbonding_delay(&mut self) -> u64 {
+        T::get_unbonding_delay(self)
     }
 }
 
@@ -94,5 +103,14 @@ impl StateReader for LmdbWasmTestBuilder {
 
     fn get_unbonds(&mut self) -> UnbondingPurses {
         LmdbWasmTestBuilder::get_unbonds(self)
+    }
+
+    fn get_unbonding_delay(&mut self) -> u64 {
+        // Find the hash of the auction contract.
+        let auction_contract_hash = self.get_system_auction_hash();
+
+        self.get_contract(auction_contract_hash)
+            .expect("auction should exist")
+            .named_keys()[UNBONDING_DELAY_KEY]
     }
 }

--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -302,7 +302,7 @@ impl<T: StateReader> StateTracker<T> {
         for (delegator_public_key, delegator) in bid.delegators() {
             let old_amount = self.get_purse_balance(*delegator.bonding_purse());
             let already_unbonded =
-                self.already_unbonding_amount(&account_hash, &delegator_public_key);
+                self.already_unbonding_amount(&account_hash, delegator_public_key);
             let new_amount = *delegator.staked_amount() + already_unbonded;
             if (slash && new_amount != old_amount) || new_amount > old_amount {
                 self.set_purse_balance(*delegator.bonding_purse(), new_amount);
@@ -319,7 +319,7 @@ impl<T: StateReader> StateTracker<T> {
 
     /// Returns the sum of already unbonding purses for the given validator account & unbonder.
     fn already_unbonding_amount(&mut self, account: &AccountHash, unbonder: &PublicKey) -> U512 {
-        let current_era = self.read_snapshot().1.keys().next().unwrap();
+        let current_era = *self.read_snapshot().1.keys().next().unwrap();
         let unbonding_delay = self.reader.get_unbonding_delay();
         let limit_era = current_era.saturating_sub(unbonding_delay);
 

--- a/utils/global-state-update-gen/src/generic/testing.rs
+++ b/utils/global-state-update-gen/src/generic/testing.rs
@@ -270,6 +270,10 @@ impl StateReader for MockStateReader {
     fn get_unbonds(&mut self) -> UnbondingPurses {
         self.unbonds.clone()
     }
+
+    fn get_unbonding_delay(&mut self) -> u64 {
+        7
+    }
 }
 
 impl ValidatorInfo {


### PR DESCRIPTION
This fixes a bug in which stray `Withdraw` entries in the global state could throw off the calculations of target amounts in bonding purses.

It also fixes an unrelated bug where the target amounts could be calculated incorrectly for validators being in the middle of unbonding.