### PR TITLE
Fix named key retrieval for system entities in WasmTestBuilder

### DIFF
--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -1381,7 +1381,7 @@ where
     ) -> Option<EntityWithNamedKeys> {
         match self.get_addressable_entity(entity_hash) {
             Some(entity) => {
-                let named_keys = self.get_named_keys_by_contract_entity_hash(entity_hash);
+                let named_keys = self.get_named_keys(entity.entity_addr(entity_hash));
                 Some(EntityWithNamedKeys::new(entity, named_keys))
             }
             None => None,
@@ -1543,15 +1543,6 @@ where
             .get_entity_hash_by_account_hash(account_hash)
             .expect("must have entity hash");
         let entity_addr = EntityAddr::new_account(entity_hash.value());
-        self.get_named_keys(entity_addr)
-    }
-
-    /// Returns named keys for an account entity by its entity hash.
-    pub fn get_named_keys_by_contract_entity_hash(
-        &self,
-        contract_hash: AddressableEntityHash,
-    ) -> NamedKeys {
-        let entity_addr = EntityAddr::new_smart_contract(contract_hash.value());
         self.get_named_keys(entity_addr)
     }
 

--- a/execution_engine_testing/tests/src/test/contract_api/dictionary.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/dictionary.rs
@@ -311,9 +311,12 @@ fn should_write_with_write_access_rights() {
 
     builder.exec(call_request).commit();
 
-    let contract_named_keys = builder.get_named_keys_by_contract_entity_hash(contract_hash);
+    let contract = builder
+        .get_entity_with_named_keys_by_entity_hash(contract_hash)
+        .expect("should have account");
 
-    let stored_dictionary_key = contract_named_keys
+    let stored_dictionary_key = contract
+        .named_keys()
         .get(dictionary::DICTIONARY_NAME)
         .expect("dictionary");
     let dictionary_root_uref = stored_dictionary_key.into_uref().expect("should be uref");

--- a/utils/global-state-update-gen/src/admins.rs
+++ b/utils/global-state-update-gen/src/admins.rs
@@ -2,7 +2,8 @@ use casper_engine_test_support::LmdbWasmTestBuilder;
 use casper_execution_engine::engine_state::engine_config::DEFAULT_PROTOCOL_VERSION;
 use casper_types::{
     account::Account, addressable_entity::NamedKeys, bytesrepr::ToBytes, system::mint,
-    AccessRights, AsymmetricType, CLTyped, CLValue, Key, PublicKey, StoredValue, URef, U512,
+    AccessRights, AsymmetricType, CLTyped, CLValue, EntityAddr, Key, PublicKey, StoredValue, URef,
+    U512,
 };
 use clap::ArgMatches;
 use rand::Rng;
@@ -86,7 +87,7 @@ pub(crate) fn generate_admins(matches: &ArgMatches<'_>) {
         let mint_contract_hash = test_builder.get_mint_contract_hash();
 
         let mint_named_keys =
-            test_builder.get_named_keys_by_contract_entity_hash(mint_contract_hash);
+            test_builder.get_named_keys(EntityAddr::new_system(mint_contract_hash.value()));
 
         mint_named_keys
             .get(mint::TOTAL_SUPPLY_KEY)


### PR DESCRIPTION
`get_named_keys_by_contract_entity_hash` is used to look up mint named keys, but it doesn't support retrieving system and account named keys (it's hardcoded to search for smart contract named keys), which broke emergency upgrades in NCTL tests

I've deleted the method to avoid confusion and replaced the calls to it with calls to different methods
