### PR TITLE
Transaction buffer improvements

### DIFF
--- a/node/src/components/block_validator/state.rs
+++ b/node/src/components/block_validator/state.rs
@@ -349,7 +349,7 @@ impl BlockValidationState {
                 // valid.
                 let approvals = approvals_info.approvals;
                 let footprint = footprint.clone().with_approvals(approvals);
-                match appendable_block.add_transaction(footprint.clone()) {
+                match appendable_block.add_transaction(&footprint) {
                     Ok(_) => {
                         if !missing_transactions.is_empty() || !missing_signatures.is_empty() {
                             // The appendable block is still valid, but we still have missing

--- a/node/src/components/transaction_buffer.rs
+++ b/node/src/components/transaction_buffer.rs
@@ -398,16 +398,13 @@ impl TransactionBuffer {
     fn buckets(
         &mut self,
         current_era_gas_price: u8,
-    ) -> HashMap<Digest, Vec<(TransactionHash, &TransactionFootprint)>> {
+    ) -> HashMap<&Digest, Vec<(TransactionHash, &TransactionFootprint)>> {
         let proposable = self.proposable(current_era_gas_price);
 
-        let mut buckets: HashMap<Digest, Vec<(TransactionHash, &TransactionFootprint)>> =
-            HashMap::new();
-
+        let mut buckets: HashMap<_, Vec<_>> = HashMap::new();
         for (transaction_hash, footprint) in proposable {
-            let body_hash = footprint.body_hash;
             buckets
-                .entry(body_hash)
+                .entry(&footprint.body_hash)
                 .and_modify(|vec| vec.push((*transaction_hash, footprint)))
                 .or_insert(vec![(*transaction_hash, footprint)]);
         }
@@ -449,7 +446,7 @@ impl TransactionBuffer {
                 );
             }
 
-            let Some((transaction_hash, footprint)) = buckets.get_mut(&body_hash).and_then(Vec::<_>::pop)
+            let Some((transaction_hash, footprint)) = buckets.get_mut(body_hash).and_then(Vec::<_>::pop)
                 else {
                     continue;
                 };

--- a/node/src/components/transaction_buffer/tests.rs
+++ b/node/src/components/transaction_buffer/tests.rs
@@ -315,7 +315,9 @@ fn get_proposable_transactions() {
 
         // Check which transactions are proposable. Should return the transactions that were not
         // included in the block since those should be dead.
-        let proposable = transaction_buffer.proposable(DEFAULT_MINIMUM_GAS_PRICE);
+        let proposable: Vec<_> = transaction_buffer
+            .proposable(DEFAULT_MINIMUM_GAS_PRICE)
+            .collect();
         assert_eq!(proposable.len(), transactions.len());
         let proposable_transaction_hashes: HashSet<_> =
             proposable.iter().map(|(th, _)| *th).collect();
@@ -334,15 +336,17 @@ fn get_proposable_transactions() {
         );
 
         // Check that held blocks are not proposable
-        let proposable = transaction_buffer.proposable(DEFAULT_MINIMUM_GAS_PRICE);
+        let proposable: Vec<_> = transaction_buffer
+            .proposable(DEFAULT_MINIMUM_GAS_PRICE)
+            .collect();
         assert_eq!(
             proposable.len(),
             transactions.len() - appendable_block.transaction_hashes().len()
         );
-        for transaction in proposable.iter() {
+        for transaction in proposable {
             assert!(!appendable_block
                 .transaction_hashes()
-                .contains(&transaction.0));
+                .contains(transaction.0));
         }
     }
 }

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -58,7 +58,7 @@ impl AppendableBlock {
     /// Attempt to append transaction to block.
     pub(crate) fn add_transaction(
         &mut self,
-        footprint: TransactionFootprint,
+        footprint: &TransactionFootprint,
     ) -> Result<(), AddError> {
         if self
             .transactions
@@ -135,7 +135,7 @@ impl AppendableBlock {
             return Err(AddError::ApprovalCount);
         }
         self.transactions
-            .insert(footprint.transaction_hash, footprint);
+            .insert(footprint.transaction_hash, footprint.clone());
         Ok(())
     }
 


### PR DESCRIPTION
This PR modified the transaction buffer code slightly, by:
1. removing some unnecessary cloning of the footprint (now, we only clone it at the very end of `add_transaction` when we know all checks have passed)
2. avoiding creation of temporary `Vec` in `proposable()`