### PR TITLE
Alter reward distribution logic to take account of prior eras' delegator identities and weights

### DIFF
--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -1007,7 +1007,7 @@ where
         &mut self,
         pre_state_hash: Option<Digest>,
         protocol_version: ProtocolVersion,
-        rewards: BTreeMap<PublicKey, U512>,
+        rewards: BTreeMap<PublicKey, Vec<U512>>,
         block_time: u64,
     ) -> BlockRewardsResult {
         let pre_state_hash = pre_state_hash.or(self.post_state_hash).unwrap();

--- a/execution_engine_testing/tests/src/test/private_chain/restricted_auction.rs
+++ b/execution_engine_testing/tests/src/test/private_chain/restricted_auction.rs
@@ -25,7 +25,8 @@ fn should_not_distribute_rewards_but_compute_next_set() {
         builder.distribute(
             None,
             DEFAULT_PROTOCOL_VERSION,
-            IntoIterator::into_iter([(VALIDATOR_1_PUBLIC_KEY.clone(), U512::from(0))]).collect(),
+            IntoIterator::into_iter([(VALIDATOR_1_PUBLIC_KEY.clone(), vec![U512::from(0)])])
+                .collect(),
             DEFAULT_BLOCK_TIME,
         );
         let step_request = StepRequestBuilder::new()
@@ -51,7 +52,7 @@ fn should_not_distribute_rewards_but_compute_next_set() {
     builder.distribute(
         None,
         DEFAULT_PROTOCOL_VERSION,
-        IntoIterator::into_iter([(VALIDATOR_1_PUBLIC_KEY.clone(), U512::from(0))]).collect(),
+        IntoIterator::into_iter([(VALIDATOR_1_PUBLIC_KEY.clone(), vec![U512::from(0)])]).collect(),
         DEFAULT_BLOCK_TIME,
     );
 

--- a/execution_engine_testing/tests/src/test/regression/gh_3710.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3710.rs
@@ -180,7 +180,7 @@ fn distribute_rewards<S>(
     builder.distribute(
         None,
         ProtocolVersion::V1_0_0,
-        IntoIterator::into_iter([(proposer.clone(), amount)]).collect(),
+        IntoIterator::into_iter([(proposer.clone(), vec![amount])]).collect(),
         block_height,
     );
 }

--- a/execution_engine_testing/tests/src/test/regression/gov_89_regression.rs
+++ b/execution_engine_testing/tests/src/test/regression/gov_89_regression.rs
@@ -142,9 +142,9 @@ fn should_not_create_any_purse() {
         SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
     );
     assert!(
-        !before_auction_seigniorage
+        !after_auction_seigniorage
             .keys()
-            .all(|key| after_auction_seigniorage.contains_key(key)),
+            .all(|key| before_auction_seigniorage.contains_key(key)),
         "run auction should have changed seigniorage keys"
     );
 

--- a/execution_engine_testing/tests/src/test/step.rs
+++ b/execution_engine_testing/tests/src/test/step.rs
@@ -115,9 +115,9 @@ fn should_step() {
         SEIGNIORAGE_RECIPIENTS_SNAPSHOT_KEY,
     );
     assert!(
-        !before_auction_seigniorage
+        !after_auction_seigniorage
             .keys()
-            .all(|key| after_auction_seigniorage.contains_key(key)),
+            .all(|key| before_auction_seigniorage.contains_key(key)),
         "run auction should have changed seigniorage keys"
     );
 }

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -642,7 +642,7 @@ fn should_calculate_era_validators() {
     assert!(post_era_id > EraId::from(0));
     let consensus_next_era_id: EraId = post_era_id + auction_delay + 1;
 
-    let snapshot_size = auction_delay as usize + 1;
+    let snapshot_size = auction_delay as usize + 2;
     assert_eq!(
         era_validators.len(),
         snapshot_size,
@@ -772,7 +772,7 @@ fn should_get_first_seigniorage_recipients() {
 
     let mut era_validators: EraValidators = builder.get_era_validators();
     let auction_delay = builder.get_auction_delay();
-    let snapshot_size = auction_delay as usize + 1;
+    let snapshot_size = auction_delay as usize + 2;
 
     assert_eq!(era_validators.len(), snapshot_size, "{:?}", era_validators); // eraindex==1 - ran once
 
@@ -4690,7 +4690,7 @@ fn should_change_validator_bid_public_key() {
     let protocol_version = DEFAULT_PROTOCOL_VERSION;
     let total_payout = builder.base_round_reward(None, protocol_version);
     let mut rewards = BTreeMap::new();
-    rewards.insert(NON_FOUNDER_VALIDATOR_1_PK.clone(), total_payout);
+    rewards.insert(NON_FOUNDER_VALIDATOR_1_PK.clone(), vec![total_payout]);
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
         builder.get_auction_contract_hash(),
@@ -4977,7 +4977,7 @@ fn should_handle_excessively_long_bridge_record_chains() {
     let protocol_version = DEFAULT_PROTOCOL_VERSION;
     let total_payout = builder.base_round_reward(None, protocol_version);
     let mut rewards = BTreeMap::new();
-    rewards.insert(NON_FOUNDER_VALIDATOR_1_PK.clone(), total_payout);
+    rewards.insert(NON_FOUNDER_VALIDATOR_1_PK.clone(), vec![total_payout]);
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
         builder.get_auction_contract_hash(),

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -280,7 +280,7 @@ fn should_distribute_delegation_rate_zero() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
@@ -545,7 +545,7 @@ fn should_withdraw_bids_after_distribute() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
@@ -1180,7 +1180,7 @@ fn should_distribute_delegation_rate_half() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
@@ -1401,7 +1401,7 @@ fn should_distribute_delegation_rate_full() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), expected_total_reward_integer);
+    rewards.insert(VALIDATOR_1.clone(), vec![expected_total_reward_integer]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
@@ -1594,7 +1594,7 @@ fn should_distribute_uneven_delegation_rate_zero() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
@@ -1897,7 +1897,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
 
     // Validator 1 distribution
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -1956,7 +1956,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     ));
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_2.clone(), total_payout);
+    rewards.insert(VALIDATOR_2.clone(), vec![total_payout]);
 
     // Validator 2 distribution
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -2002,7 +2002,7 @@ fn should_distribute_with_multiple_validators_and_delegators() {
     ));
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_3.clone(), total_payout);
+    rewards.insert(VALIDATOR_3.clone(), vec![total_payout]);
 
     // Validator 3 distribution
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -2228,9 +2228,9 @@ fn should_distribute_with_multiple_validators_and_shared_delegator() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
-    rewards.insert(VALIDATOR_2.clone(), total_payout);
-    rewards.insert(VALIDATOR_3.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
+    rewards.insert(VALIDATOR_2.clone(), vec![total_payout]);
+    rewards.insert(VALIDATOR_3.clone(), vec![total_payout]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
@@ -2589,9 +2589,9 @@ fn should_increase_total_supply_after_distribute() {
     let total_payout = U512::from(1_000_000_000_000_u64);
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
-    rewards.insert(VALIDATOR_2.clone(), total_payout);
-    rewards.insert(VALIDATOR_3.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
+    rewards.insert(VALIDATOR_2.clone(), vec![total_payout]);
+    rewards.insert(VALIDATOR_3.clone(), vec![total_payout]);
 
     for _ in 0..5 {
         let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -2769,7 +2769,7 @@ fn should_not_create_purses_during_distribute() {
     let total_payout = U512::from(1_000_000_000_000_u64);
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), total_payout);
+    rewards.insert(VALIDATOR_1.clone(), vec![total_payout]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,
@@ -2917,7 +2917,7 @@ fn should_distribute_delegation_rate_full_after_upgrading() {
     }
 
     let mut rewards = BTreeMap::new();
-    rewards.insert(VALIDATOR_1.clone(), expected_total_reward_integer);
+    rewards.insert(VALIDATOR_1.clone(), vec![expected_total_reward_integer]);
 
     let distribute_request = ExecuteRequestBuilder::contract_call_by_hash(
         *SYSTEM_ADDR,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -863,7 +863,7 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
     for idx in 0..10 {
         let rewards = {
             let mut rewards = BTreeMap::new();
-            rewards.insert(VALIDATOR_1.clone(), round_reward);
+            rewards.insert(VALIDATOR_1.clone(), vec![round_reward]);
             rewards
         };
 
@@ -3006,7 +3006,7 @@ fn should_distribute_delegation_rate_full_after_upgrading() {
     let mut rewards = BTreeMap::new();
     rewards.insert(
         VALIDATOR_1.clone(),
-        expected_total_reward_after.to_integer(),
+        vec![expected_total_reward_after.to_integer()],
     );
     assert!(
         builder

--- a/node/src/components/contract_runtime/rewards/tests.rs
+++ b/node/src/components/contract_runtime/rewards/tests.rs
@@ -91,9 +91,11 @@ fn production_payout_increases_with_the_supply() {
 
     // Checks:
 
-    for ((recipient_1, amount_1), (recipient_2, amount_2)) in
+    for ((recipient_1, amounts_1), (recipient_2, amounts_2)) in
         iter::zip(rewards_for_era_1, rewards_for_era_2)
     {
+        let amount_1: U512 = amounts_1.into_iter().sum();
+        let amount_2: U512 = amounts_2.into_iter().sum();
         assert_eq!(
             ratio(amount_1),
             ratio(era_1_reward_per_round) * ratio(core_config.production_rewards_proportion())
@@ -168,10 +170,10 @@ fn production_payout_depends_on_the_blocks_produced() {
     assert_eq!(
         rewards,
         map! {
-            VALIDATOR_1.deref().clone() => (ratio(2 * era_1_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer(),
-            VALIDATOR_2.deref().clone() => U512::zero(),
-            VALIDATOR_3.deref().clone() => (ratio(era_1_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer(),
-            VALIDATOR_4.deref().clone() => U512::zero(),
+            VALIDATOR_1.deref().clone() => vec![(ratio(2 * era_1_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer()],
+            VALIDATOR_2.deref().clone() => vec![U512::zero()],
+            VALIDATOR_3.deref().clone() => vec![(ratio(era_1_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer()],
+            VALIDATOR_4.deref().clone() => vec![U512::zero()],
         }
     );
 
@@ -183,10 +185,10 @@ fn production_payout_depends_on_the_blocks_produced() {
     assert_eq!(
         rewards,
         map! {
-            VALIDATOR_1.deref().clone() => U512::zero(),
-            VALIDATOR_2.deref().clone() => (ratio(era_2_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer(),
-            VALIDATOR_3.deref().clone() => (ratio(era_2_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer(),
-            VALIDATOR_4.deref().clone() => (ratio(era_2_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer(),
+            VALIDATOR_1.deref().clone() => vec![U512::zero()],
+            VALIDATOR_2.deref().clone() => vec![(ratio(era_2_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer()],
+            VALIDATOR_3.deref().clone() => vec![(ratio(era_2_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer()],
+            VALIDATOR_4.deref().clone() => vec![(ratio(era_2_reward_per_round) * ratio(core_config.production_rewards_proportion())).to_integer()],
         }
     );
 }
@@ -264,9 +266,9 @@ fn all_signatures_rewards_without_contribution_fee() {
 
     assert_eq!(
         map! {
-            VALIDATOR_1.clone() => validator_1_expected_payout.to_integer(),
-            VALIDATOR_2.clone() => validator_2_expected_payout.to_integer(),
-            VALIDATOR_3.clone() => validator_3_expected_payout.to_integer(),
+            VALIDATOR_1.clone() => vec![validator_1_expected_payout.to_integer()],
+            VALIDATOR_2.clone() => vec![validator_2_expected_payout.to_integer()],
+            VALIDATOR_3.clone() => vec![validator_3_expected_payout.to_integer()],
         },
         rewards_for_era_1,
     );
@@ -278,9 +280,13 @@ fn all_signatures_rewards_without_contribution_fee() {
 
     let validator_1_expected_payout = {
         // 1 block produced:
-        ratio(1) * ratio(era_2_reward_per_round) * ratio(core_config.production_rewards_proportion())
+        ratio(1)
+            * ratio(era_2_reward_per_round)
+            * ratio(core_config.production_rewards_proportion())
+    };
+    let validator_1_expected_payout_prev_era = {
         // All finality signature collected:
-        + ratio(era_1_reward_per_round) * ratio(core_config.collection_rewards_proportion())
+        ratio(era_1_reward_per_round) * ratio(core_config.collection_rewards_proportion())
     };
     let validator_2_expected_payout = {
         // 1 block produced:
@@ -297,9 +303,10 @@ fn all_signatures_rewards_without_contribution_fee() {
 
     assert_eq!(
         map! {
-            VALIDATOR_1.clone() => validator_1_expected_payout.to_integer(),
-            VALIDATOR_2.clone() => validator_2_expected_payout.to_integer(),
-            VALIDATOR_3.clone() => validator_3_expected_payout.to_integer(),
+            VALIDATOR_1.clone() => vec![validator_1_expected_payout.to_integer(),
+                                        validator_1_expected_payout_prev_era.to_integer()],
+            VALIDATOR_2.clone() => vec![validator_2_expected_payout.to_integer()],
+            VALIDATOR_3.clone() => vec![validator_3_expected_payout.to_integer()],
         },
         rewards_for_era_2,
     );
@@ -379,9 +386,9 @@ fn all_signatures_rewards_without_finder_fee() {
     assert_eq!(
         rewards_for_era_1,
         map! {
-            VALIDATOR_1.clone() => validator_1_expected_payout.to_integer(),
-            VALIDATOR_2.clone() => validator_2_expected_payout.to_integer(),
-            VALIDATOR_3.clone() => validator_3_expected_payout.to_integer(),
+            VALIDATOR_1.clone() => vec![validator_1_expected_payout.to_integer()],
+            VALIDATOR_2.clone() => vec![validator_2_expected_payout.to_integer()],
+            VALIDATOR_3.clone() => vec![validator_3_expected_payout.to_integer()],
         }
     );
 }
@@ -465,9 +472,9 @@ fn all_signatures_rewards() {
     assert_eq!(
         rewards_for_era_1,
         map! {
-            VALIDATOR_1.clone() => validator_1_expected_payout.to_integer(),
-            VALIDATOR_2.clone() => validator_2_expected_payout.to_integer(),
-            VALIDATOR_3.clone() => validator_3_expected_payout.to_integer(),
+            VALIDATOR_1.clone() => vec![validator_1_expected_payout.to_integer()],
+            VALIDATOR_2.clone() => vec![validator_2_expected_payout.to_integer()],
+            VALIDATOR_3.clone() => vec![validator_3_expected_payout.to_integer()],
         }
     );
 }
@@ -575,9 +582,9 @@ fn mixed_signatures_pattern() {
         assert_eq!(
             rewards_for_era_1,
             map! {
-                VALIDATOR_1.clone() => validator_1_expected_payout.to_integer(),
-                VALIDATOR_2.clone() => validator_2_expected_payout.to_integer(),
-                VALIDATOR_3.clone() => validator_3_expected_payout.to_integer(),
+                VALIDATOR_1.clone() => vec![validator_1_expected_payout.to_integer()],
+                VALIDATOR_2.clone() => vec![validator_2_expected_payout.to_integer()],
+                VALIDATOR_3.clone() => vec![validator_3_expected_payout.to_integer()],
             }
         );
     }
@@ -588,9 +595,9 @@ fn mixed_signatures_pattern() {
         let rewards_for_era_2 =
             rewards_for_era(constructor.for_era(rng, era), era, &core_config).unwrap();
 
-        let validator_1_expected_payout = {
+        let validator_1_expected_payout = vec![
             // 1 block produced:
-            production * ratio(1) * ratio(era_2_reward_per_round)
+            (production * ratio(1) * ratio(era_2_reward_per_round)
             // 2 finality signatures collected:
             + collection * {
                 ratio(1) * constructor.weight(era, VALIDATOR_1.deref())
@@ -598,30 +605,30 @@ fn mixed_signatures_pattern() {
             } * ratio(era_2_reward_per_round)
             // Finality signed:
             + contribution * {
-                // 1 in previous era:
-                ratio(1) * ratio(era_1_reward_per_round) * constructor.weight(1, VALIDATOR_1.deref())
                 // 3 in current era:
-                + ratio(3) * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_1.deref())
-            }
-        };
+                ratio(3) * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_1.deref())
+            }).to_integer(),
+            // 1 contributed in previous era:
+            (contribution * {
+                ratio(1) * ratio(era_1_reward_per_round) * constructor.weight(1, VALIDATOR_1.deref())
+            }).to_integer()
+        ];
 
-        let validator_2_expected_payout = {
+        let validator_2_expected_payout = vec![
             // 1 block produced:
-            ratio(1) * production * ratio(era_2_reward_per_round)
+            (ratio(1) * production * ratio(era_2_reward_per_round)
             // No finality signature collected:
             // 3 finality signed:
-            + ratio(3) * contribution * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_2.deref())
-        };
+            + ratio(3) * contribution * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_2.deref()))
+            .to_integer()
+        ];
 
-        let validator_3_expected_payout = {
+        let validator_3_expected_payout = vec![
             // 1 block produced:
-            ratio(1) * production * ratio(era_2_reward_per_round)
+            (ratio(1) * production * ratio(era_2_reward_per_round)
             // 2 finality signatures collected:
             + collection * {
                 (
-                    ratio(1) * constructor.weight(1, VALIDATOR_1.deref())
-                ) * ratio(era_1_reward_per_round)
-                + (
                     ratio(1) * constructor.weight(era, VALIDATOR_1.deref())
                     + ratio(1) * constructor.weight(era, VALIDATOR_2.deref())
                     + ratio(1) * constructor.weight(era, VALIDATOR_3.deref())
@@ -630,22 +637,27 @@ fn mixed_signatures_pattern() {
             }
             // Finality signed:
             + contribution * {
+                // 3 in current era:
+                ratio(3) * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_3.deref())
+            }).to_integer(),
+            // for era 1
+            (collection * {
+                (
+                    ratio(1) * constructor.weight(1, VALIDATOR_1.deref())
+                ) * ratio(era_1_reward_per_round)
+            }
+            + contribution * {
                 // 1 in previous era:
                 ratio(1) * ratio(era_1_reward_per_round) * constructor.weight(1, VALIDATOR_3.deref())
-                // 3 in current era:
-                + ratio(3) * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_3.deref())
-            }
-        };
+            }).to_integer()
+        ];
 
-        let validator_4_expected_payout = {
+        let validator_4_expected_payout = vec![
             // 1 block produced:
-            ratio(1) * production * ratio(era_2_reward_per_round)
+            (ratio(1) * production * ratio(era_2_reward_per_round)
             // 6 finality signatures collected:
             + collection * {
                 (
-                    ratio(1) * constructor.weight(1, VALIDATOR_3.deref())
-                ) * ratio(era_1_reward_per_round)
-                + (
                     ratio(1) * constructor.weight(era, VALIDATOR_1.deref())
                     + ratio(1) * constructor.weight(era, VALIDATOR_2.deref())
                     + ratio(2) * constructor.weight(era, VALIDATOR_3.deref())
@@ -653,16 +665,23 @@ fn mixed_signatures_pattern() {
                 ) * ratio(era_2_reward_per_round)
             }
             // 3 finality signed:
-            + ratio(2) * contribution * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_4.deref())
-        };
+            + ratio(2) * contribution * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_4.deref()))
+            .to_integer(),
+            // for era 1
+            (collection * {
+                (
+                    ratio(1) * constructor.weight(1, VALIDATOR_3.deref())
+                ) * ratio(era_1_reward_per_round)
+            }).to_integer()
+        ];
 
         assert_eq!(
             rewards_for_era_2,
             map! {
-                VALIDATOR_1.clone() => validator_1_expected_payout.to_integer(),
-                VALIDATOR_2.clone() => validator_2_expected_payout.to_integer(),
-                VALIDATOR_3.clone() => validator_3_expected_payout.to_integer(),
-                VALIDATOR_4.clone() => validator_4_expected_payout.to_integer(),
+                VALIDATOR_1.clone() => validator_1_expected_payout,
+                VALIDATOR_2.clone() => validator_2_expected_payout,
+                VALIDATOR_3.clone() => validator_3_expected_payout,
+                VALIDATOR_4.clone() => validator_4_expected_payout,
             }
         );
     }

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -2125,8 +2125,18 @@ async fn rewards_are_calculated() {
 
     let switch_block = fixture.switch_block(ERA_TWO);
 
-    for reward in switch_block.era_end().unwrap().rewards().values() {
-        assert_ne!(reward, &U512::zero());
+    for reward in switch_block
+        .era_end()
+        .unwrap()
+        .rewards()
+        .values()
+        .map(|amounts| {
+            amounts
+                .iter()
+                .fold(U512::zero(), |acc, amount| *amount + acc)
+        })
+    {
+        assert_ne!(reward, U512::zero());
     }
 }
 
@@ -2251,15 +2261,18 @@ async fn run_rewards_network_scenario(
     #[inline]
     fn add_to_rewards(
         recipient: PublicKey,
+        era: EraId,
         reward: Ratio<U512>,
-        rewards: &mut BTreeMap<PublicKey, Ratio<U512>>,
+        rewards: &mut BTreeMap<PublicKey, BTreeMap<EraId, Ratio<U512>>>,
     ) {
         match rewards.get_mut(&recipient) {
-            Some(value) => {
-                *value += reward;
+            Some(map) => {
+                *map.entry(era).or_insert(Ratio::zero()) += reward;
             }
             None => {
-                rewards.insert(recipient, reward);
+                let mut map = BTreeMap::new();
+                map.insert(era, reward);
+                rewards.insert(recipient, map);
             }
         }
     }
@@ -2292,20 +2305,21 @@ async fn run_rewards_network_scenario(
             let total_current_era_weights = current_era_slated_weights
                 .iter()
                 .fold(U512::zero(), move |acc, s| acc + s.1);
+            let weights_block_idx = if switch_blocks.headers[i - 1].is_genesis() {
+                i - 1
+            } else {
+                i - 2
+            };
             let (previous_era_slated_weights, total_previous_era_weights) =
-                if switch_blocks.headers[i - 1].is_genesis() {
-                    (None, None)
-                } else {
-                    match switch_blocks.headers[i - 2].clone_era_end() {
-                        Some(era_report) => {
-                            let next_weights = era_report.next_era_validator_weights().clone();
-                            let total_next_weights = next_weights
-                                .iter()
-                                .fold(U512::zero(), move |acc, s| acc + s.1);
-                            (Some(next_weights), Some(total_next_weights))
-                        }
-                        _ => panic!("unexpectedly absent era report"),
+                match switch_blocks.headers[weights_block_idx].clone_era_end() {
+                    Some(era_report) => {
+                        let next_weights = era_report.next_era_validator_weights().clone();
+                        let total_next_weights = next_weights
+                            .iter()
+                            .fold(U512::zero(), move |acc, s| acc + s.1);
+                        (next_weights, total_next_weights)
                     }
+                    _ => panic!("unexpectedly absent era report"),
                 };
 
             // TODO: Investigate whether the rewards pay out for the signatures
@@ -2336,28 +2350,32 @@ async fn run_rewards_network_scenario(
                     .core_config
                     .round_seigniorage_rate
                     .into_u512();
-            let previous_signatures_reward = if switch_blocks.headers[i - 1].is_genesis() {
-                None
+            let previous_signatures_reward_idx = if switch_blocks.headers[i - 1].is_genesis() {
+                i - 1
             } else {
-                Some(
-                    fixture
-                        .chainspec
-                        .core_config
-                        .finality_signature_proportion
-                        .into_u512()
-                        * recomputed_total_supply[&(i - 2)]
-                        * fixture
-                            .chainspec
-                            .core_config
-                            .round_seigniorage_rate
-                            .into_u512(),
-                )
+                i - 2
             };
+            let previous_signatures_reward = fixture
+                .chainspec
+                .core_config
+                .finality_signature_proportion
+                .into_u512()
+                * recomputed_total_supply[&previous_signatures_reward_idx]
+                * fixture
+                    .chainspec
+                    .core_config
+                    .round_seigniorage_rate
+                    .into_u512();
 
             rewarded_blocks.iter().for_each(|block: &Block| {
                 // Block production rewards
                 let proposer = block.proposer().clone();
-                add_to_rewards(proposer.clone(), block_reward, &mut recomputed_era_rewards);
+                add_to_rewards(
+                    proposer.clone(),
+                    block.era_id(),
+                    block_reward,
+                    &mut recomputed_era_rewards,
+                );
 
                 // Recover relevant finality signatures
                 // TODO: Deal with the implicit assumption that lookback only look backs one
@@ -2366,12 +2384,9 @@ async fn run_rewards_network_scenario(
                     |(offset, signatures_packed)| {
                         if block.height() as usize - offset - 1
                             <= previous_switch_block_height as usize
-                            && !switch_blocks.headers[i - 1].is_genesis()
                         {
                             let rewarded_contributors = signatures_packed.to_validator_set(
                                 previous_era_slated_weights
-                                    .as_ref()
-                                    .expect("expected previous era weights")
                                     .keys()
                                     .cloned()
                                     .collect::<BTreeSet<PublicKey>>(),
@@ -2379,27 +2394,26 @@ async fn run_rewards_network_scenario(
                             rewarded_contributors.iter().for_each(|contributor| {
                                 let contributor_proportion = Ratio::new(
                                     previous_era_slated_weights
-                                        .as_ref()
-                                        .expect("expected previous era weights")
                                         .get(contributor)
                                         .copied()
                                         .expect("expected current era validator"),
-                                    total_previous_era_weights
-                                        .expect("expected total previous era weight"),
+                                    total_previous_era_weights,
                                 );
                                 add_to_rewards(
                                     proposer.clone(),
+                                    switch_blocks.headers[i - 1].era_id(),
                                     fixture.chainspec.core_config.finders_fee.into_u512()
                                         * contributor_proportion
-                                        * previous_signatures_reward.unwrap(),
+                                        * previous_signatures_reward,
                                     &mut recomputed_era_rewards,
                                 );
                                 add_to_rewards(
                                     contributor.clone(),
+                                    switch_blocks.headers[i - 1].era_id(),
                                     (Ratio::<U512>::one()
                                         - fixture.chainspec.core_config.finders_fee.into_u512())
                                         * contributor_proportion
-                                        * previous_signatures_reward.unwrap(),
+                                        * previous_signatures_reward,
                                     &mut recomputed_era_rewards,
                                 )
                             });
@@ -2419,6 +2433,7 @@ async fn run_rewards_network_scenario(
                                 );
                                 add_to_rewards(
                                     proposer.clone(),
+                                    block.era_id(),
                                     fixture.chainspec.core_config.finders_fee.into_u512()
                                         * contributor_proportion
                                         * signatures_reward,
@@ -2426,6 +2441,7 @@ async fn run_rewards_network_scenario(
                                 );
                                 add_to_rewards(
                                     contributor.clone(),
+                                    block.era_id(),
                                     (Ratio::<U512>::one()
                                         - fixture.chainspec.core_config.finders_fee.into_u512())
                                         * contributor_proportion
@@ -2440,9 +2456,11 @@ async fn run_rewards_network_scenario(
 
             // Make sure we round just as we do in the real code, at the end of an era's
             // calculation, right before minting and transferring
-            recomputed_era_rewards.iter_mut().for_each(|(_, reward)| {
-                let truncated_reward = reward.trunc();
-                *reward = truncated_reward;
+            recomputed_era_rewards.iter_mut().for_each(|(_, rewards)| {
+                rewards.values_mut().for_each(|amount| {
+                    *amount = amount.trunc();
+                });
+                let truncated_reward = rewards.values().sum::<Ratio<U512>>();
                 let era_end_supply = recomputed_total_supply
                     .get_mut(&i)
                     .expect("expected supply at end of era");
@@ -2481,16 +2499,23 @@ async fn run_rewards_network_scenario(
                     .fold(U512::zero(), |acc, reward| U512::from(*reward.1) + acc),
                 Rewards::V2(v2_rewards) => v2_rewards
                     .iter()
-                    .fold(U512::zero(), |acc, reward| *reward.1 + acc),
+                    .flat_map(|(_key, amounts)| amounts)
+                    .fold(U512::zero(), |acc, reward| *reward + acc),
             };
-            let recomputed_total_rewards = rewards
-                .iter()
-                .fold(U512::zero(), |acc, x| x.1.to_integer() + acc);
+            let recomputed_total_rewards: U512 = rewards
+                .values()
+                .flat_map(|amounts| amounts.values().map(|reward| reward.to_integer()))
+                .sum();
             assert_eq!(
                 Ratio::from(recomputed_total_rewards),
                 Ratio::from(observed_total_rewards),
-                "total rewards do not match at era {}",
-                era
+                "total rewards do not match at era {}\nobserved = {:#?}\nrecomputed = {:#?}",
+                era,
+                switch_blocks.headers[*era]
+                    .clone_era_end()
+                    .expect("")
+                    .rewards(),
+                rewards,
             );
             assert_eq!(
                 Ratio::from(recomputed_total_rewards),

--- a/node/src/types/block/executable_block.rs
+++ b/node/src/types/block/executable_block.rs
@@ -25,7 +25,7 @@ pub struct ExecutableBlock {
     pub(crate) transaction_map: BTreeMap<u8, Vec<TransactionHash>>,
     /// `None` may indicate that the rewards have not been computed yet,
     /// or that the block is not a switch one.
-    pub(crate) rewards: Option<BTreeMap<PublicKey, U512>>,
+    pub(crate) rewards: Option<BTreeMap<PublicKey, Vec<U512>>>,
     /// `None` may indicate that the next era gas has not been computed yet,
     /// or that the block is not a switch one.
     pub(crate) next_era_gas_price: Option<u8>,

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -54,6 +54,17 @@ pub fn validate_chainspec(chainspec: &Chainspec) -> bool {
         }
     }
 
+    // We don't support lookback by more than one era in the rewards scheme.
+    if chainspec.core_config.minimum_era_height < chainspec.core_config.signature_rewards_max_delay
+    {
+        error!(
+            minimum_era_height = %chainspec.core_config.minimum_era_height,
+            signature_rewards_max_delay = %chainspec.core_config.signature_rewards_max_delay,
+            "signature_rewards_max_delay must be less than minimum_era_height"
+        );
+        return false;
+    }
+
     network::within_message_size_limit_tolerance(chainspec)
         && validate_protocol_config(&chainspec.protocol_config)
         && validate_core_config(&chainspec.core_config)

--- a/node/src/utils/specimen.rs
+++ b/node/src/utils/specimen.rs
@@ -635,11 +635,20 @@ impl LargestSpecimen for EraEndV1 {
 
 impl LargestSpecimen for EraEndV2 {
     fn largest_specimen<E: SizeEstimator>(estimator: &E, cache: &mut Cache) -> Self {
+        let rewards = {
+            let count = estimator.parameter("validator_count");
+
+            PublicKey::large_unique_sequence(estimator, count, cache)
+                .into_iter()
+                // at most two reward amounts per validator
+                .map(|key| (key, vec_of_largest_specimen(estimator, 2, cache)))
+                .collect()
+        };
         EraEndV2::new(
             vec_prop_specimen(estimator, "validator_count", cache),
             vec_prop_specimen(estimator, "validator_count", cache),
             btree_map_distinct_from_prop(estimator, "validator_count", cache),
-            btree_map_distinct_from_prop(estimator, "validator_count", cache),
+            rewards,
             1u8,
         )
     }

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -778,7 +778,10 @@
           "description": "The rewards distributed to the validators.",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/U512"
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/U512"
+            }
           }
         },
         "next_era_gas_price": {

--- a/storage/src/data_access_layer/block_rewards.rs
+++ b/storage/src/data_access_layer/block_rewards.rs
@@ -17,7 +17,7 @@ pub struct BlockRewardsRequest {
     config: Config,
     state_hash: Digest,
     protocol_version: ProtocolVersion,
-    rewards: BTreeMap<PublicKey, U512>,
+    rewards: BTreeMap<PublicKey, Vec<U512>>,
     block_time: BlockTime,
 }
 
@@ -27,7 +27,7 @@ impl BlockRewardsRequest {
         state_hash: Digest,
         protocol_version: ProtocolVersion,
         block_time: BlockTime,
-        rewards: BTreeMap<PublicKey, U512>,
+        rewards: BTreeMap<PublicKey, Vec<U512>>,
     ) -> Self {
         BlockRewardsRequest {
             config,
@@ -54,7 +54,7 @@ impl BlockRewardsRequest {
     }
 
     /// Returns rewards.
-    pub fn rewards(&self) -> &BTreeMap<PublicKey, U512> {
+    pub fn rewards(&self) -> &BTreeMap<PublicKey, Vec<U512>> {
         &self.rewards
     }
 

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -618,8 +618,9 @@ pub trait Auction:
                     .enumerate()
                     .map(move |(i, amount)| (key.clone(), amount, i as u64))
             })
-            // do not process zero amounts unnecessarily
-            .filter(|(_key, amount, _eras_back)| !amount.is_zero())
+            // do not process zero amounts, unless they are for the current era (we still want to
+            // record zero allocations for the current validators in EraInfo)
+            .filter(|(_key, amount, eras_back)| !amount.is_zero() || *eras_back == 0)
         {
             // fetch most recent validator public key if public key was changed
             // or the validator withdrew their bid completely

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -475,7 +475,9 @@ pub trait Auction:
         let vesting_schedule_period_millis = self.vesting_schedule_period_millis();
         let validator_slots = detail::get_validator_slots(self)?;
         let auction_delay = detail::get_auction_delay(self)?;
-        let snapshot_size = auction_delay as usize + 1;
+        // We have to store auction_delay future eras, one current era and one past era (for
+        // rewards calculations).
+        let snapshot_size = auction_delay as usize + 2;
         let mut era_id: EraId = detail::get_era_id(self)?;
 
         // Process unbond requests

--- a/types/src/block/rewards.rs
+++ b/types/src/block/rewards.rs
@@ -1,11 +1,12 @@
-use alloc::collections::BTreeMap;
+use alloc::{collections::BTreeMap, vec::Vec};
 
 use crate::{PublicKey, U512};
 
 /// Rewards distributed to validators.
+#[derive(Debug)]
 pub enum Rewards<'a> {
     /// Rewards for version 1, associate a ratio to each validator.
     V1(&'a BTreeMap<PublicKey, u64>),
     /// Rewards for version 1, associate a tokens amount to each validator.
-    V2(&'a BTreeMap<PublicKey, U512>),
+    V2(&'a BTreeMap<PublicKey, Vec<U512>>),
 }

--- a/types/src/block/test_block_builder/test_block_v2_builder.rs
+++ b/types/src/block/test_block_builder/test_block_v2_builder.rs
@@ -275,8 +275,11 @@ fn gen_era_end_v2(
         .collect();
     let rewards = iter::repeat_with(|| {
         let pub_key = PublicKey::random(rng);
-        let reward = rng.gen_range(1..=1_000_000_000 + 1);
-        (pub_key, U512::from(reward))
+        let mut rewards = vec![U512::from(rng.gen_range(1..=1_000_000_000 + 1))];
+        if rng.gen_bool(0.2) {
+            rewards.push(U512::from(rng.gen_range(1..=1_000_000_000 + 1)));
+        };
+        (pub_key, rewards)
     })
     .take(rewards_count)
     .collect();

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -53,6 +53,15 @@ impl EraId {
         (current_era_id..=current_era_id + num_eras).map(EraId)
     }
 
+    /// Returns an iterator over a range of era IDs, starting from `start` and ending at `end`,
+    /// inclusive.
+    pub fn iter_range_inclusive(
+        start: EraId,
+        end: EraId,
+    ) -> impl DoubleEndedIterator<Item = EraId> {
+        (start.0..=end.0).map(EraId)
+    }
+
     /// Increments the era.
     ///
     /// For `u64::MAX`, this returns `u64::MAX` again: We want to make sure this doesn't panic, and


### PR DESCRIPTION
This PR fixes how the rewards are being distributed between the validator and their delegators when a part of the reward is for finality signatures from the previous era.

In order to use the correct weights, one past era is now kept in the `SeigniorageRecipientsSnapshot` in the auction contract state. We also support finality signatures from only one past era to be rewarded, and chainspec settings are being validated to make sure that the lookback can never reach more than one past era.

The calculated reward amounts per validator are now split into up to two amounts, one per era, so that auction can know which part to distribute according to which era's weights.

Closes #4724 