### PR TITLE
BUG FIX: native auction uref extension

### DIFF
--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -840,11 +840,11 @@ where
             auction::METHOD_WITHDRAW_BID => (|| {
                 runtime.charge_system_contract_call(auction_costs.withdraw_bid)?;
 
-                let account_hash = Self::get_named_argument(runtime_args, auction::ARG_PUBLIC_KEY)?;
+                let public_key = Self::get_named_argument(runtime_args, auction::ARG_PUBLIC_KEY)?;
                 let amount = Self::get_named_argument(runtime_args, auction::ARG_AMOUNT)?;
 
                 let result = runtime
-                    .withdraw_bid(account_hash, amount)
+                    .withdraw_bid(public_key, amount)
                     .map_err(Self::reverter)?;
                 CLValue::from_t(result).map_err(Self::reverter)
             })(),

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -2693,3 +2693,124 @@ async fn validator_credit_is_written_and_cleared_after_auction() {
         .into_iter()
         .any(|bid| matches!(bid, BidKind::Credit(_))));
 }
+
+#[tokio::test]
+async fn add_and_withdraw_bid_transaction() {
+    let config = SingleTransactionTestCase::default_test_config()
+        .with_pricing_handling(PricingHandling::Fixed)
+        .with_refund_handling(RefundHandling::NoRefund)
+        .with_fee_handling(FeeHandling::NoFee)
+        .with_gas_hold_balance_handling(HoldBalanceHandling::Accrued);
+
+    let mut test = SingleTransactionTestCase::new(
+        ALICE_SECRET_KEY.clone(),
+        BOB_SECRET_KEY.clone(),
+        CHARLIE_SECRET_KEY.clone(),
+        Some(config),
+    )
+    .await;
+
+    let transfer_cost: U512 =
+        U512::from(test.chainspec().system_costs_config.mint_costs().transfer) * MIN_GAS_PRICE;
+    let min_transfer_amount = U512::from(
+        test.chainspec()
+            .transaction_config
+            .native_transfer_minimum_motes,
+    );
+    let half_transfer_cost =
+        (Ratio::new(U512::from(1), U512::from(2)) * transfer_cost).to_integer();
+    let transfer_amount = min_transfer_amount * 2 + transfer_cost + half_transfer_cost;
+
+    let mut txn = Transaction::from(
+        TransactionV1Builder::new_add_bid(PublicKey::from(&**BOB_SECRET_KEY), 0, transfer_amount)
+            .unwrap()
+            .with_chain_name(CHAIN_NAME)
+            .with_initiator_addr(PublicKey::from(&**BOB_SECRET_KEY))
+            .build()
+            .unwrap(),
+    );
+    txn.sign(&BOB_SECRET_KEY);
+
+    test.fixture
+        .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
+        .await;
+
+    let (_, _bob_initial_balance, _) = test.get_balances(None);
+    let (_txn_hash, _block_height, exec_result) = test.send_transaction(txn).await;
+    assert!(exec_result_is_success(&exec_result));
+
+    test.fixture
+        .run_until_consensus_in_era(ERA_TWO, ONE_MIN)
+        .await;
+
+    let mut txn = Transaction::from(
+        TransactionV1Builder::new_withdraw_bid(PublicKey::from(&**BOB_SECRET_KEY), transfer_amount)
+            .unwrap()
+            .with_chain_name(CHAIN_NAME)
+            .with_initiator_addr(PublicKey::from(&**BOB_SECRET_KEY))
+            .build()
+            .unwrap(),
+    );
+    txn.sign(&BOB_SECRET_KEY);
+
+    let (_txn_hash, _block_height, exec_result) = test.send_transaction(txn).await;
+    println!("{:?}", exec_result);
+    assert!(exec_result_is_success(&exec_result));
+}
+
+#[tokio::test]
+async fn delegate_and_undelegate_bid_transaction() {
+    let config = SingleTransactionTestCase::default_test_config()
+        .with_pricing_handling(PricingHandling::Fixed)
+        .with_refund_handling(RefundHandling::NoRefund)
+        .with_fee_handling(FeeHandling::NoFee)
+        .with_gas_hold_balance_handling(HoldBalanceHandling::Accrued);
+
+    let mut test = SingleTransactionTestCase::new(
+        ALICE_SECRET_KEY.clone(),
+        BOB_SECRET_KEY.clone(),
+        CHARLIE_SECRET_KEY.clone(),
+        Some(config),
+    )
+    .await;
+
+    let delegate_amount = U512::from(500_000_000_000u64);
+
+    let mut txn = Transaction::from(
+        TransactionV1Builder::new_delegate(
+            PublicKey::from(&**BOB_SECRET_KEY),
+            PublicKey::from(&**ALICE_SECRET_KEY),
+            delegate_amount,
+        )
+        .unwrap()
+        .with_chain_name(CHAIN_NAME)
+        .with_initiator_addr(PublicKey::from(&**BOB_SECRET_KEY))
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&BOB_SECRET_KEY);
+
+    let (_txn_hash, _block_height, exec_result) = test.send_transaction(txn).await;
+    assert!(exec_result_is_success(&exec_result));
+
+    test.fixture
+        .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
+        .await;
+
+    let mut txn = Transaction::from(
+        TransactionV1Builder::new_undelegate(
+            PublicKey::from(&**BOB_SECRET_KEY),
+            PublicKey::from(&**ALICE_SECRET_KEY),
+            delegate_amount,
+        )
+        .unwrap()
+        .with_chain_name(CHAIN_NAME)
+        .with_initiator_addr(PublicKey::from(&**BOB_SECRET_KEY))
+        .build()
+        .unwrap(),
+    );
+    txn.sign(&BOB_SECRET_KEY);
+
+    let (_txn_hash, _block_height, exec_result) = test.send_transaction(txn).await;
+    assert!(exec_result_is_success(&exec_result));
+}

