### PR TITLE
Efficient byte prefix queries for tracking copy cache

### DIFF
--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -1942,11 +1942,7 @@ pub trait StateProvider {
             Ok(None) => return PrefixedValuesResult::RootNotFound,
             Err(err) => return PrefixedValuesResult::Failure(TrackingCopyError::Storage(err)),
         };
-        let byte_prefix = match request.key_prefix().to_bytes() {
-            Ok(prefix) => prefix,
-            Err(error) => return PrefixedValuesResult::Failure(error.into()),
-        };
-        match tc.reader().keys_with_prefix(&byte_prefix) {
+        match tc.get_keys_by_prefix(request.key_prefix()) {
             Ok(keys) => {
                 let mut values = Vec::with_capacity(keys.len());
                 for key in keys {
@@ -1961,7 +1957,7 @@ pub trait StateProvider {
                     key_prefix: request.key_prefix().clone(),
                 }
             }
-            Err(error) => PrefixedValuesResult::Failure(error.into()),
+            Err(error) => PrefixedValuesResult::Failure(error),
         }
     }
 

--- a/storage/src/tracking_copy/ext.rs
+++ b/storage/src/tracking_copy/ext.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    collections::{btree_map::Entry, BTreeMap},
     convert::TryInto,
 };
 use tracing::{error, warn};
@@ -25,9 +25,8 @@ use casper_types::{
         MINT,
     },
     BlockGlobalAddr, BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash, CLValue, ChecksumRegistry,
-    EntityAddr, EntryPointAddr, EntryPointValue, EntryPoints, HoldBalanceHandling, HoldsEpoch, Key,
-    KeyTag, Motes, Package, PackageHash, StoredValue, StoredValueTypeMismatch,
-    SystemEntityRegistry, URef, URefAddr, U512,
+    EntityAddr, EntryPointValue, EntryPoints, HoldBalanceHandling, HoldsEpoch, Key, Motes, Package,
+    PackageHash, StoredValue, StoredValueTypeMismatch, SystemEntityRegistry, URef, URefAddr, U512,
 };
 
 /// Higher-level operations on the state via a `TrackingCopy`.
