### PR TITLE
Change the unbonding process to only prune bids after unbonding is processed

### DIFF
--- a/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
@@ -439,8 +439,10 @@ fn regression_20210831_should_fail_to_activate_bid() {
     builder.exec(withdraw_bid_request).expect_success().commit();
 
     let bids = builder.get_bids();
-    let bid = bids.validator_bid(&DEFAULT_ACCOUNT_PUBLIC_KEY);
-    assert!(bid.is_none());
+    let bid = bids
+        .validator_bid(&DEFAULT_ACCOUNT_PUBLIC_KEY)
+        .expect("should have zero bid");
+    assert!(bid.staked_amount().is_zero());
 
     let sender = *ACCOUNT_2_ADDR;
     let activate_bid_args = runtime_args! {
@@ -466,7 +468,6 @@ fn regression_20210831_should_fail_to_activate_bid() {
         error_1
     );
 
-    // ACCOUNT_2 unbonds ACCOUNT_1 through a proxy
     let activate_bid_request_2 = ExecuteRequestBuilder::contract_call_by_name(
         sender,
         CONTRACT_HASH_NAME,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -1624,7 +1624,11 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         .expect_success();
 
     let bids_after = builder.get_bids();
-    assert!(bids_after.validator_bid(&VALIDATOR_1).is_none());
+    assert!(bids_after
+        .validator_bid(&VALIDATOR_1)
+        .expect("should still have zero bid")
+        .staked_amount()
+        .is_zero());
 
     let unbonding_purses_after: UnbondingPurses = builder.get_unbonds();
     assert_ne!(unbonding_purses_after, unbonding_purses_before);
@@ -1827,7 +1831,11 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         .expect_success();
 
     let bids_after = builder.get_bids();
-    assert!(bids_after.validator_bid(&VALIDATOR_1).is_none());
+    assert!(bids_after
+        .validator_bid(&VALIDATOR_1)
+        .expect("should still have zero bid")
+        .staked_amount()
+        .is_zero());
 
     let unbonding_purses_before: UnbondingPurses = builder.get_unbonds();
 
@@ -1885,6 +1893,9 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         builder.run_auction(timestamp_millis, Vec::new());
         timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
     }
+
+    let bids_after_2 = builder.get_bids();
+    assert!(bids_after_2.validator_bid(&VALIDATOR_1).is_none());
 
     let validator_1_balance_after = builder.get_purse_balance(validator_1.main_purse());
     let delegator_1_balance_after = builder.get_purse_balance(delegator_1.main_purse());
@@ -3871,6 +3882,9 @@ fn should_enforce_max_delegators_per_validator_cap() {
         .len();
 
     assert_eq!(current_delegator_count, 1);
+
+    // Make the undelegation go through and remove the bid completely.
+    builder.advance_eras_by(DEFAULT_UNBONDING_DELAY + 1);
 
     let delegation_request_3 = ExecuteRequestBuilder::standard(
         *DELEGATOR_1_ADDR,

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -711,13 +711,18 @@ impl TestFixture {
         self.try_run_until(
             move |nodes: &Nodes| {
                 nodes.values().all(|runner| {
+                    let available_block_range =
+                        runner.main_reactor().storage().get_available_block_range();
                     runner
                         .main_reactor()
                         .storage()
                         .read_highest_switch_block_headers(1)
                         .unwrap()
                         .last()
-                        .map_or(false, |header| header.era_id() == era_id)
+                        .map_or(false, |header| {
+                            header.era_id() == era_id
+                                && available_block_range.contains(header.height())
+                        })
                 })
             },
             within,
@@ -817,8 +822,10 @@ impl TestFixture {
         let highest_block = runner
             .main_reactor()
             .storage
-            .read_highest_block()
-            .expect("should have block");
+            .read_highest_signed_block(true)
+            .expect("should have block")
+            .into_inner()
+            .0;
         let bids_request = BidsRequest::new(*highest_block.state_root_hash());
         let bids_result = runner
             .main_reactor()
@@ -844,7 +851,7 @@ impl TestFixture {
                 }
             }
         } else {
-            panic!("network should have bids");
+            panic!("network should have bids: {:?}", bids_result);
         }
     }
 
@@ -1773,7 +1780,16 @@ async fn run_withdraw_bid_network() {
     let alice_stake = 200_000_000_000_u64;
     let initial_stakes = InitialStakes::FromVec(vec![alice_stake.into(), 10_000_000_000]);
 
-    let mut fixture = TestFixture::new(initial_stakes, None).await;
+    let unbonding_delay = 2;
+
+    let mut fixture = TestFixture::new(
+        initial_stakes,
+        Some(ConfigsOverride {
+            unbonding_delay,
+            ..Default::default()
+        }),
+    )
+    .await;
     let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
     let alice_public_key = PublicKey::from(&*alice_secret_key);
 
@@ -1802,21 +1818,36 @@ async fn run_withdraw_bid_network() {
         .run_until_executed_transaction(&txn_hash, TEN_SECS)
         .await;
 
-    // Ensure execution succeeded and that there is a Prune transform for the bid's key.
+    // Ensure execution succeeded and that there is a Write transform for the bid's key.
     let bid_key = Key::BidAddr(BidAddr::from(alice_public_key.clone()));
     fixture
         .successful_execution_transforms(&txn_hash)
         .iter()
         .find(|transform| match transform.kind() {
-            TransformKindV2::Prune(prune_key) => prune_key == &bid_key,
+            TransformKindV2::Write(StoredValue::BidKind(bid_kind)) => {
+                Key::from(bid_kind.bid_addr()) == bid_key
+            }
             _ => false,
         })
-        .expect("should have a prune record for bid");
+        .expect("should have a write record for bid");
 
     // Crank the network forward until the era ends.
     fixture
         .run_until_stored_switch_block_header(ERA_ONE, ONE_MIN)
         .await;
+
+    // The bid record should still exist for now.
+    fixture.check_bid_existence_at_tip(&alice_public_key, None, true);
+
+    // Crank the network forward until the unbonds are processed.
+    fixture
+        .run_until_stored_switch_block_header(
+            ERA_ONE.saturating_add(unbonding_delay + 1),
+            ONE_MIN * 2,
+        )
+        .await;
+
+    // The bid record should have been pruned once unbonding ran.
     fixture.check_bid_existence_at_tip(&alice_public_key, None, false);
 }
 
@@ -1826,7 +1857,16 @@ async fn run_undelegate_bid_network() {
     let bob_stake = 300_000_000_000_u64;
     let initial_stakes = InitialStakes::FromVec(vec![alice_stake.into(), bob_stake.into()]);
 
-    let mut fixture = TestFixture::new(initial_stakes, None).await;
+    let unbonding_delay = 2;
+
+    let mut fixture = TestFixture::new(
+        initial_stakes,
+        Some(ConfigsOverride {
+            unbonding_delay,
+            ..Default::default()
+        }),
+    )
+    .await;
     let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
     let alice_public_key = PublicKey::from(&*alice_secret_key);
     let bob_public_key = PublicKey::from(&*fixture.node_contexts[1].secret_key);
@@ -1904,19 +1944,34 @@ async fn run_undelegate_bid_network() {
         .run_until_executed_transaction(&txn_hash, TEN_SECS)
         .await;
 
-    // Ensure execution succeeded and that there is a Prune transform for the bid's key.
+    // Ensure execution succeeded and that there is a Write transform for the bid's key.
     fixture
         .successful_execution_transforms(&txn_hash)
         .iter()
         .find(|transform| match transform.kind() {
-            TransformKindV2::Prune(prune_key) => prune_key == &bid_key,
+            TransformKindV2::Write(StoredValue::BidKind(bid_kind)) => {
+                Key::from(bid_kind.bid_addr()) == bid_key
+            }
             _ => false,
         })
-        .expect("should have a prune record for undelegated bid");
+        .expect("should have a write record for undelegated bid");
 
     // Crank the network forward until the era ends.
     fixture
         .run_until_stored_switch_block_header(ERA_ONE, ONE_MIN)
+        .await;
+
+    // Ensure the validator records are still present.
+    fixture.check_bid_existence_at_tip(&alice_public_key, None, true);
+    fixture.check_bid_existence_at_tip(&bob_public_key, None, true);
+    fixture.check_bid_existence_at_tip(&bob_public_key, Some(&alice_public_key), true);
+
+    // Crank the network forward until the unbonds are processed.
+    fixture
+        .run_until_stored_switch_block_header(
+            ERA_ONE.saturating_add(unbonding_delay + 1),
+            ONE_MIN * 2,
+        )
         .await;
 
     // Ensure the validator records are still present but the undelegated bid is gone.

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -188,14 +188,17 @@ pub trait Auction:
                 let delegator_bid_addr =
                     BidAddr::new_from_public_keys(&public_key, Some(&delegator_public_key));
 
-                debug!("pruning delegator bid {}", delegator_bid_addr);
-                self.prune_bid(delegator_bid_addr)
+                // Keep the bids for now - they will be pruned when the validator's unbonds get
+                // processed.
+                self.write_bid(
+                    delegator_bid_addr.into(),
+                    BidKind::Delegator(Box::new(delegator)),
+                )?;
             }
-            debug!("pruning validator bid {}", validator_bid_addr);
-            self.prune_bid(validator_bid_addr);
-        } else {
-            self.write_bid(validator_bid_key, BidKind::Validator(validator_bid))?;
         }
+
+        self.write_bid(validator_bid_key, BidKind::Validator(validator_bid))?;
+
         Ok(updated_stake)
     }
 
@@ -285,12 +288,9 @@ pub trait Auction:
             updated_stake
         );
 
-        if updated_stake.is_zero() {
-            debug!("pruning delegator bid {}", delegator_bid_addr);
-            self.prune_bid(delegator_bid_addr);
-        } else {
-            self.write_bid(delegator_bid_addr.into(), BidKind::Delegator(delegator_bid))?;
-        }
+        // Keep the bid for now - it will get pruned when the unbonds are processed.
+        self.write_bid(delegator_bid_addr.into(), BidKind::Delegator(delegator_bid))?;
+
         Ok(updated_stake)
     }
 
@@ -540,6 +540,7 @@ pub trait Auction:
                     .chain(
                         unlocked_validators
                             .into_iter()
+                            .filter(|(_, stake)| !stake.is_zero())
                             .take(remaining_auction_slots),
                     )
                     .collect()
@@ -623,7 +624,7 @@ pub trait Auction:
                 };
 
             let total_reward = Ratio::from(reward_amount);
-            let recipient = seigniorage_recipients
+            let Some(recipient) = seigniorage_recipients
                 .get(&proposer)
                 .cloned()
                 .or_else(|| {
@@ -631,9 +632,33 @@ pub trait Auction:
                     let validator_bid = read_validator_bid(self, &bid_key).ok()?;
                     seigniorage_recipient(self, &validator_bid).ok()
                 })
-                .ok_or(Error::ValidatorNotFound)?;
+                else {
+                    // If the bid doesn't exist, either, the validator has likely been slashed. In
+                    // such a case, simply don't distribute the reward to them.
+                    continue;
+                };
 
             let total_stake = recipient.total_stake().ok_or(Error::ArithmeticOverflow)?;
+
+            if total_stake.is_zero() {
+                // The validator has completely unbonded. We can't compute the delegators' part (as
+                // their stakes are also zero), so we just give the whole reward to the validator.
+                // Mint the reward into their bonding purse and increase their unbond request by the
+                // corresponding amount.
+                let validator_bonding_purse = detail::distribute_validator_rewards(
+                    self,
+                    seigniorage_allocations,
+                    validator_public_key.clone(),
+                    reward_amount,
+                )?;
+
+                // mint new token and put it to the recipients' purses
+                self.mint_into_existing_purse(reward_amount, validator_bonding_purse)
+                    .map_err(Error::from)?;
+
+                continue;
+            }
+
             let delegator_total_stake: U512 = recipient
                 .delegator_total_stake()
                 .ok_or(Error::ArithmeticOverflow)?;

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -432,7 +432,9 @@ pub fn process_unbond_requests<P: Auction + ?Sized>(
     // or their delegators' bids
     for validator_public_key in processed_validators {
         let validator_bid_addr = BidAddr::new_from_public_keys(&validator_public_key, None);
-        let validator_bid = read_validator_bid(provider, &validator_bid_addr.into())?;
+        let validator_bid = read_current_validator_bid(provider, validator_bid_addr.into())?;
+        let validator_public_key = validator_bid.validator_public_key().clone(); // use the current
+                                                                                 // public key
         let mut delegator_bids = read_delegator_bids(provider, &validator_public_key)?;
 
         // prune the delegators that have no stake and no remaining unbonds to be processed

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, convert::TryInto, ops::Mul};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    convert::TryInto,
+    ops::Mul,
+};
 
 use num_rational::Ratio;
 
@@ -14,7 +18,7 @@ use casper_types::{
     },
     ApiError, CLTyped, EraId, Key, KeyTag, PublicKey, URef, U512,
 };
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use super::{
     Auction, EraValidators, MintProvider, RuntimeProvider, StorageProvider, ValidatorWeights,
@@ -378,13 +382,20 @@ pub fn process_unbond_requests<P: Auction + ?Sized>(
 
     let unbonding_delay = get_unbonding_delay(provider)?;
 
+    let mut processed_validators = BTreeSet::new();
+    let mut still_unbonding_public_keys = HashSet::new();
+
     for unbonding_list in unbonding_purses.values_mut() {
         let mut new_unbonding_list = Vec::new();
+
         for unbonding_purse in unbonding_list.iter() {
             // Since `process_unbond_requests` is run before `run_auction`, we should check if
             // current era id + unbonding delay is equal or greater than the `era_of_creation` that
             // was calculated on `unbond` attempt.
             if current_era_id >= unbonding_purse.era_of_creation() + unbonding_delay {
+                // remember the validator's key, so that we can later check if we can prune their
+                // bid now that the unbond has been processed
+                processed_validators.insert(unbonding_purse.validator_public_key().clone());
                 match handle_redelegation(
                     provider,
                     unbonding_purse,
@@ -408,9 +419,47 @@ pub fn process_unbond_requests<P: Auction + ?Sized>(
                 }
             } else {
                 new_unbonding_list.push(unbonding_purse.clone());
+                // remember the key of the unbonder that is still not fully unbonded - so that we
+                // don't prune bids of validators that still have delegators waiting for unbonding,
+                // or the waiting delegators
+                still_unbonding_public_keys.insert(unbonding_purse.unbonder_public_key().clone());
             }
         }
         *unbonding_list = new_unbonding_list;
+    }
+
+    // revisit the validators for which we processed some unbonds and see if we can now prune their
+    // or their delegators' bids
+    for validator_public_key in processed_validators {
+        let validator_bid_addr = BidAddr::new_from_public_keys(&validator_public_key, None);
+        let validator_bid = read_validator_bid(provider, &validator_bid_addr.into())?;
+        let mut delegator_bids = read_delegator_bids(provider, &validator_public_key)?;
+
+        // prune the delegators that have no stake and no remaining unbonds to be processed
+        delegator_bids.retain(|delegator| {
+            if delegator.staked_amount().is_zero()
+                && !still_unbonding_public_keys.contains(delegator.delegator_public_key())
+            {
+                let delegator_bid_addr = BidAddr::new_from_public_keys(
+                    &validator_public_key,
+                    Some(delegator.delegator_public_key()),
+                );
+                debug!("pruning delegator bid {}", delegator_bid_addr);
+                provider.prune_bid(delegator_bid_addr);
+                false
+            } else {
+                true
+            }
+        });
+
+        // if the validator has no delegators, no stake and no remaining unbonds, prune them, too
+        if !still_unbonding_public_keys.contains(&validator_public_key)
+            && delegator_bids.is_empty()
+            && validator_bid.staked_amount().is_zero()
+        {
+            debug!("pruning validator bid {}", validator_bid_addr);
+            provider.prune_bid(validator_bid_addr);
+        }
     }
 
     set_unbonding_purses(provider, unbonding_purses)?;
@@ -509,13 +558,13 @@ where
 
         let delegator_reward_trunc = delegator_reward.to_integer();
         let delegator_bonding_purse = match read_delegator_bid(provider, &bid_key) {
-            Ok(mut delegator_bid) => {
+            Ok(mut delegator_bid) if !delegator_bid.staked_amount().is_zero() => {
                 let purse = *delegator_bid.bonding_purse();
                 delegator_bid.increase_stake(delegator_reward_trunc)?;
                 provider.write_bid(bid_key, BidKind::Delegator(delegator_bid))?;
                 purse
             }
-            Err(Error::DelegatorNotFound) => {
+            Ok(_) | Err(Error::DelegatorNotFound) => {
                 // check to see if there are unbond entries for this recipient
                 // (validator + delegator match), and if there are apply the amount
                 // to the unbond entry with the highest era.
@@ -580,13 +629,16 @@ where
 {
     let bid_key: Key = BidAddr::from(validator_public_key.clone()).into();
     let bonding_purse = match read_current_validator_bid(provider, bid_key) {
-        Ok(mut validator_bid) => {
+        Ok(mut validator_bid) if !validator_bid.staked_amount().is_zero() => {
+            // Only distribute to the bonding purse if the staked amount is not zero - an amount of
+            // zero indicates a validator that has unbonded, but whose unbonds haven't been
+            // processed yet.
             let purse = *validator_bid.bonding_purse();
             validator_bid.increase_stake(amount)?;
             provider.write_bid(bid_key, BidKind::Validator(validator_bid))?;
             purse
         }
-        Err(Error::ValidatorNotFound) => {
+        Ok(_) | Err(Error::ValidatorNotFound) => {
             // check to see if there are unbond entries for this recipient, and if there are
             // apply the amount to the unbond entry with the highest era.
             let account_hash = validator_public_key.to_account_hash();
@@ -703,7 +755,13 @@ where
 
     let validator_bid_addr = BidAddr::from(validator_public_key.clone());
     // is there such a validator?
-    let _ = read_validator_bid(provider, &validator_bid_addr.into())?;
+    let validator_bid = read_validator_bid(provider, &validator_bid_addr.into())?;
+
+    if validator_bid.staked_amount().is_zero() {
+        // The validator has unbonded, but the unbond has not yet been processed, and so an empty
+        // bid still exists. Treat this case as if there was no such validator.
+        return Err(Error::ValidatorNotFound.into());
+    }
 
     // is there already a record for this delegator?
     let delegator_bid_key =


### PR DESCRIPTION
This changes how the unbonding process works.

The bids used to be pruned upon a full unbond. Now, in order to better cooperate with the rewards distribution, a full unbond only sets the bid to zero stake. The bid is only pruned once all the unbonding entries have been processed.

The auction is also modified to filter out bids with zero stake, in order to prevent nodes with zero stake from becoming validators when there are fewer nonzero bids than there are validator slots.
