### PR TITLE
Remove unused "gas_hold_handling" from binary port config

### DIFF
--- a/node/src/components/binary_port/config.rs
+++ b/node/src/components/binary_port/config.rs
@@ -1,4 +1,3 @@
-use casper_types::{HoldBalanceHandling, DEFAULT_GAS_HOLD_BALANCE_HANDLING};
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
@@ -38,8 +37,6 @@ pub struct Config {
     pub client_request_buffer_size: usize,
     /// Maximum number of connections to the server.
     pub max_connections: usize,
-    /// Gas hold handling
-    pub gas_hold_handling: HoldBalanceHandling,
 }
 
 impl Config {
@@ -55,7 +52,6 @@ impl Config {
             max_message_size_bytes: DEFAULT_MAX_MESSAGE_SIZE,
             client_request_buffer_size: DEFAULT_CHANNEL_BUFFER_SIZE,
             max_connections: DEFAULT_MAX_CONNECTIONS,
-            gas_hold_handling: DEFAULT_GAS_HOLD_BALANCE_HANDLING,
         }
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -317,8 +317,6 @@ client_request_limit = 10
 # Number of requests that can be buffered.
 client_request_buffer_size = 20
 
-gas_hold_handling = { type = 'accrued' }
-
 # Maximum number of connections to the server.
 max_connections = 16
 

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -315,8 +315,6 @@ client_request_limit = 3
 # Number of requests that can be buffered per client.
 client_request_buffer_size = 16
 
-gas_hold_handling = { type = 'accrued' }
-
 # Maximum number of connections to the server.
 max_connections = 16
 


### PR DESCRIPTION
This PR removes the no longer used "gas_hold_handling" from binary port config. It was initially added [here](https://github.com/casper-network/casper-node/pull/4671), but then moved to chainspec.