### PR TITLE
Small refactors in support for `casper-db-utils` rewrite.

### DIFF
--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -585,11 +585,9 @@ impl Storage {
                 block_hash,
                 responder,
             } => {
-                let mut txn = self.block_store.checkout_ro()?;
+                let txn = self.block_store.checkout_ro()?;
                 responder
-                    .respond(DataReader::<BlockHash, Block>::exists(
-                        &mut txn, block_hash,
-                    )?)
+                    .respond(DataReader::<BlockHash, Block>::exists(&txn, block_hash)?)
                     .ignore()
             }
             StorageRequest::GetApprovalsHashes {
@@ -624,10 +622,10 @@ impl Storage {
                 only_from_available_block_range,
                 responder,
             } => {
-                let mut txn = self.block_store.checkout_ro()?;
+                let txn = self.block_store.checkout_ro()?;
                 responder
                     .respond(self.get_single_block_header_restricted(
-                        &mut txn,
+                        &txn,
                         &block_hash,
                         only_from_available_block_range,
                     )?)
@@ -645,10 +643,8 @@ impl Storage {
                 responder,
             } => {
                 let mut rw_txn = self.block_store.checkout_rw()?;
-                if DataReader::<TransactionHash, Transaction>::exists(
-                    &mut rw_txn,
-                    transaction.hash(),
-                )? {
+                if DataReader::<TransactionHash, Transaction>::exists(&rw_txn, transaction.hash())?
+                {
                     responder.respond(false).ignore()
                 } else {
                     let _ = rw_txn.write(&*transaction)?;
@@ -673,9 +669,9 @@ impl Storage {
                 transaction_id,
                 responder,
             } => {
-                let mut ro_txn = self.block_store.checkout_ro()?;
+                let ro_txn = self.block_store.checkout_ro()?;
                 let maybe_transaction = match self.get_transaction_with_finalized_approvals(
-                    &mut ro_txn,
+                    &ro_txn,
                     &transaction_id.transaction_hash(),
                 )? {
                     None => None,
@@ -695,11 +691,11 @@ impl Storage {
                 with_finalized_approvals,
                 responder,
             } => {
-                let mut ro_txn = self.block_store.checkout_ro()?;
+                let ro_txn = self.block_store.checkout_ro()?;
 
                 let transaction = if with_finalized_approvals {
                     match self
-                        .get_transaction_with_finalized_approvals(&mut ro_txn, &transaction_hash)?
+                        .get_transaction_with_finalized_approvals(&ro_txn, &transaction_hash)?
                     {
                         Some((transaction, maybe_approvals)) => {
                             if let Some(approvals) = maybe_approvals {
@@ -738,9 +734,9 @@ impl Storage {
                 transaction_id,
                 responder,
             } => {
-                let mut txn = self.block_store.checkout_ro()?;
+                let txn = self.block_store.checkout_ro()?;
                 let has_transaction = DataReader::<TransactionHash, Transaction>::exists(
-                    &mut txn,
+                    &txn,
                     transaction_id.transaction_hash(),
                 )?;
                 responder.respond(has_transaction).ignore()
@@ -749,10 +745,10 @@ impl Storage {
                 block_hash,
                 responder,
             } => {
-                let mut txn = self.block_store.checkout_ro()?;
+                let txn = self.block_store.checkout_ro()?;
                 responder
                     .respond(
-                        self.get_execution_results_with_transaction_headers(&mut txn, &block_hash)?,
+                        self.get_execution_results_with_transaction_headers(&txn, &block_hash)?,
                     )
                     .ignore()
             }
@@ -1050,11 +1046,11 @@ impl Storage {
         transaction_hashes: impl Iterator<Item = &'a TransactionHash>,
     ) -> Result<SmallVec<[Option<(Transaction, Option<BTreeSet<Approval>>)>; 1]>, FatalStorageError>
     {
-        let mut ro_txn = self.block_store.checkout_ro()?;
+        let ro_txn = self.block_store.checkout_ro()?;
 
         transaction_hashes
             .map(|transaction_hash| {
-                self.get_transaction_with_finalized_approvals(&mut ro_txn, transaction_hash)
+                self.get_transaction_with_finalized_approvals(&ro_txn, transaction_hash)
                     .map_err(FatalStorageError::from)
             })
             .collect()
@@ -1366,7 +1362,7 @@ impl Storage {
     /// LMDB error.
     fn get_highest_complete_signed_block_header(
         &self,
-        txn: &mut (impl DataReader<BlockHeight, BlockHeader> + DataReader<BlockHash, BlockSignatures>),
+        txn: &(impl DataReader<BlockHeight, BlockHeader> + DataReader<BlockHash, BlockSignatures>),
     ) -> Result<Option<SignedBlockHeader>, FatalStorageError> {
         let highest_complete_block_height = match self.completed_blocks.highest_sequence() {
             Some(sequence) => sequence.high(),
@@ -1419,7 +1415,7 @@ impl Storage {
     /// should be present in the available blocks index.
     fn get_single_block_header_restricted(
         &self,
-        txn: &mut impl DataReader<BlockHash, BlockHeader>,
+        txn: &impl DataReader<BlockHash, BlockHeader>,
         block_hash: &BlockHash,
         only_from_available_block_range: bool,
     ) -> Result<Option<BlockHeader>, FatalStorageError> {
@@ -1439,7 +1435,7 @@ impl Storage {
     /// recent switch block.
     fn get_trusted_ancestor_headers(
         &self,
-        txn: &mut impl DataReader<BlockHash, BlockHeader>,
+        txn: &impl DataReader<BlockHash, BlockHeader>,
         trusted_block_header: &BlockHeader,
     ) -> Result<Option<Vec<BlockHeader>>, FatalStorageError> {
         if trusted_block_header.is_genesis() {
@@ -1476,7 +1472,7 @@ impl Storage {
     /// highest block, with signatures, plus the signed highest block.
     fn get_signed_block_headers(
         &self,
-        txn: &mut (impl DataReader<BlockHash, BlockSignatures> + DataReader<EraId, BlockHeader>),
+        txn: &(impl DataReader<BlockHash, BlockSignatures> + DataReader<EraId, BlockHeader>),
         trusted_block_header: &BlockHeader,
         highest_signed_block_header: &SignedBlockHeader,
     ) -> Result<Option<Vec<SignedBlockHeader>>, FatalStorageError> {
@@ -1617,9 +1613,9 @@ impl Storage {
         deploy_hash: DeployHash,
     ) -> Result<Option<LegacyDeploy>, FatalStorageError> {
         let transaction_hash = TransactionHash::from(deploy_hash);
-        let mut txn = self.block_store.checkout_ro()?;
+        let txn = self.block_store.checkout_ro()?;
         let transaction =
-            match self.get_transaction_with_finalized_approvals(&mut txn, &transaction_hash)? {
+            match self.get_transaction_with_finalized_approvals(&txn, &transaction_hash)? {
                 Some((transaction, maybe_approvals)) => {
                     if let Some(approvals) = maybe_approvals {
                         transaction.with_approvals(approvals)
@@ -1700,8 +1696,8 @@ impl Storage {
     #[allow(clippy::type_complexity)]
     fn get_transaction_with_finalized_approvals(
         &self,
-        txn: &mut (impl DataReader<TransactionHash, Transaction>
-                  + DataReader<TransactionHash, BTreeSet<Approval>>),
+        txn: &(impl DataReader<TransactionHash, Transaction>
+              + DataReader<TransactionHash, BTreeSet<Approval>>),
         transaction_hash: &TransactionHash,
     ) -> Result<Option<(Transaction, Option<BTreeSet<Approval>>)>, FatalStorageError> {
         let maybe_transaction: Option<Transaction> = txn.read(*transaction_hash)?;
@@ -1722,11 +1718,11 @@ impl Storage {
     ) -> Result<FetchResponse<SyncLeap, SyncLeapIdentifier>, FatalStorageError> {
         let block_hash = sync_leap_identifier.block_hash();
 
-        let mut txn = self.block_store.checkout_ro()?;
+        let txn = self.block_store.checkout_ro()?;
 
         let only_from_available_block_range = true;
         let trusted_block_header = match self.get_single_block_header_restricted(
-            &mut txn,
+            &txn,
             &block_hash,
             only_from_available_block_range,
         )? {
@@ -1735,7 +1731,7 @@ impl Storage {
         };
 
         let trusted_ancestor_headers =
-            match self.get_trusted_ancestor_headers(&mut txn, &trusted_block_header)? {
+            match self.get_trusted_ancestor_headers(&txn, &trusted_block_header)? {
                 Some(trusted_ancestor_headers) => trusted_ancestor_headers,
                 None => return Ok(FetchResponse::NotFound(sync_leap_identifier)),
             };
@@ -1751,7 +1747,7 @@ impl Storage {
         }
 
         let highest_complete_block_header =
-            match self.get_highest_complete_signed_block_header(&mut txn)? {
+            match self.get_highest_complete_signed_block_header(&txn)? {
                 Some(highest_complete_block_header) => highest_complete_block_header,
                 None => return Ok(FetchResponse::NotFound(sync_leap_identifier)),
             };
@@ -1777,7 +1773,7 @@ impl Storage {
         // The `highest_complete_block_header` and `trusted_block_header` are both within the
         // highest complete block range, thus so are all the switch blocks between them.
         if let Some(signed_block_headers) = self.get_signed_block_headers(
-            &mut txn,
+            &txn,
             &trusted_block_header,
             &highest_complete_block_header,
         )? {
@@ -1906,9 +1902,9 @@ impl Storage {
         &self,
         request: &BlockExecutionResultsOrChunkId,
     ) -> Result<Option<BlockExecutionResultsOrChunk>, FatalStorageError> {
-        let mut txn = self.block_store.checkout_ro()?;
+        let txn = self.block_store.checkout_ro()?;
 
-        let execution_results = match self.get_execution_results(&mut txn, request.block_hash())? {
+        let execution_results = match self.get_execution_results(&txn, request.block_hash())? {
             Some(execution_results) => execution_results
                 .into_iter()
                 .map(|(_deploy_hash, execution_result)| execution_result)
@@ -1958,7 +1954,7 @@ impl Storage {
 
     fn get_execution_results(
         &self,
-        txn: &mut (impl DataReader<BlockHash, Block> + DataReader<TransactionHash, ExecutionResult>),
+        txn: &(impl DataReader<BlockHash, Block> + DataReader<TransactionHash, ExecutionResult>),
         block_hash: &BlockHash,
     ) -> Result<Option<Vec<(TransactionHash, ExecutionResult)>>, FatalStorageError> {
         let block = txn.read(*block_hash)?;
@@ -1997,9 +1993,9 @@ impl Storage {
     #[allow(clippy::type_complexity)]
     fn get_execution_results_with_transaction_headers(
         &self,
-        txn: &mut (impl DataReader<BlockHash, Block>
-                  + DataReader<TransactionHash, ExecutionResult>
-                  + DataReader<TransactionHash, Transaction>),
+        txn: &(impl DataReader<BlockHash, Block>
+              + DataReader<TransactionHash, ExecutionResult>
+              + DataReader<TransactionHash, Transaction>),
         block_hash: &BlockHash,
     ) -> Result<Option<Vec<(TransactionHash, TransactionHeader, ExecutionResult)>>, FatalStorageError>
     {
@@ -2180,11 +2176,11 @@ impl Storage {
         &self,
         transaction_hash: &TransactionHash,
     ) -> Option<(Transaction, Option<BTreeSet<Approval>>)> {
-        let mut txn = self
+        let txn = self
             .block_store
             .checkout_ro()
             .expect("could not create RO transaction");
-        self.get_transaction_with_finalized_approvals(&mut txn, transaction_hash)
+        self.get_transaction_with_finalized_approvals(&txn, transaction_hash)
             .expect("could not retrieve a transaction with finalized approvals from storage")
     }
 

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -1931,10 +1931,10 @@ fn should_get_trusted_ancestor_headers() {
     let (storage, _, blocks) = create_sync_leap_test_chain(&[], false, None);
 
     let get_results = |requested_height: usize| -> Vec<u64> {
-        let mut txn = storage.block_store.checkout_ro().unwrap();
+        let txn = storage.block_store.checkout_ro().unwrap();
         let requested_block_header = blocks.get(requested_height).unwrap().clone_header();
         storage
-            .get_trusted_ancestor_headers(&mut txn, &requested_block_header)
+            .get_trusted_ancestor_headers(&txn, &requested_block_header)
             .unwrap()
             .unwrap()
             .iter()
@@ -1952,15 +1952,15 @@ fn should_get_signed_block_headers() {
     let (storage, _, blocks) = create_sync_leap_test_chain(&[], false, None);
 
     let get_results = |requested_height: usize| -> Vec<u64> {
-        let mut txn = storage.block_store.checkout_ro().unwrap();
+        let txn = storage.block_store.checkout_ro().unwrap();
         let requested_block_header = blocks.get(requested_height).unwrap().clone_header();
         let highest_block_header_with_sufficient_signatures = storage
-            .get_highest_complete_signed_block_header(&mut txn)
+            .get_highest_complete_signed_block_header(&txn)
             .unwrap()
             .unwrap();
         storage
             .get_signed_block_headers(
-                &mut txn,
+                &txn,
                 &requested_block_header,
                 &highest_block_header_with_sufficient_signatures,
             )
@@ -1995,16 +1995,16 @@ fn should_get_signed_block_headers_when_no_sufficient_finality_in_most_recent_bl
     let (storage, _, blocks) = create_sync_leap_test_chain(&[12], false, None);
 
     let get_results = |requested_height: usize| -> Vec<u64> {
-        let mut txn = storage.block_store.checkout_ro().unwrap();
+        let txn = storage.block_store.checkout_ro().unwrap();
         let requested_block_header = blocks.get(requested_height).unwrap().clone_header();
         let highest_block_header_with_sufficient_signatures = storage
-            .get_highest_complete_signed_block_header(&mut txn)
+            .get_highest_complete_signed_block_header(&txn)
             .unwrap()
             .unwrap();
 
         storage
             .get_signed_block_headers(
-                &mut txn,
+                &txn,
                 &requested_block_header,
                 &highest_block_header_with_sufficient_signatures,
             )

--- a/storage/src/block_store/block_provider.rs
+++ b/storage/src/block_store/block_provider.rs
@@ -23,7 +23,7 @@ pub trait BlockStoreTransaction {
 
 pub trait DataReader<K, T> {
     fn read(&self, key: K) -> Result<Option<T>, BlockStoreError>;
-    fn exists(&mut self, key: K) -> Result<bool, BlockStoreError>;
+    fn exists(&self, key: K) -> Result<bool, BlockStoreError>;
 }
 
 pub trait DataWriter<K, T> {

--- a/storage/src/block_store/lmdb/indexed_lmdb_block_store.rs
+++ b/storage/src/block_store/lmdb/indexed_lmdb_block_store.rs
@@ -601,7 +601,7 @@ impl<'t> DataReader<BlockHash, Block> for IndexedLmdbBlockStoreReadTransaction<'
             .get_single_block(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.block_store.block_exists(&self.txn, &key)
     }
 }
@@ -613,7 +613,7 @@ impl<'t> DataReader<BlockHash, BlockHeader> for IndexedLmdbBlockStoreReadTransac
             .get_single_block_header(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .block_store
             .block_header_exists(&self.txn, &key)
@@ -627,7 +627,7 @@ impl<'t> DataReader<BlockHash, ApprovalsHashes> for IndexedLmdbBlockStoreReadTra
             .read_approvals_hashes(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .block_store
             .block_header_exists(&self.txn, &key)
@@ -641,7 +641,7 @@ impl<'t> DataReader<BlockHash, BlockSignatures> for IndexedLmdbBlockStoreReadTra
             .get_block_signatures(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .block_store
             .block_signatures_exist(&self.txn, &key)
@@ -653,7 +653,7 @@ impl<'t> DataReader<BlockHeight, Block> for IndexedLmdbBlockStoreReadTransaction
         self.read_block_indexed(LmdbBlockStoreIndex::BlockHeight(IndexPosition::Key(key)))
     }
 
-    fn exists(&mut self, key: BlockHeight) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHeight) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::BlockHeight(IndexPosition::Key(key)),
             DataType::Block,
@@ -666,7 +666,7 @@ impl<'t> DataReader<BlockHeight, BlockHeader> for IndexedLmdbBlockStoreReadTrans
         self.read_block_header_indexed(LmdbBlockStoreIndex::BlockHeight(IndexPosition::Key(key)))
     }
 
-    fn exists(&mut self, key: BlockHeight) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHeight) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::BlockHeight(IndexPosition::Key(key)),
             DataType::BlockHeader,
@@ -681,7 +681,7 @@ impl<'t> DataReader<BlockHeight, ApprovalsHashes> for IndexedLmdbBlockStoreReadT
         )))
     }
 
-    fn exists(&mut self, key: BlockHeight) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHeight) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::BlockHeight(IndexPosition::Key(key)),
             DataType::ApprovalsHashes,
@@ -696,7 +696,7 @@ impl<'t> DataReader<BlockHeight, BlockSignatures> for IndexedLmdbBlockStoreReadT
         )))
     }
 
-    fn exists(&mut self, key: BlockHeight) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHeight) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::BlockHeight(IndexPosition::Key(key)),
             DataType::BlockSignatures,
@@ -712,7 +712,7 @@ impl<'t> DataReader<EraId, Block> for IndexedLmdbBlockStoreReadTransaction<'t> {
         )))
     }
 
-    fn exists(&mut self, key: EraId) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: EraId) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::SwitchBlockEraId(IndexPosition::Key(key)),
             DataType::Block,
@@ -729,7 +729,7 @@ impl<'t> DataReader<EraId, BlockHeader> for IndexedLmdbBlockStoreReadTransaction
         )))
     }
 
-    fn exists(&mut self, key: EraId) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: EraId) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::SwitchBlockEraId(IndexPosition::Key(key)),
             DataType::BlockHeader,
@@ -744,7 +744,7 @@ impl<'t> DataReader<EraId, ApprovalsHashes> for IndexedLmdbBlockStoreReadTransac
         ))
     }
 
-    fn exists(&mut self, key: EraId) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: EraId) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::SwitchBlockEraId(IndexPosition::Key(key)),
             DataType::ApprovalsHashes,
@@ -759,7 +759,7 @@ impl<'t> DataReader<EraId, BlockSignatures> for IndexedLmdbBlockStoreReadTransac
         ))
     }
 
-    fn exists(&mut self, key: EraId) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: EraId) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::SwitchBlockEraId(IndexPosition::Key(key)),
             DataType::BlockSignatures,
@@ -772,7 +772,7 @@ impl<'t> DataReader<Tip, BlockHeader> for IndexedLmdbBlockStoreReadTransaction<'
         self.read_block_header_indexed(LmdbBlockStoreIndex::BlockHeight(IndexPosition::Tip))
     }
 
-    fn exists(&mut self, _key: Tip) -> Result<bool, BlockStoreError> {
+    fn exists(&self, _key: Tip) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::BlockHeight(IndexPosition::Tip),
             DataType::BlockHeader,
@@ -785,7 +785,7 @@ impl<'t> DataReader<Tip, Block> for IndexedLmdbBlockStoreReadTransaction<'t> {
         self.read_block_indexed(LmdbBlockStoreIndex::BlockHeight(IndexPosition::Tip))
     }
 
-    fn exists(&mut self, _key: Tip) -> Result<bool, BlockStoreError> {
+    fn exists(&self, _key: Tip) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::BlockHeight(IndexPosition::Tip),
             DataType::Block,
@@ -798,7 +798,7 @@ impl<'t> DataReader<LatestSwitchBlock, BlockHeader> for IndexedLmdbBlockStoreRea
         self.read_block_header_indexed(LmdbBlockStoreIndex::SwitchBlockEraId(IndexPosition::Tip))
     }
 
-    fn exists(&mut self, _key: LatestSwitchBlock) -> Result<bool, BlockStoreError> {
+    fn exists(&self, _key: LatestSwitchBlock) -> Result<bool, BlockStoreError> {
         self.contains_data_indexed(
             LmdbBlockStoreIndex::SwitchBlockEraId(IndexPosition::Tip),
             DataType::BlockHeader,
@@ -813,7 +813,7 @@ impl<'t> DataReader<TransactionHash, BlockHashHeightAndEra>
         Ok(self.block_store.transaction_hash_index.get(&key).copied())
     }
 
-    fn exists(&mut self, key: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: TransactionHash) -> Result<bool, BlockStoreError> {
         Ok(self.block_store.transaction_hash_index.contains_key(&key))
     }
 }
@@ -827,7 +827,7 @@ impl<'t> DataReader<TransactionHash, Transaction> for IndexedLmdbBlockStoreReadT
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, key: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .block_store
             .transaction_exists(&self.txn, &key)
@@ -845,7 +845,7 @@ impl<'t> DataReader<TransactionHash, BTreeSet<Approval>>
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, key: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .block_store
             .finalized_transaction_approvals_dbs
@@ -863,7 +863,7 @@ impl<'t> DataReader<TransactionHash, ExecutionResult> for IndexedLmdbBlockStoreR
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, key: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .block_store
             .execution_result_dbs
@@ -879,7 +879,7 @@ impl<'t> DataReader<StateStoreKey, Vec<u8>> for IndexedLmdbBlockStoreReadTransac
             .read_state_store(&self.txn, &key)
     }
 
-    fn exists(&mut self, StateStoreKey(key): StateStoreKey) -> Result<bool, BlockStoreError> {
+    fn exists(&self, StateStoreKey(key): StateStoreKey) -> Result<bool, BlockStoreError> {
         self.block_store
             .block_store
             .state_store_key_exists(&self.txn, &key)
@@ -909,7 +909,7 @@ impl<'t> DataReader<(DbTableId, Vec<u8>), DbRawBytesSpec>
         res.map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, key: (DbTableId, Vec<u8>)) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: (DbTableId, Vec<u8>)) -> Result<bool, BlockStoreError> {
         self.read(key).map(|res| res.is_some())
     }
 }
@@ -1166,7 +1166,7 @@ impl<'t> DataReader<TransactionHash, Transaction> for IndexedLmdbBlockStoreRWTra
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, query: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, query: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store.transaction_exists(&self.txn, &query)
     }
 }
@@ -1176,7 +1176,7 @@ impl<'t> DataReader<BlockHash, BlockSignatures> for IndexedLmdbBlockStoreRWTrans
         self.block_store.get_block_signatures(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.block_signatures_exist(&self.txn, &key)
     }
 }
@@ -1191,7 +1191,7 @@ impl<'t> DataReader<TransactionHash, BTreeSet<Approval>>
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, query: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, query: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .finalized_transaction_approvals_dbs
             .exists(&self.txn, &query)
@@ -1204,8 +1204,18 @@ impl<'t> DataReader<BlockHash, Block> for IndexedLmdbBlockStoreRWTransaction<'t>
         self.block_store.get_single_block(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.block_exists(&self.txn, &key)
+    }
+}
+
+impl<'t> DataReader<BlockHash, BlockHeader> for IndexedLmdbBlockStoreRWTransaction<'t> {
+    fn read(&self, key: BlockHash) -> Result<Option<BlockHeader>, BlockStoreError> {
+        self.block_store.get_single_block_header(&self.txn, &key)
+    }
+
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
+        self.block_store.block_header_exists(&self.txn, &key)
     }
 }
 
@@ -1217,7 +1227,7 @@ impl<'t> DataReader<TransactionHash, ExecutionResult> for IndexedLmdbBlockStoreR
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, query: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, query: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .execution_result_dbs
             .exists(&self.txn, &query)
@@ -1230,7 +1240,7 @@ impl<'t> DataReader<BlockHash, Vec<Transfer>> for IndexedLmdbBlockStoreRWTransac
         self.block_store.get_transfers(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.has_transfers(&self.txn, &key)
     }
 }

--- a/storage/src/block_store/lmdb/lmdb_block_store.rs
+++ b/storage/src/block_store/lmdb/lmdb_block_store.rs
@@ -520,6 +520,23 @@ impl LmdbBlockStore {
         }
         Ok(was_written)
     }
+
+    pub(crate) fn delete_execution_results(
+        &self,
+        txn: &mut RwTransaction,
+        block_hash: &BlockHash,
+    ) -> Result<bool, BlockStoreError> {
+        let block = self.get_single_block(txn, block_hash)?;
+
+        if let Some(block) = block {
+            for txn_hash in block.all_transaction_hashes() {
+                self.execution_result_dbs
+                    .delete(txn, &txn_hash)
+                    .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))?;
+            }
+        }
+        Ok(true)
+    }
 }
 
 pub(crate) fn new_environment(
@@ -636,7 +653,7 @@ where
         self.block_store.get_single_block(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.block_exists(&self.txn, &key)
     }
 }
@@ -649,7 +666,7 @@ where
         self.block_store.get_single_block_header(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.block_header_exists(&self.txn, &key)
     }
 }
@@ -662,7 +679,7 @@ where
         self.block_store.read_approvals_hashes(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.block_header_exists(&self.txn, &key)
     }
 }
@@ -675,7 +692,7 @@ where
         self.block_store.get_block_signatures(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.block_signatures_exist(&self.txn, &key)
     }
 }
@@ -691,7 +708,7 @@ where
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, key: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store.transaction_exists(&self.txn, &key)
     }
 }
@@ -707,7 +724,7 @@ where
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, key: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .finalized_transaction_approvals_dbs
             .exists(&self.txn, &key)
@@ -726,7 +743,7 @@ where
             .map_err(|err| BlockStoreError::InternalStorage(Box::new(err)))
     }
 
-    fn exists(&mut self, key: TransactionHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: TransactionHash) -> Result<bool, BlockStoreError> {
         self.block_store
             .execution_result_dbs
             .exists(&self.txn, &key)
@@ -742,7 +759,7 @@ where
         self.block_store.get_transfers(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: BlockHash) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: BlockHash) -> Result<bool, BlockStoreError> {
         self.block_store.has_transfers(&self.txn, &key)
     }
 }
@@ -756,7 +773,7 @@ where
         self.block_store.read_state_store(&self.txn, &key)
     }
 
-    fn exists(&mut self, key: K) -> Result<bool, BlockStoreError> {
+    fn exists(&self, key: K) -> Result<bool, BlockStoreError> {
         self.block_store.state_store_key_exists(&self.txn, &key)
     }
 }
@@ -901,7 +918,12 @@ impl<'t> DataWriter<BlockHashHeightAndEra, BlockExecutionResults>
         Ok(data.block_info)
     }
 
-    fn delete(&mut self, _key: BlockHashHeightAndEra) -> Result<(), BlockStoreError> {
-        Err(BlockStoreError::UnsupportedOperation)
+    fn delete(&mut self, key: BlockHashHeightAndEra) -> Result<(), BlockStoreError> {
+        let block_hash = key.block_hash;
+
+        let _ = self
+            .block_store
+            .delete_execution_results(&mut self.txn, &block_hash)?;
+        Ok(())
     }
 }

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -23,6 +23,7 @@ mod test_block_builder;
 
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt::{self, Display, Formatter};
+use itertools::Either;
 #[cfg(feature = "json-schema")]
 use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
@@ -400,15 +401,15 @@ impl Block {
     }
 
     /// Returns a list of all transaction hashes in a block.
-    pub fn all_transaction_hashes(&self) -> Box<dyn Iterator<Item = TransactionHash> + '_> {
+    pub fn all_transaction_hashes(&self) -> impl Iterator<Item = TransactionHash> + '_ {
         match self {
-            Block::V1(block) => Box::new(
+            Block::V1(block) => Either::Left(
                 block
                     .body
                     .deploy_and_transfer_hashes()
                     .map(TransactionHash::from),
             ),
-            Block::V2(block_v2) => Box::new(block_v2.all_transactions().copied()),
+            Block::V2(block_v2) => Either::Right(block_v2.all_transactions().copied()),
         }
     }
 

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -40,9 +40,8 @@ use schemars::JsonSchema;
 use crate::TransactionConfig;
 
 use crate::{
-    bytesrepr,
-    bytesrepr::{FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
-    Digest, EraId, ProtocolVersion, PublicKey, Timestamp,
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    Digest, EraId, ProtocolVersion, PublicKey, Timestamp, TransactionHash,
 };
 pub use available_block_range::AvailableBlockRange;
 pub use block_body::{BlockBody, BlockBodyV1, BlockBodyV2};
@@ -397,6 +396,19 @@ impl Block {
                 (block.body.deploy_hashes().len() + block.body.transfer_hashes().len()) as u64
             }
             Block::V2(block_v2) => block_v2.all_transactions().count() as u64,
+        }
+    }
+
+    /// Returns a list of all transaction hashes in a block.
+    pub fn all_transaction_hashes(&self) -> Box<dyn Iterator<Item = TransactionHash> + '_> {
+        match self {
+            Block::V1(block) => Box::new(
+                block
+                    .body
+                    .deploy_and_transfer_hashes()
+                    .map(TransactionHash::from),
+            ),
+            Block::V2(block_v2) => Box::new(block_v2.all_transactions().copied()),
         }
     }
 

--- a/types/src/block/block_signatures.rs
+++ b/types/src/block/block_signatures.rs
@@ -209,6 +209,14 @@ impl BlockSignatures {
         }
     }
 
+    /// Removes a signature corresponding to the specified key.
+    pub fn remove_signature(&mut self, public_key: &PublicKey) -> Option<Signature> {
+        match self {
+            BlockSignatures::V1(block_signatures) => block_signatures.proofs.remove(public_key),
+            BlockSignatures::V2(block_signatures) => block_signatures.proofs.remove(public_key),
+        }
+    }
+
     /// Sets the era ID to its max value, rendering it and hence `self` invalid (assuming the
     /// relevant era ID for this `SignedBlockHeader` wasn't already the max value).
     #[cfg(any(feature = "testing", test))]


### PR DESCRIPTION
To make `casper-db-utils` compatible with the Condor changes of the node, adding a few small things:
* Removing the need for RO block store transactions to be mutable in order to read data.
* Add a method to retrieve all transaction hashes for a block
* Add a method to remove a signature from `BlockSignatures`
* Implement the writer that allows deleting execution results from the block store