@@ -549,38 +548,11 @@ where
     }
 
     fn get_named_keys(&self, entity_addr: EntityAddr) -> Result<NamedKeys, Self::Error> {
-        let prefix = KeyPrefix::NamedKeysByEntity(entity_addr)
-            .to_bytes()
-            .map_err(Self::Error::BytesRepr)?;
-
-        let mut ret: BTreeSet<Key> = BTreeSet::new();
-        let keys = self.reader.keys_with_prefix(&prefix)?;
-        let pruned = &self.cache.prunes_cached;
-        // don't include keys marked for pruning
-        for key in keys {
-            if pruned.contains(&key) {
-                continue;
-            }
-            ret.insert(key);
-        }
-
-        let cache = self.cache.get_key_tag_muts_cached(&KeyTag::NamedKey);
-
-        // there may be newly inserted keys which have not been committed yet
-        if let Some(keys) = cache {
-            for key in keys {
-                if ret.contains(&key) {
-                    continue;
-                }
-                if key.is_entry_for_base(&entity_addr) {
-                    ret.insert(key);
-                }
-            }
-        }
+        let keys = self.get_keys_by_prefix(&KeyPrefix::NamedKeysByEntity(entity_addr))?;
 
         let mut named_keys = NamedKeys::new();
 
-        for entry_key in ret.iter() {
+        for entry_key in &keys {
             match self.read(entry_key)? {
                 Some(StoredValue::NamedKey(named_key)) => {
                     let key = named_key.get_key().map_err(TrackingCopyError::CLValue)?;
@@ -613,43 +585,11 @@ where
     }
 
     fn get_v1_entry_points(&mut self, entity_addr: EntityAddr) -> Result<EntryPoints, Self::Error> {
-        let entry_points_prefix = KeyPrefix::EntryPointsV1ByEntity(entity_addr)
-            .to_bytes()
-            .map_err(Self::Error::BytesRepr)?;
-
-        let mut ret: BTreeSet<Key> = BTreeSet::new();
-        let keys = self.reader.keys_with_prefix(&entry_points_prefix)?;
-        let pruned = &self.cache.prunes_cached;
-        // don't include keys marked for pruning
-        for key in keys {
-            if pruned.contains(&key) {
-                continue;
-            }
-            ret.insert(key);
-        }
-
-        let cache = self.cache.get_key_tag_muts_cached(&KeyTag::EntryPoint);
-
-        // there may be newly inserted keys which have not been committed yet
-        if let Some(keys) = cache {
-            for key in keys {
-                if ret.contains(&key) {
-                    continue;
-                }
-                if let Key::EntryPoint(entry_point_addr) = key {
-                    match entry_point_addr {
-                        EntryPointAddr::VmCasperV1 { .. } => {
-                            ret.insert(key);
-                        }
-                        EntryPointAddr::VmCasperV2 { .. } => continue,
-                    }
-                }
-            }
-        };
+        let keys = self.get_keys_by_prefix(&KeyPrefix::EntryPointsV1ByEntity(entity_addr))?;
 
         let mut entry_points_v1 = EntryPoints::new();
 
-        for entry_point_key in ret.iter() {
+        for entry_point_key in keys.iter() {
             match self.read(entry_point_key)? {
                 Some(StoredValue::EntryPoint(EntryPointValue::V1CasperVm(entry_point))) => {
                     entry_points_v1.add_entry_point(entry_point)

--- a/storage/src/tracking_copy/ext.rs
+++ b/storage/src/tracking_copy/ext.rs
@@ -26,9 +26,9 @@ use casper_types::{
         MINT,
     },
     BlockGlobalAddr, BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash, CLValue, ChecksumRegistry,
-    Contract, EntityAddr, EntryPointAddr, EntryPointValue, EntryPoints, HoldBalanceHandling,
-    HoldsEpoch, Key, KeyTag, Motes, Package, PackageHash, StoredValue, StoredValueTypeMismatch,
-    SystemEntityRegistry, URef, URefAddr, U512,
+    Contract, EntityAddr, EntryPointValue, EntryPoints, HoldBalanceHandling, HoldsEpoch, Key,
+    Motes, Package, PackageHash, StoredValue, StoredValueTypeMismatch, SystemEntityRegistry, URef,
+    URefAddr, U512,
 };
 
 /// Higher-level operations on the state via a `TrackingCopy`.

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -226,7 +226,7 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
 
     /// Gets value from `key` in the cache.
     pub fn get(&mut self, key: &Key) -> Option<&StoredValue> {
-        if self.prunes_cached.get(&key).is_some() {
+        if self.prunes_cached.get(key).is_some() {
             // the item is marked for pruning and therefore
             // is no longer accessible.
             return None;
@@ -247,16 +247,8 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
             .collect()
     }
 
-    pub fn get_muts_cached_by_key_tag(&self, key_tag: &KeyTag) -> Vec<Key> {
-        self.get_muts_cached_by_byte_prefix(&[*key_tag as u8])
-    }
-
-    pub fn get_muts_cached_by_key_prefix(&self, key_prefix: &KeyPrefix) -> Vec<Key> {
-        self.get_muts_cached_by_byte_prefix(&key_prefix.to_bytes().unwrap())
-    }
-
     pub fn is_pruned(&self, key: &Key) -> bool {
-        self.prunes_cached.contains(&key)
+        self.prunes_cached.contains(key)
     }
 }
 

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -254,7 +254,7 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
 
 /// A helper type for `TrackingCopyCache` that allows convenient storage and access
 /// to keys as bytes.
-/// It's equality and ordering is based on the byte representation of the key.
+/// Its equality and ordering is based on the byte representation of the key.
 struct KeyWithByteRepr(Key, Vec<u8>);
 
 impl KeyWithByteRepr {

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -10,25 +10,29 @@ pub(self) mod meter;
 mod tests;
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    borrow::Borrow,
+    collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
     convert::{From, TryInto},
 };
 
 use linked_hash_map::LinkedHashMap;
 use thiserror::Error;
 
-use crate::global_state::{
-    error::Error as GlobalStateError, state::StateReader,
-    trie_store::operations::compute_state_hash, DEFAULT_MAX_QUERY_DEPTH,
+use crate::{
+    global_state::{
+        error::Error as GlobalStateError, state::StateReader,
+        trie_store::operations::compute_state_hash, DEFAULT_MAX_QUERY_DEPTH,
+    },
+    KeyPrefix,
 };
 use casper_types::{
     addressable_entity::{NamedKeyAddr, NamedKeys},
-    bytesrepr,
+    bytesrepr::{self, ToBytes},
     contract_messages::{Message, Messages},
     execution::{Effects, TransformError, TransformInstruction, TransformKindV2, TransformV2},
     global_state::TrieMerkleProof,
     handle_stored_dictionary_value, BlockGlobalAddr, CLType, CLValue, CLValueError, Digest, Key,
-    KeyTag, StoredValue, StoredValueTypeMismatch, Tagged, U512,
+    KeyTag, StoredValue, StoredValueTypeMismatch, U512,
 };
 
 use self::meter::{heap_meter::HeapSize, Meter};
@@ -171,9 +175,8 @@ pub struct TrackingCopyCache<M> {
     max_cache_size: usize,
     current_cache_size: usize,
     reads_cached: LinkedHashMap<Key, StoredValue>,
-    muts_cached: HashMap<Key, StoredValue>,
-    prunes_cached: HashSet<Key>,
-    key_tag_muts_cached: HashMap<KeyTag, BTreeSet<Key>>,
+    muts_cached: BTreeMap<KeyWithByteRepr, StoredValue>,
+    prunes_cached: BTreeSet<KeyWithByteRepr>,
     meter: M,
 }
 
@@ -187,9 +190,8 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
             max_cache_size,
             current_cache_size: 0,
             reads_cached: LinkedHashMap::new(),
-            muts_cached: HashMap::new(),
-            key_tag_muts_cached: HashMap::new(),
-            prunes_cached: HashSet::new(),
+            muts_cached: BTreeMap::new(),
+            prunes_cached: BTreeSet::new(),
             meter,
         }
     }
@@ -212,50 +214,102 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
 
     /// Inserts `key` and `value` pair to Write/Add cache.
     pub fn insert_write(&mut self, key: Key, value: StoredValue) {
-        self.prunes_cached.remove(&key);
-        self.muts_cached.insert(key, value);
-
-        let key_set = self
-            .key_tag_muts_cached
-            .entry(key.tag())
-            .or_insert_with(BTreeSet::new);
-
-        key_set.insert(key);
+        let kb = KeyWithByteRepr::new(key);
+        self.prunes_cached.remove(&kb);
+        self.muts_cached.insert(kb, value);
     }
 
     /// Inserts `key` and `value` pair to Write/Add cache.
     pub fn insert_prune(&mut self, key: Key) {
-        self.prunes_cached.insert(key);
+        self.prunes_cached.insert(KeyWithByteRepr::new(key));
     }
 
     /// Gets value from `key` in the cache.
     pub fn get(&mut self, key: &Key) -> Option<&StoredValue> {
-        if self.prunes_cached.get(key).is_some() {
+        let kb = KeyWithByteRepr::new(*key);
+        if self.prunes_cached.get(&kb).is_some() {
             // the item is marked for pruning and therefore
             // is no longer accessible.
             return None;
         }
-        if let Some(value) = self.muts_cached.get(key) {
+        if let Some(value) = self.muts_cached.get(&kb) {
             return Some(value);
         };
 
         self.reads_cached.get_refresh(key).map(|v| &*v)
     }
 
-    /// Gets the set of mutated keys in the cache by `KeyTag`.
-    pub fn get_key_tag_muts_cached(&self, key_tag: &KeyTag) -> Option<BTreeSet<Key>> {
-        let pruned = &self.prunes_cached;
-        if let Some(keys) = self.key_tag_muts_cached.get(key_tag) {
-            let mut ret = BTreeSet::new();
-            for key in keys {
-                if !pruned.contains(key) {
-                    ret.insert(*key);
-                }
-            }
-            Some(ret)
-        } else {
-            None
-        }
+    fn get_muts_cached_by_byte_prefix(&self, prefix: &[u8]) -> Vec<Key> {
+        self.muts_cached
+            .range(prefix.to_vec()..)
+            .take_while(|(key, _)| key.starts_with(prefix))
+            .map(|(key, _)| key.to_key())
+            .collect()
+    }
+
+    pub fn get_muts_cached_by_key_tag(&self, key_tag: &KeyTag) -> Vec<Key> {
+        self.get_muts_cached_by_byte_prefix(&[*key_tag as u8])
+    }
+
+    pub fn get_muts_cached_by_key_prefix(&self, key_prefix: &KeyPrefix) -> Vec<Key> {
+        self.get_muts_cached_by_byte_prefix(&key_prefix.to_bytes().unwrap())
+    }
+
+    pub fn is_pruned(&self, key: &Key) -> bool {
+        self.prunes_cached.contains(&KeyWithByteRepr::new(*key))
+    }
+}
+
+/// A helper type for `TrackingCopyCache` that allows convenient storage and access
+/// to keys as bytes.
+/// It's equality and ordering is based on the byte representation of the key.
+struct KeyWithByteRepr(Key, Vec<u8>);
+
+impl KeyWithByteRepr {
+    #[inline]
+    fn new(key: Key) -> Self {
+        let bytes = key.to_bytes().expect("should always serialize a Key");
+        KeyWithByteRepr(key, bytes)
+    }
+
+    #[inline]
+    fn starts_with(&self, prefix: &[u8]) -> bool {
+        self.1.starts_with(prefix)
+    }
+
+    #[inline]
+    fn to_key(&self) -> Key {
+        self.0
+    }
+}
+
+impl Borrow<Vec<u8>> for KeyWithByteRepr {
+    #[inline]
+    fn borrow(&self) -> &Vec<u8> {
+        &self.1
+    }
+}
+
+impl PartialEq for KeyWithByteRepr {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.1 == other.1
+    }
+}
+
+impl Eq for KeyWithByteRepr {}
+
+impl PartialOrd for KeyWithByteRepr {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for KeyWithByteRepr {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.1.cmp(&other.1)
     }
 }
 
@@ -358,29 +412,34 @@ where
     }
 
     /// Gets the set of keys in the state whose tag is `key_tag`.
-    pub fn get_keys(&mut self, key_tag: &KeyTag) -> Result<BTreeSet<Key>, TrackingCopyError> {
-        let mut ret: BTreeSet<Key> = BTreeSet::new();
-        let keys = match self.reader.keys_with_prefix(&[*key_tag as u8]) {
+    pub fn get_keys(&self, key_tag: &KeyTag) -> Result<BTreeSet<Key>, TrackingCopyError> {
+        self.get_by_byte_prefix(&[*key_tag as u8])
+    }
+
+    pub fn get_keys_by_prefix(
+        &self,
+        key_prefix: &KeyPrefix,
+    ) -> Result<BTreeSet<Key>, TrackingCopyError> {
+        let byte_prefix = key_prefix
+            .to_bytes()
+            .map_err(TrackingCopyError::BytesRepr)?;
+        self.get_by_byte_prefix(&byte_prefix)
+    }
+
+    /// Gets the set of keys in the state by a byte prefix.
+    fn get_by_byte_prefix(&self, byte_prefix: &[u8]) -> Result<BTreeSet<Key>, TrackingCopyError> {
+        let keys = match self.reader.keys_with_prefix(byte_prefix) {
             Ok(ret) => ret,
             Err(err) => return Err(TrackingCopyError::Storage(err)),
         };
-        let pruned = &self.cache.prunes_cached;
-        // don't include keys marked for pruning
-        for key in keys {
-            if pruned.contains(&key) {
-                continue;
-            }
-            ret.insert(key);
-        }
-        // there may be newly inserted keys which have not been committed yet
-        if let Some(keys) = self.cache.get_key_tag_muts_cached(key_tag) {
-            for key in keys {
-                if ret.contains(&key) {
-                    continue;
-                }
-                ret.insert(key);
-            }
-        }
+
+        let ret = keys
+            .into_iter()
+            // don't include keys marked for pruning
+            .filter(|key| !self.cache.is_pruned(key))
+            // there may be newly inserted keys which have not been committed yet
+            .chain(self.cache.get_muts_cached_by_byte_prefix(byte_prefix))
+            .collect();
         Ok(ret)
     }
 
@@ -722,7 +781,8 @@ impl<R: StateReader<Key, StoredValue>> StateReader<Key, StoredValue> for &Tracki
     type Error = R::Error;
 
     fn read(&self, key: &Key) -> Result<Option<StoredValue>, Self::Error> {
-        if let Some(value) = self.cache.muts_cached.get(key) {
+        let kb = KeyWithByteRepr::new(*key);
+        if let Some(value) = self.cache.muts_cached.get(&kb) {
             return Ok(Some(value.to_owned()));
         }
         if let Some(value) = self.reader.read(key)? {

--- a/storage/src/tracking_copy/tests.rs
+++ b/storage/src/tracking_copy/tests.rs
@@ -899,7 +899,7 @@ fn get_keys_should_return_keys_in_the_account_keyspace() {
         .expect("should checkout")
         .expect("should have view");
 
-    let mut tracking_copy = TrackingCopy::new(view, DEFAULT_MAX_QUERY_DEPTH);
+    let tracking_copy = TrackingCopy::new(view, DEFAULT_MAX_QUERY_DEPTH);
 
     let key_set = tracking_copy.get_keys(&KeyTag::Account).unwrap();
 


### PR DESCRIPTION
What this PR does:
- replaces the current way of querying the tracking copy cache
  - our current method requires iterating over potentially very large sets (for example iterating over all named keys in the cache when looking up named keys for a single entity in `TrackingCopyExt::get_named_keys`) and duplicates some data due to use of multiple collections for the same keys in the cache
  - the new method uses a `BTreeMap` keyed by a pair of a key and its byte representation, which is then queried using byte prefixes of keys passed to `BTreeMap::range` to select only the keys we're interested in, which should offer a big performance improvement
- removes some repetetive code in `get_named_keys` and `get_v1_entry_points`, replaces it with calls to a new unified `get_keys_by_prefix` method
- fixes `prefixed_values` to now properly check the cache

Caveats:
- there's a single `expect` in the code that assumes that our `ToBytes` for `Key` shouldn't fail, and seemingly it shouldn't because it doesn't check for allocation errors and all keys are representable