--- a/storage/src/system/runtime_native.rs
+++ b/storage/src/system/runtime_native.rs
@@ -417,12 +417,20 @@ where
         self.address
     }
 
+    pub fn with_address(&mut self, account_hash: AccountHash) {
+        self.address = account_hash;
+    }
+
     pub fn entity_key(&self) -> &Key {
         &self.entity_key
     }
 
     pub fn addressable_entity(&self) -> &AddressableEntity {
         &self.addressable_entity
+    }
+
+    pub fn with_addressable_entity(&mut self, entity: AddressableEntity) {
+        self.addressable_entity = entity;
     }
 
     pub fn named_keys(&self) -> &NamedKeys {

--- a/storage/src/tracking_copy/ext_entity.rs
+++ b/storage/src/tracking_copy/ext_entity.rs
@@ -153,6 +153,13 @@ pub trait TrackingCopyEntityExt<R> {
         protocol_version: ProtocolVersion,
         fees_purse_handling: FeesPurseHandling,
     ) -> Result<URef, TrackingCopyError>;
+
+    /// Returns named key from selected system contract.
+    fn get_system_contract_named_key(
+        &mut self,
+        system_contract_name: &str,
+        name: &str,
+    ) -> Result<Option<Key>, Self::Error>;
 }
 
 impl<R> TrackingCopyEntityExt<R> for TrackingCopy<R>
@@ -843,5 +850,29 @@ where
                 Ok(URef::default())
             }
         }
+    }
+
+    fn get_system_contract_named_key(
+        &mut self,
+        system_contract_name: &str,
+        name: &str,
+    ) -> Result<Option<Key>, Self::Error> {
+        let system_entity_registry = self.get_system_entity_registry()?;
+        let hash = match system_entity_registry.get(system_contract_name).copied() {
+            Some(hash) => hash,
+            None => {
+                error!(
+                    "unexpected failure; system contract {} not found",
+                    system_contract_name
+                );
+                return Err(TrackingCopyError::MissingSystemContractHash(
+                    system_contract_name.to_string(),
+                ));
+            }
+        };
+        let addressable_entity = self.get_addressable_entity_by_hash(hash)?;
+        let entity_addr = addressable_entity.entity_addr(hash);
+        let named_keys = self.get_named_keys(entity_addr)?;
+        Ok(named_keys.get(name).copied())
     }
 }


### PR DESCRIPTION
This PR extends the runtime instance used in native auctions with uref access to two underlying settings needed by interior logic.