### PR TITLE
Protocol upgrade as async task

### DIFF
--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -502,13 +502,16 @@ impl ContractRuntime {
                         next_block_height,
                         PublicKey::System,
                     );
+
+                    info!("Enqueuing block for execution post state refresh");
+
                     effect_builder.enqueue_block_for_execution(
                         ExecutableBlock::from_finalized_block_and_transactions(
                             finalized_block,
                             vec![],
                         ),
                         MetaBlockState::new_not_to_be_gossiped(),
-                    ).ignore::<REv>();
+                    ).await;
                 }.ignore()
             }
             ContractRuntimeRequest::DoProtocolUpgrade {

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -38,12 +38,11 @@ use casper_storage::{
         transaction_source::lmdb::LmdbEnvironment,
         trie_store::lmdb::LmdbTrieStore,
     },
-    system::{genesis::GenesisError},
+    system::genesis::GenesisError,
     tracking_copy::TrackingCopyError,
 };
 use casper_types::{
-    ActivationPoint, Chainspec, ChainspecRawBytes, ChainspecRegistry, EraId,
-    PublicKey,
+    ActivationPoint, Chainspec, ChainspecRawBytes, ChainspecRegistry, EraId, PublicKey,
 };
 
 use crate::{
@@ -266,7 +265,6 @@ impl ContractRuntime {
         result
     }
 
-
     /// Handles a contract runtime request.
     fn handle_contract_runtime_request<REv>(
         &mut self,
@@ -274,8 +272,8 @@ impl ContractRuntime {
         _rng: &mut NodeRng,
         request: ContractRuntimeRequest,
     ) -> Effects<Event>
-        where
-            REv: From<ContractRuntimeRequest>
+    where
+        REv: From<ContractRuntimeRequest>
             + From<ContractRuntimeAnnouncement>
             + From<StorageRequest>
             + From<MetaBlockAnnouncement>
@@ -298,7 +296,7 @@ impl ContractRuntime {
                     trace!(?result, "query result");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::QueryByPrefix {
                 request: query_request,
@@ -315,7 +313,7 @@ impl ContractRuntime {
                     trace!(?result, "query by prefix result");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::GetBalance {
                 request: balance_request,
@@ -331,7 +329,7 @@ impl ContractRuntime {
                     trace!(?result, "balance result");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::GetEraValidators {
                 request: era_validators_request,
@@ -349,7 +347,7 @@ impl ContractRuntime {
                     trace!(?result, "era validators result");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::GetExecutionResultsChecksum {
                 state_root_hash,
@@ -368,7 +366,7 @@ impl ContractRuntime {
                     trace!(?result, "execution result checksum");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::GetAddressableEntity {
                 state_root_hash,
@@ -388,7 +386,7 @@ impl ContractRuntime {
                     trace!(?result, "get addressable entity");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::GetEntryPoint {
                 state_root_hash,
@@ -406,7 +404,7 @@ impl ContractRuntime {
                     trace!(?result, "get addressable entity");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::GetTaggedValues {
                 request: tagged_values_request,
@@ -424,7 +422,7 @@ impl ContractRuntime {
                     trace!(?result, "get all values result");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             // trie related events
             ContractRuntimeRequest::GetTrie {
@@ -441,7 +439,7 @@ impl ContractRuntime {
                     trace!(?result, "trie response");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::PutTrie {
                 request: put_trie_request,
@@ -462,7 +460,7 @@ impl ContractRuntime {
                     trace!(?result, "put trie response");
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::UpdatePreState { new_pre_state } => {
                 let next_block_height = new_pre_state.next_block_height();
@@ -473,24 +471,24 @@ impl ContractRuntime {
                         .await
                     {
                         Some(header)
-                        if header.is_switch_block()
-                            && (header.height() + 1 == next_block_height) =>
-                            {
-                                header
-                            }
+                            if header.is_switch_block()
+                                && (header.height() + 1 == next_block_height) =>
+                        {
+                            header
+                        }
                         Some(_) => {
                             return fatal!(
                                 effect_builder,
                                 "Latest complete block is not a switch block to update state"
                             )
-                                .await;
+                            .await;
                         }
                         None => {
                             return fatal!(
                                 effect_builder,
                                 "No complete block header found to update post upgrade state"
                             )
-                                .await;
+                            .await;
                         }
                     };
 
@@ -505,14 +503,17 @@ impl ContractRuntime {
 
                     info!("Enqueuing block for execution post state refresh");
 
-                    effect_builder.enqueue_block_for_execution(
-                        ExecutableBlock::from_finalized_block_and_transactions(
-                            finalized_block,
-                            vec![],
-                        ),
-                        MetaBlockState::new_not_to_be_gossiped(),
-                    ).await;
-                }.ignore()
+                    effect_builder
+                        .enqueue_block_for_execution(
+                            ExecutableBlock::from_finalized_block_and_transactions(
+                                finalized_block,
+                                vec![],
+                            ),
+                            MetaBlockState::new_not_to_be_gossiped(),
+                        )
+                        .await;
+                }
+                .ignore()
             }
             ContractRuntimeRequest::DoProtocolUpgrade {
                 protocol_upgrade_config,
@@ -533,7 +534,7 @@ impl ContractRuntime {
                         parent_hash,
                         parent_seed,
                     )
-                        .ignore(),
+                    .ignore(),
                 );
                 effects
             }
@@ -608,7 +609,7 @@ impl ContractRuntime {
                                 meta_block_state,
                                 current_gas_price,
                             )
-                                .ignore(),
+                            .ignore(),
                         )
                     }
                 }
@@ -635,10 +636,10 @@ impl ContractRuntime {
                             *transaction,
                         )
                     })
-                        .await;
+                    .await;
                     responder.respond(result).await
                 }
-                    .ignore()
+                .ignore()
             }
             ContractRuntimeRequest::GetEraGasPrice { era_id, responder } => responder
                 .respond(self.current_gas_price.maybe_gas_price_for_era_id(era_id))
@@ -656,8 +657,8 @@ impl ContractRuntime {
         effect_builder: EffectBuilder<REv>,
         TrieRequestIncoming { sender, message }: TrieRequestIncoming,
     ) -> Effects<Event>
-        where
-            REv: From<NetworkRequest<Message>> + Send,
+    where
+        REv: From<NetworkRequest<Message>> + Send,
     {
         let TrieRequestMessage(ref serialized_id) = *message;
         let fetch_response = match self.fetch_trie_local(serialized_id) {
@@ -745,8 +746,8 @@ impl ContractRuntime {
 }
 
 impl<REv> Component<REv> for ContractRuntime
-    where
-        REv: From<ContractRuntimeRequest>
+where
+    REv: From<ContractRuntimeRequest>
         + From<ContractRuntimeAnnouncement>
         + From<NetworkRequest<Message>>
         + From<StorageRequest>

--- a/node/src/components/contract_runtime/utils.rs
+++ b/node/src/components/contract_runtime/utils.rs
@@ -26,7 +26,6 @@ use crate::{
     types::{ExecutableBlock, MetaBlock, MetaBlockState},
 };
 
-use crate::types::{BlockPayload, FinalizedBlock, InternalEraReport};
 use casper_binary_port::SpeculativeExecutionResult;
 use casper_execution_engine::engine_state::{ExecutionEngineV1, WasmV1Result};
 use casper_storage::{
@@ -34,11 +33,9 @@ use casper_storage::{
         DataAccessLayer, FlushRequest, FlushResult, ProtocolUpgradeRequest, ProtocolUpgradeResult,
     },
     global_state::state::{lmdb::LmdbGlobalState, CommitProvider, StateProvider},
-    system::protocol_upgrade::ProtocolUpgradeError,
 };
 use casper_types::{
-    BlockHash, BlockHeader, Chainspec, Digest, EraId, GasLimited, Key, ProtocolUpgradeConfig,
-    PublicKey,
+    BlockHash, Chainspec, Digest, EraId, GasLimited, Key, ProtocolUpgradeConfig,
 };
 
 /// Maximum number of resource intensive tasks that can be run in parallel.

--- a/node/src/components/contract_runtime/utils.rs
+++ b/node/src/components/contract_runtime/utils.rs
@@ -6,6 +6,7 @@ use std::{
     fmt::Debug,
     ops::Range,
     sync::{Arc, Mutex},
+    time::Instant,
 };
 use tracing::{debug, error, info, warn};
 
@@ -25,12 +26,20 @@ use crate::{
     types::{ExecutableBlock, MetaBlock, MetaBlockState},
 };
 
+use crate::types::{BlockPayload, FinalizedBlock, InternalEraReport};
 use casper_binary_port::SpeculativeExecutionResult;
 use casper_execution_engine::engine_state::{ExecutionEngineV1, WasmV1Result};
 use casper_storage::{
-    data_access_layer::DataAccessLayer, global_state::state::lmdb::LmdbGlobalState,
+    data_access_layer::{
+        DataAccessLayer, FlushRequest, FlushResult, ProtocolUpgradeRequest, ProtocolUpgradeResult,
+    },
+    global_state::state::{lmdb::LmdbGlobalState, CommitProvider, StateProvider},
+    system::protocol_upgrade::ProtocolUpgradeError,
 };
-use casper_types::{BlockHash, Chainspec, EraId, GasLimited, Key};
+use casper_types::{
+    BlockHash, BlockHeader, Chainspec, Digest, EraId, GasLimited, Key, ProtocolUpgradeConfig,
+    PublicKey,
+};
 
 /// Maximum number of resource intensive tasks that can be run in parallel.
 ///
@@ -46,9 +55,9 @@ static INTENSIVE_TASKS_SEMAPHORE: Lazy<tokio::sync::Semaphore> =
 /// The task is a closure that takes no arguments and returns a value.
 /// This function returns a future for that value.
 pub(super) async fn run_intensive_task<T, V>(task: T) -> V
-where
-    T: 'static + Send + FnOnce() -> V,
-    V: 'static + Send + Debug,
+    where
+        T: 'static + Send + FnOnce() -> V,
+        V: 'static + Send + Debug,
 {
     // This will never panic since the semaphore is never closed.
     let _permit = INTENSIVE_TASKS_SEMAPHORE.acquire().await.unwrap();
@@ -78,11 +87,11 @@ pub(super) async fn exec_or_requeue<REv>(
     current_gas_price: u8,
 ) where
     REv: From<ContractRuntimeRequest>
-        + From<ContractRuntimeAnnouncement>
-        + From<StorageRequest>
-        + From<MetaBlockAnnouncement>
-        + From<FatalAnnouncement>
-        + Send,
+    + From<ContractRuntimeAnnouncement>
+    + From<StorageRequest>
+    + From<MetaBlockAnnouncement>
+    + From<FatalAnnouncement>
+    + Send,
 {
     debug!("ContractRuntime: execute_finalized_block_or_requeue");
     let contract_runtime_metrics = metrics.clone();
@@ -95,7 +104,7 @@ pub(super) async fn exec_or_requeue<REv>(
                 chainspec.as_ref(),
                 executable_block.clone(),
             )
-            .await
+                .await
             {
                 Ok(rewards) => rewards,
                 Err(e) => {
@@ -175,7 +184,7 @@ pub(super) async fn exec_or_requeue<REv>(
                     executable_block.transactions.len() as u64 * 100,
                     per_block_capacity,
                 )
-                .to_integer();
+                    .to_integer();
 
                 let uitilization_scores = vec![slot_utilization, gas_utilization, size_utilization];
 
@@ -259,7 +268,7 @@ pub(super) async fn exec_or_requeue<REv>(
             last_switch_block_hash,
         )
     })
-    .await
+        .await
     {
         Ok(ret) => ret,
         Err(error) => {
@@ -293,9 +302,9 @@ pub(super) async fn exec_or_requeue<REv>(
     let current_era_id = block.era_id();
 
     if let Some(StepOutcome {
-        step_effects,
-        mut upcoming_era_validators,
-    }) = maybe_step_outcome
+                    step_effects,
+                    mut upcoming_era_validators,
+                }) = maybe_step_outcome
     {
         effect_builder
             .announce_commit_step_success(current_era_id, step_effects)
@@ -377,15 +386,86 @@ pub(super) async fn exec_or_requeue<REv>(
 
     // We schedule the next block from the queue to be executed:
     if let Some(QueueItem {
-        executable_block,
-        meta_block_state,
-    }) = next_block
+                    executable_block,
+                    meta_block_state,
+                }) = next_block
     {
         metrics.exec_queue_size.dec();
         debug!("ContractRuntime: next block enqueue_block_for_execution");
         effect_builder
             .enqueue_block_for_execution(executable_block, meta_block_state)
             .await;
+    }
+}
+
+pub(super) async fn handle_protocol_upgrade<REv>(
+    effect_builder: EffectBuilder<REv>,
+    data_access_layer: Arc<DataAccessLayer<LmdbGlobalState>>,
+    metrics: Arc<Metrics>,
+    upgrade_config: ProtocolUpgradeConfig,
+    next_block_height: u64,
+    parent_hash: BlockHash,
+    parent_seed: Digest,
+) where
+    REv: From<ContractRuntimeRequest>
+    + From<ContractRuntimeAnnouncement>
+    + From<StorageRequest>
+    + From<MetaBlockAnnouncement>
+    + From<FatalAnnouncement>
+    + Send,
+{
+    debug!(?upgrade_config, "upgrade");
+    let start = Instant::now();
+    let upgrade_request = ProtocolUpgradeRequest::new(upgrade_config);
+
+    let result = run_intensive_task(move || {
+        let result = data_access_layer.protocol_upgrade(upgrade_request);
+        if result.is_success() {
+            info!("committed upgrade");
+            metrics
+                .commit_upgrade
+                .observe(start.elapsed().as_secs_f64());
+            let flush_req = FlushRequest::new();
+            if let FlushResult::Failure(err) = data_access_layer.flush(flush_req) {
+                return Err(format!("{:?}", err));
+            }
+        }
+
+        Ok(result)
+    })
+        .await;
+
+    match result {
+        Err(error_msg) => {
+            // The only way this happens is if there is a problem in the flushing.
+            error!(%error_msg, ":Error in post upgrade flush");
+            fatal!(effect_builder, "{}", error_msg).await;
+        }
+        Ok(result) => match result {
+            ProtocolUpgradeResult::RootNotFound => {
+                let error_msg = "Root not found for protocol upgrade";
+                error!(%error_msg);
+                fatal!(effect_builder, "{}", error_msg).await;
+            }
+            ProtocolUpgradeResult::Failure(err) => {
+                error!(%err, ": Failure in protocol upgrade");
+                fatal!(effect_builder, "{:?}", err).await;
+            }
+            ProtocolUpgradeResult::Success {
+                post_state_hash, ..
+            } => {
+                let post_upgrade_state = ExecutionPreState::new(
+                    next_block_height,
+                    post_state_hash,
+                    parent_hash,
+                    parent_seed,
+                );
+
+                effect_builder
+                    .update_contract_runtime_state(post_upgrade_state)
+                    .await
+            }
+        },
     }
 }
 

--- a/node/src/components/contract_runtime/utils.rs
+++ b/node/src/components/contract_runtime/utils.rs
@@ -34,9 +34,7 @@ use casper_storage::{
     },
     global_state::state::{lmdb::LmdbGlobalState, CommitProvider, StateProvider},
 };
-use casper_types::{
-    BlockHash, Chainspec, Digest, EraId, GasLimited, Key, ProtocolUpgradeConfig,
-};
+use casper_types::{BlockHash, Chainspec, Digest, EraId, GasLimited, Key, ProtocolUpgradeConfig};
 
 /// Maximum number of resource intensive tasks that can be run in parallel.
 ///
@@ -52,9 +50,9 @@ static INTENSIVE_TASKS_SEMAPHORE: Lazy<tokio::sync::Semaphore> =
 /// The task is a closure that takes no arguments and returns a value.
 /// This function returns a future for that value.
 pub(super) async fn run_intensive_task<T, V>(task: T) -> V
-    where
-        T: 'static + Send + FnOnce() -> V,
-        V: 'static + Send + Debug,
+where
+    T: 'static + Send + FnOnce() -> V,
+    V: 'static + Send + Debug,
 {
     // This will never panic since the semaphore is never closed.
     let _permit = INTENSIVE_TASKS_SEMAPHORE.acquire().await.unwrap();
@@ -84,11 +82,11 @@ pub(super) async fn exec_or_requeue<REv>(
     current_gas_price: u8,
 ) where
     REv: From<ContractRuntimeRequest>
-    + From<ContractRuntimeAnnouncement>
-    + From<StorageRequest>
-    + From<MetaBlockAnnouncement>
-    + From<FatalAnnouncement>
-    + Send,
+        + From<ContractRuntimeAnnouncement>
+        + From<StorageRequest>
+        + From<MetaBlockAnnouncement>
+        + From<FatalAnnouncement>
+        + Send,
 {
     debug!("ContractRuntime: execute_finalized_block_or_requeue");
     let contract_runtime_metrics = metrics.clone();
@@ -101,7 +99,7 @@ pub(super) async fn exec_or_requeue<REv>(
                 chainspec.as_ref(),
                 executable_block.clone(),
             )
-                .await
+            .await
             {
                 Ok(rewards) => rewards,
                 Err(e) => {
@@ -181,7 +179,7 @@ pub(super) async fn exec_or_requeue<REv>(
                     executable_block.transactions.len() as u64 * 100,
                     per_block_capacity,
                 )
-                    .to_integer();
+                .to_integer();
 
                 let uitilization_scores = vec![slot_utilization, gas_utilization, size_utilization];
 
@@ -265,7 +263,7 @@ pub(super) async fn exec_or_requeue<REv>(
             last_switch_block_hash,
         )
     })
-        .await
+    .await
     {
         Ok(ret) => ret,
         Err(error) => {
@@ -299,9 +297,9 @@ pub(super) async fn exec_or_requeue<REv>(
     let current_era_id = block.era_id();
 
     if let Some(StepOutcome {
-                    step_effects,
-                    mut upcoming_era_validators,
-                }) = maybe_step_outcome
+        step_effects,
+        mut upcoming_era_validators,
+    }) = maybe_step_outcome
     {
         effect_builder
             .announce_commit_step_success(current_era_id, step_effects)
@@ -383,9 +381,9 @@ pub(super) async fn exec_or_requeue<REv>(
 
     // We schedule the next block from the queue to be executed:
     if let Some(QueueItem {
-                    executable_block,
-                    meta_block_state,
-                }) = next_block
+        executable_block,
+        meta_block_state,
+    }) = next_block
     {
         metrics.exec_queue_size.dec();
         debug!("ContractRuntime: next block enqueue_block_for_execution");
@@ -405,11 +403,11 @@ pub(super) async fn handle_protocol_upgrade<REv>(
     parent_seed: Digest,
 ) where
     REv: From<ContractRuntimeRequest>
-    + From<ContractRuntimeAnnouncement>
-    + From<StorageRequest>
-    + From<MetaBlockAnnouncement>
-    + From<FatalAnnouncement>
-    + Send,
+        + From<ContractRuntimeAnnouncement>
+        + From<StorageRequest>
+        + From<MetaBlockAnnouncement>
+        + From<FatalAnnouncement>
+        + Send,
 {
     debug!(?upgrade_config, "upgrade");
     let start = Instant::now();
@@ -430,7 +428,7 @@ pub(super) async fn handle_protocol_upgrade<REv>(
 
         Ok(result)
     })
-        .await;
+    .await;
 
     match result {
         Err(error_msg) => {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -324,13 +324,13 @@ impl<T: Debug> Responder<T> {
 
 impl<T> Debug for Responder<T> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        write!(formatter, "Responder<{}>", type_name::<T>(), )
+        write!(formatter, "Responder<{}>", type_name::<T>(),)
     }
 }
 
 impl<T> Display for Responder<T> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-        write!(formatter, "responder({})", type_name::<T>(), )
+        write!(formatter, "responder({})", type_name::<T>(),)
     }
 }
 
@@ -373,21 +373,21 @@ pub(crate) trait EffectExt: Future + Send {
     ///
     /// The function `f` is used to translate the returned value from an effect into an event.
     fn event<U, F>(self, f: F) -> Effects<U>
-        where
-            F: FnOnce(Self::Output) -> U + 'static + Send,
-            U: 'static,
-            Self: Sized;
+    where
+        F: FnOnce(Self::Output) -> U + 'static + Send,
+        U: 'static,
+        Self: Sized;
 
     /// Finalizes a future into an effect that returns an iterator of events.
     ///
     /// The function `f` is used to translate the returned value from an effect into an iterator of
     /// events.
     fn events<U, F, I>(self, f: F) -> Effects<U>
-        where
-            F: FnOnce(Self::Output) -> I + 'static + Send,
-            U: 'static,
-            I: Iterator<Item=U>,
-            Self: Sized;
+    where
+        F: FnOnce(Self::Output) -> I + 'static + Send,
+        U: 'static,
+        I: Iterator<Item = U>,
+        Self: Sized;
 
     /// Finalizes a future into an effect that runs but drops the result.
     fn ignore<Ev>(self) -> Effects<Ev>;
@@ -406,10 +406,10 @@ pub(crate) trait EffectResultExt {
     /// The function `f_ok` is used to translate the returned value from an effect into an event,
     /// while the function `f_err` does the same for a potential error.
     fn result<U, F, G>(self, f_ok: F, f_err: G) -> Effects<U>
-        where
-            F: FnOnce(Self::Value) -> U + 'static + Send,
-            G: FnOnce(Self::Error) -> U + 'static + Send,
-            U: 'static;
+    where
+        F: FnOnce(Self::Value) -> U + 'static + Send,
+        G: FnOnce(Self::Error) -> U + 'static + Send,
+        U: 'static;
 }
 
 /// Effect extension for futures, used to convert futures returning an `Option` into two different
@@ -423,38 +423,38 @@ pub(crate) trait EffectOptionExt {
     /// The function `f_some` is used to translate the returned value from an effect into an event,
     /// while the function `f_none` does the same for a returned `None`.
     fn map_or_else<U, F, G>(self, f_some: F, f_none: G) -> Effects<U>
-        where
-            F: FnOnce(Self::Value) -> U + 'static + Send,
-            G: FnOnce() -> U + 'static + Send,
-            U: 'static;
+    where
+        F: FnOnce(Self::Value) -> U + 'static + Send,
+        G: FnOnce() -> U + 'static + Send,
+        U: 'static;
 
     /// Finalizes a future returning an `Option` into two different effects.
     ///
     /// The function `f` is used to translate the returned value from an effect into an event,
     /// In the case of `None`, empty vector of effects is returned.
     fn map_some<U, F>(self, f: F) -> Effects<U>
-        where
-            F: FnOnce(Self::Value) -> U + 'static + Send,
-            U: 'static;
+    where
+        F: FnOnce(Self::Value) -> U + 'static + Send,
+        U: 'static;
 }
 
 impl<T: ?Sized> EffectExt for T
-    where
-        T: Future + Send + 'static + Sized,
+where
+    T: Future + Send + 'static + Sized,
 {
     fn event<U, F>(self, f: F) -> Effects<U>
-        where
-            F: FnOnce(Self::Output) -> U + 'static + Send,
-            U: 'static,
+    where
+        F: FnOnce(Self::Output) -> U + 'static + Send,
+        U: 'static,
     {
         smallvec![self.map(f).map(|item| smallvec![item]).boxed()]
     }
 
     fn events<U, F, I>(self, f: F) -> Effects<U>
-        where
-            F: FnOnce(Self::Output) -> I + 'static + Send,
-            U: 'static,
-            I: Iterator<Item=U>,
+    where
+        F: FnOnce(Self::Output) -> I + 'static + Send,
+        U: 'static,
+        I: Iterator<Item = U>,
     {
         smallvec![self.map(f).map(|iter| iter.collect()).boxed()]
     }
@@ -465,18 +465,18 @@ impl<T: ?Sized> EffectExt for T
 }
 
 impl<T, V, E> EffectResultExt for T
-    where
-        T: Future<Output=Result<V, E>> + Send + 'static + Sized,
-        T: ?Sized,
+where
+    T: Future<Output = Result<V, E>> + Send + 'static + Sized,
+    T: ?Sized,
 {
     type Value = V;
     type Error = E;
 
     fn result<U, F, G>(self, f_ok: F, f_err: G) -> Effects<U>
-        where
-            F: FnOnce(V) -> U + 'static + Send,
-            G: FnOnce(E) -> U + 'static + Send,
-            U: 'static,
+    where
+        F: FnOnce(V) -> U + 'static + Send,
+        G: FnOnce(E) -> U + 'static + Send,
+        U: 'static,
     {
         smallvec![self
             .map(|result| result.map_or_else(f_err, f_ok))
@@ -486,17 +486,17 @@ impl<T, V, E> EffectResultExt for T
 }
 
 impl<T, V> EffectOptionExt for T
-    where
-        T: Future<Output=Option<V>> + Send + 'static + Sized,
-        T: ?Sized,
+where
+    T: Future<Output = Option<V>> + Send + 'static + Sized,
+    T: ?Sized,
 {
     type Value = V;
 
     fn map_or_else<U, F, G>(self, f_some: F, f_none: G) -> Effects<U>
-        where
-            F: FnOnce(V) -> U + 'static + Send,
-            G: FnOnce() -> U + 'static + Send,
-            U: 'static,
+    where
+        F: FnOnce(V) -> U + 'static + Send,
+        G: FnOnce() -> U + 'static + Send,
+        U: 'static,
     {
         smallvec![self
             .map(|option| option.map_or_else(f_none, f_some))
@@ -509,9 +509,9 @@ impl<T, V> EffectOptionExt for T
     /// The function `f` is used to translate the returned value from an effect into an event,
     /// In the case of `None`, empty vector is returned.
     fn map_some<U, F>(self, f: F) -> Effects<U>
-        where
-            F: FnOnce(Self::Value) -> U + 'static + Send,
-            U: 'static,
+    where
+        F: FnOnce(Self::Value) -> U + 'static + Send,
+        U: 'static,
     {
         smallvec![self
             .map(|option| option
@@ -572,10 +572,10 @@ impl<REv> EffectBuilder<REv> {
     /// This future is cancellation safe: If it is dropped without being polled, it merely indicates
     /// the original requester is not longer interested in the result, which will be discarded.
     pub(crate) async fn make_request<T, Q, F>(self, f: F, queue_kind: QueueKind) -> T
-        where
-            T: Send + 'static,
-            Q: Into<REv>,
-            F: FnOnce(Responder<T>) -> Q,
+    where
+        T: Send + 'static,
+        Q: Into<REv>,
+        F: FnOnce(Responder<T>) -> Q,
     {
         let (event, wait_future) = self.create_request_parts(f);
 
@@ -591,11 +591,11 @@ impl<REv> EffectBuilder<REv> {
     /// creates both of them without processing or spawning either.
     ///
     /// Usually you will want to call the higher level `make_request` function.
-    pub(crate) fn create_request_parts<T, Q, F>(self, f: F) -> (REv, impl Future<Output=T>)
-        where
-            T: Send + 'static,
-            Q: Into<REv>,
-            F: FnOnce(Responder<T>) -> Q,
+    pub(crate) fn create_request_parts<T, Q, F>(self, f: F) -> (REv, impl Future<Output = T>)
+    where
+        T: Send + 'static,
+        Q: Into<REv>,
+        F: FnOnce(Responder<T>) -> Q,
     {
         // Prepare a channel.
         let (sender, receiver) = oneshot::channel();
@@ -639,7 +639,7 @@ impl<REv> EffectBuilder<REv> {
     /// "do nothing", as it will still cause a task to be spawned.
     #[inline(always)]
     #[allow(clippy::manual_async_fn)]
-    pub(crate) fn immediately(self) -> impl Future<Output=()> + Send {
+    pub(crate) fn immediately(self) -> impl Future<Output = ()> + Send {
         // Note: This function is implemented manually without `async` sugar because the `Send`
         // inference seems to not work in all cases otherwise.
         async {}
@@ -649,8 +649,8 @@ impl<REv> EffectBuilder<REv> {
     ///
     /// Usually causes the node to cease operations quickly and exit/crash.
     pub(crate) async fn fatal(self, file: &'static str, line: u32, msg: String)
-        where
-            REv: From<FatalAnnouncement>,
+    where
+        REv: From<FatalAnnouncement>,
     {
         self.event_queue
             .schedule(FatalAnnouncement { file, line, msg }, QueueKind::Control)
@@ -668,14 +668,14 @@ impl<REv> EffectBuilder<REv> {
     ///
     /// If an error occurred producing the metrics, `None` is returned.
     pub(crate) async fn get_metrics(self) -> Option<String>
-        where
-            REv: From<MetricsRequest>,
+    where
+        REv: From<MetricsRequest>,
     {
         self.make_request(
             |responder| MetricsRequest::RenderNodeMetricsText { responder },
             QueueKind::Api,
         )
-            .await
+        .await
     }
 
     /// Sends a network message.
@@ -683,8 +683,8 @@ impl<REv> EffectBuilder<REv> {
     /// The message is queued and sent, but no delivery guaranteed. Will return after the message
     /// has been buffered in the outgoing kernel buffer and thus is subject to backpressure.
     pub(crate) async fn send_message<P>(self, dest: NodeId, payload: P)
-        where
-            REv: From<NetworkRequest<P>>,
+    where
+        REv: From<NetworkRequest<P>>,
     {
         self.make_request(
             |responder| NetworkRequest::SendMessage {
@@ -695,7 +695,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Network,
         )
-            .await;
+        .await;
     }
 
     /// Enqueues a network message.
@@ -703,8 +703,8 @@ impl<REv> EffectBuilder<REv> {
     /// The message is queued in "fire-and-forget" fashion, there is no guarantee that the peer
     /// will receive it. Returns as soon as the message is queued inside the networking component.
     pub(crate) async fn enqueue_message<P>(self, dest: NodeId, payload: P)
-        where
-            REv: From<NetworkRequest<P>>,
+    where
+        REv: From<NetworkRequest<P>>,
     {
         self.make_request(
             |responder| NetworkRequest::SendMessage {
@@ -715,13 +715,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Network,
         )
-            .await;
+        .await;
     }
 
     /// Broadcasts a network message to validator peers in the given era.
     pub(crate) async fn broadcast_message_to_validators<P>(self, payload: P, era_id: EraId)
-        where
-            REv: From<NetworkRequest<P>>,
+    where
+        REv: From<NetworkRequest<P>>,
     {
         self.make_request(
             |responder| {
@@ -734,7 +734,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Network,
         )
-            .await;
+        .await;
     }
 
     /// Gossips a network message.
@@ -750,9 +750,9 @@ impl<REv> EffectBuilder<REv> {
         count: usize,
         exclude: HashSet<NodeId>,
     ) -> HashSet<NodeId>
-        where
-            REv: From<NetworkRequest<P>>,
-            P: Send,
+    where
+        REv: From<NetworkRequest<P>>,
+        P: Send,
     {
         self.make_request(
             |responder| NetworkRequest::Gossip {
@@ -764,50 +764,50 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Network,
         )
-            .await
-            .unwrap_or_default()
+        .await
+        .unwrap_or_default()
     }
 
     /// Gets a structure describing the current network status.
     pub(crate) async fn get_network_insights(self) -> NetworkInsights
-        where
-            REv: From<NetworkInfoRequest>,
+    where
+        REv: From<NetworkInfoRequest>,
     {
         self.make_request(
             |responder| NetworkInfoRequest::Insight { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     /// Gets a map of the current network peers to their socket addresses.
     pub(crate) async fn network_peers(self) -> BTreeMap<NodeId, String>
-        where
-            REv: From<NetworkInfoRequest>,
+    where
+        REv: From<NetworkInfoRequest>,
     {
         self.make_request(
             |responder| NetworkInfoRequest::Peers { responder },
             QueueKind::Api,
         )
-            .await
+        .await
     }
 
     /// Gets up to `count` fully-connected network peers in random order.
     pub async fn get_fully_connected_peers(self, count: usize) -> Vec<NodeId>
-        where
-            REv: From<NetworkInfoRequest>,
+    where
+        REv: From<NetworkInfoRequest>,
     {
         self.make_request(
             |responder| NetworkInfoRequest::FullyConnectedPeers { count, responder },
             QueueKind::NetworkInfo,
         )
-            .await
+        .await
     }
 
     /// Announces which transactions have expired.
     pub(crate) async fn announce_expired_transactions(self, hashes: Vec<TransactionHash>)
-        where
-            REv: From<TransactionBufferAnnouncement>,
+    where
+        REv: From<TransactionBufferAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -819,8 +819,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces an incoming network message.
     pub(crate) async fn announce_incoming<P>(self, sender: NodeId, payload: P)
-        where
-            REv: FromIncoming<P>,
+    where
+        REv: FromIncoming<P>,
     {
         self.event_queue
             .schedule(
@@ -832,8 +832,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces that a gossiper has received a new item, where the item's ID is the complete item.
     pub(crate) async fn announce_complete_item_received_via_gossip<T: GossipItem>(self, item: T::Id)
-        where
-            REv: From<GossiperAnnouncement<T>>,
+    where
+        REv: From<GossiperAnnouncement<T>>,
     {
         assert!(
             T::ID_IS_COMPLETE_ITEM,
@@ -888,8 +888,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         block_hash: BlockHash,
     ) -> Option<ExecutableBlock>
-        where
-            REv: From<MakeBlockExecutableRequest>,
+    where
+        REv: From<MakeBlockExecutableRequest>,
     {
         self.make_request(
             |responder| MakeBlockExecutableRequest {
@@ -898,7 +898,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Request that a block with a specific height be marked completed.
@@ -907,8 +907,8 @@ impl<REv> EffectBuilder<REv> {
     /// have been persisted to storage and its global state root hash is missing no dependencies
     /// in the global state.
     pub(crate) async fn mark_block_completed(self, block_height: u64) -> bool
-        where
-            REv: From<MarkBlockCompletedRequest>,
+    where
+        REv: From<MarkBlockCompletedRequest>,
     {
         self.make_request(
             |responder| MarkBlockCompletedRequest {
@@ -917,7 +917,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Try to accept a transaction received from the JSON-RPC server.
@@ -926,8 +926,8 @@ impl<REv> EffectBuilder<REv> {
         transaction: Transaction,
         is_speculative: bool,
     ) -> Result<(), transaction_acceptor::Error>
-        where
-            REv: From<AcceptTransactionRequest>,
+    where
+        REv: From<AcceptTransactionRequest>,
     {
         self.make_request(
             |responder| AcceptTransactionRequest {
@@ -937,7 +937,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Api,
         )
-            .await
+        .await
     }
 
     /// Announces that a transaction not previously stored has now been accepted and stored.
@@ -945,9 +945,9 @@ impl<REv> EffectBuilder<REv> {
         self,
         transaction: Arc<Transaction>,
         source: Source,
-    ) -> impl Future<Output=()>
-        where
-            REv: From<TransactionAcceptorAnnouncement>,
+    ) -> impl Future<Output = ()>
+    where
+        REv: From<TransactionAcceptorAnnouncement>,
     {
         self.event_queue.schedule(
             TransactionAcceptorAnnouncement::AcceptedNewTransaction {
@@ -961,9 +961,9 @@ impl<REv> EffectBuilder<REv> {
     /// Announces that we have received a gossip message from this peer,
     /// implying the peer holds the indicated item.
     pub(crate) async fn announce_gossip_received<T>(self, item_id: T::Id, sender: NodeId)
-        where
-            REv: From<GossiperAnnouncement<T>>,
-            T: GossipItem,
+    where
+        REv: From<GossiperAnnouncement<T>>,
+        T: GossipItem,
     {
         self.event_queue
             .schedule(
@@ -975,9 +975,9 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces that we have finished gossiping the indicated item.
     pub(crate) async fn announce_finished_gossiping<T>(self, item_id: T::Id)
-        where
-            REv: From<GossiperAnnouncement<T>>,
-            T: GossipItem,
+    where
+        REv: From<GossiperAnnouncement<T>>,
+        T: GossipItem,
     {
         self.event_queue
             .schedule(
@@ -991,9 +991,9 @@ impl<REv> EffectBuilder<REv> {
         self,
         transaction: Transaction,
         source: Source,
-    ) -> impl Future<Output=()>
-        where
-            REv: From<TransactionAcceptorAnnouncement>,
+    ) -> impl Future<Output = ()>
+    where
+        REv: From<TransactionAcceptorAnnouncement>,
     {
         self.event_queue.schedule(
             TransactionAcceptorAnnouncement::InvalidTransaction {
@@ -1006,8 +1006,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces upgrade activation point read.
     pub(crate) async fn announce_upgrade_activation_point_read(self, next_upgrade: NextUpgrade)
-        where
-            REv: From<UpgradeWatcherAnnouncement>,
+    where
+        REv: From<UpgradeWatcherAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -1019,8 +1019,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces a committed Step success.
     pub(crate) async fn announce_commit_step_success(self, era_id: EraId, effects: ExecutionEffects)
-        where
-            REv: From<ContractRuntimeAnnouncement>,
+    where
+        REv: From<ContractRuntimeAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -1031,8 +1031,8 @@ impl<REv> EffectBuilder<REv> {
     }
 
     pub(crate) async fn update_contract_runtime_state(self, new_pre_state: ExecutionPreState)
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.event_queue
             .schedule(
@@ -1062,8 +1062,8 @@ impl<REv> EffectBuilder<REv> {
     }
 
     pub(crate) async fn announce_new_era_gas_price(self, era_id: EraId, next_era_gas_price: u8)
-        where
-            REv: From<ContractRuntimeAnnouncement>,
+    where
+        REv: From<ContractRuntimeAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -1078,9 +1078,9 @@ impl<REv> EffectBuilder<REv> {
 
     /// Begins gossiping an item.
     pub(crate) async fn begin_gossip<T>(self, item_id: T::Id, source: Source, target: GossipTarget)
-        where
-            T: GossipItem,
-            REv: From<BeginGossipRequest<T>>,
+    where
+        T: GossipItem,
+        REv: From<BeginGossipRequest<T>>,
     {
         self.make_request(
             |responder| BeginGossipRequest {
@@ -1091,19 +1091,19 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Gossip,
         )
-            .await
+        .await
     }
 
     /// Puts the given block into the linear block store.
     pub(crate) async fn put_block_to_storage(self, block: Arc<Block>) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutBlock { block, responder },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Puts the given approvals hashes into the linear block store.
@@ -1111,8 +1111,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         approvals_hashes: Box<ApprovalsHashes>,
     ) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutApprovalsHashes {
@@ -1121,7 +1121,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Puts the given block and approvals hashes into the linear block store.
@@ -1131,8 +1131,8 @@ impl<REv> EffectBuilder<REv> {
         approvals_hashes: Box<ApprovalsHashes>,
         execution_results: HashMap<TransactionHash, ExecutionResult>,
     ) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutExecutedBlock {
@@ -1143,13 +1143,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested block from the linear block store.
     pub(crate) async fn get_block_from_storage(self, block_hash: BlockHash) -> Option<Block>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlock {
@@ -1158,7 +1158,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_block_utilization(
@@ -1167,8 +1167,8 @@ impl<REv> EffectBuilder<REv> {
         block_height: u64,
         transaction_count: u64,
     ) -> Option<(u64, u64)>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlockUtilizationScore {
@@ -1179,12 +1179,12 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn is_block_stored(self, block_hash: BlockHash) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::IsBlockStored {
@@ -1193,7 +1193,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested `ApprovalsHashes` from storage.
@@ -1201,8 +1201,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         block_hash: BlockHash,
     ) -> Option<ApprovalsHashes>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetApprovalsHashes {
@@ -1211,7 +1211,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_raw_data(
@@ -1219,8 +1219,8 @@ impl<REv> EffectBuilder<REv> {
         record_id: RecordId,
         key: Vec<u8>,
     ) -> Option<DbRawBytesSpec>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetRawData {
@@ -1230,7 +1230,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested block header from the linear block store.
@@ -1239,8 +1239,8 @@ impl<REv> EffectBuilder<REv> {
         block_hash: BlockHash,
         only_from_available_block_range: bool,
     ) -> Option<BlockHeader>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlockHeader {
@@ -1250,7 +1250,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_block_header_at_height_from_storage(
@@ -1258,8 +1258,8 @@ impl<REv> EffectBuilder<REv> {
         block_height: u64,
         only_from_available_block_range: bool,
     ) -> Option<BlockHeader>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlockHeaderByHeight {
@@ -1269,32 +1269,32 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_latest_switch_block_header_from_storage(self) -> Option<BlockHeader>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetLatestSwitchBlockHeader { responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_switch_block_header_by_era_id_from_storage(
         self,
         era_id: EraId,
     ) -> Option<BlockHeader>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetSwitchBlockHeaderByEra { era_id, responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested signature for a given block hash.
@@ -1303,8 +1303,8 @@ impl<REv> EffectBuilder<REv> {
         block_hash: BlockHash,
         public_key: PublicKey,
     ) -> Option<FinalitySignature>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlockSignature {
@@ -1314,15 +1314,15 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_execution_results_from_storage(
         self,
         block_hash: BlockHash,
     ) -> Option<Vec<(TransactionHash, TransactionHeader, ExecutionResult)>>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetExecutionResults {
@@ -1331,13 +1331,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Puts a block header to storage.
     pub(crate) async fn put_block_header_to_storage(self, block_header: Box<BlockHeader>) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutBlockHeader {
@@ -1346,7 +1346,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Puts the requested block signatures into storage.
@@ -1354,8 +1354,8 @@ impl<REv> EffectBuilder<REv> {
     /// If `signatures.proofs` is empty, no attempt to store will be made, an error will be logged,
     /// and this function will return `false`.
     pub(crate) async fn put_signatures_to_storage(self, signatures: BlockSignatures) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutBlockSignatures {
@@ -1364,15 +1364,15 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn put_finality_signature_to_storage(
         self,
         signature: FinalitySignature,
     ) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutFinalitySignature {
@@ -1381,7 +1381,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested block's transfers from storage.
@@ -1389,8 +1389,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         block_hash: BlockHash,
     ) -> Option<Vec<Transfer>>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlockTransfers {
@@ -1399,7 +1399,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Returns the era IDs of the blocks in which the given transactions were executed.  If none
@@ -1408,8 +1408,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         transaction_hashes: HashSet<TransactionHash>,
     ) -> HashSet<EraId>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetTransactionsEraIds {
@@ -1418,43 +1418,43 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Requests the highest complete block.
     pub(crate) async fn get_highest_complete_block_from_storage(self) -> Option<Block>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetHighestCompleteBlock { responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Requests the highest complete block header.
     pub(crate) async fn get_highest_complete_block_header_from_storage(self) -> Option<BlockHeader>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetHighestCompleteBlockHeader { responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Requests the height range of fully available blocks (not just block headers).
     pub(crate) async fn get_available_block_range_from_storage(self) -> AvailableBlockRange
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetAvailableBlockRange { responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Synchronize global state under the given root hash.
@@ -1463,8 +1463,8 @@ impl<REv> EffectBuilder<REv> {
         block_hash: BlockHash,
         state_root_hash: Digest,
     ) -> Result<GlobalStateSynchronizerResponse, GlobalStateSynchronizerError>
-        where
-            REv: From<SyncGlobalStateRequest>,
+    where
+        REv: From<SyncGlobalStateRequest>,
     {
         self.make_request(
             |responder| SyncGlobalStateRequest {
@@ -1474,97 +1474,97 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::SyncGlobalState,
         )
-            .await
+        .await
     }
 
     /// Get a trie or chunk by its ID.
     pub(crate) async fn get_trie(self, request: TrieRequest) -> TrieResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetTrie { request, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_reactor_state(self) -> ReactorState
-        where
-            REv: From<ReactorInfoRequest>,
+    where
+        REv: From<ReactorInfoRequest>,
     {
         self.make_request(
             |responder| ReactorInfoRequest::ReactorState { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_last_progress(self) -> LastProgress
-        where
-            REv: From<ReactorInfoRequest>,
+    where
+        REv: From<ReactorInfoRequest>,
     {
         self.make_request(
             |responder| ReactorInfoRequest::LastProgress { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_uptime(self) -> Uptime
-        where
-            REv: From<ReactorInfoRequest>,
+    where
+        REv: From<ReactorInfoRequest>,
     {
         self.make_request(
             |responder| ReactorInfoRequest::Uptime { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_network_name(self) -> NetworkName
-        where
-            REv: From<ReactorInfoRequest>,
+    where
+        REv: From<ReactorInfoRequest>,
     {
         self.make_request(
             |responder| ReactorInfoRequest::NetworkName { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_protocol_version(self) -> ProtocolVersion
-        where
-            REv: From<ReactorInfoRequest>,
+    where
+        REv: From<ReactorInfoRequest>,
     {
         self.make_request(
             |responder| ReactorInfoRequest::ProtocolVersion { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     #[allow(unused)]
     pub(crate) async fn get_balance_holds_interval(self) -> TimeDiff
-        where
-            REv: From<ReactorInfoRequest>,
+    where
+        REv: From<ReactorInfoRequest>,
     {
         self.make_request(
             |responder| ReactorInfoRequest::BalanceHoldsInterval { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_block_synchronizer_status(self) -> BlockSynchronizerStatus
-        where
-            REv: From<BlockSynchronizerRequest>,
+    where
+        REv: From<BlockSynchronizerRequest>,
     {
         self.make_request(
             |responder| BlockSynchronizerRequest::Status { responder },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     /// Puts a trie into the trie store; succeeds only if all the children of the trie are already
@@ -1574,30 +1574,30 @@ impl<REv> EffectBuilder<REv> {
         self,
         request: PutTrieRequest,
     ) -> PutTrieResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::PutTrie { request, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_current_gas_price(self, era_id: EraId) -> Option<u8>
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetEraGasPrice { era_id, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn put_transaction_to_storage(self, transaction: Transaction) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::PutTransaction {
@@ -1606,7 +1606,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested transactions from storage.
@@ -1617,8 +1617,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         transaction_hashes: Vec<TransactionHash>,
     ) -> SmallVec<[Option<(Transaction, Option<BTreeSet<Approval>>)>; 1]>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetTransactions {
@@ -1627,7 +1627,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested transaction and its execution info from storage by TransactionHash.
@@ -1636,8 +1636,8 @@ impl<REv> EffectBuilder<REv> {
         transaction_hash: TransactionHash,
         with_finalized_approvals: bool,
     ) -> Option<(Transaction, Option<ExecutionInfo>)>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetTransactionAndExecutionInfo {
@@ -1647,7 +1647,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested deploy from the deploy store by DeployHash only.
@@ -1658,8 +1658,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         deploy_hash: DeployHash,
     ) -> Option<LegacyDeploy>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetLegacyDeploy {
@@ -1668,7 +1668,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested transaction from storage by TransactionId.
@@ -1679,8 +1679,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         transaction_id: TransactionId,
     ) -> Option<Transaction>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetTransaction {
@@ -1689,12 +1689,12 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn is_transaction_stored(self, transaction_id: TransactionId) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::IsTransactionStored {
@@ -1703,7 +1703,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Stores the given execution results for the transactions in the given block in the linear
@@ -1727,7 +1727,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Gets the requested block and its finality signatures.
@@ -1736,8 +1736,8 @@ impl<REv> EffectBuilder<REv> {
         block_height: u64,
         only_from_available_block_range: bool,
     ) -> Option<BlockWithMetadata>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlockAndMetadataByHeight {
@@ -1747,7 +1747,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn collect_past_blocks_with_metadata(
@@ -1755,8 +1755,8 @@ impl<REv> EffectBuilder<REv> {
         range: std::ops::Range<u64>,
         only_from_available_block_range: bool,
     ) -> Vec<Option<BlockWithMetadata>>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         futures::future::join_all(range.into_iter().map(|block_height| {
             self.get_block_at_height_with_metadata_from_storage(
@@ -1764,9 +1764,9 @@ impl<REv> EffectBuilder<REv> {
                 only_from_available_block_range,
             )
         }))
-            .await
-            .into_iter()
-            .collect()
+        .await
+        .into_iter()
+        .collect()
     }
 
     /// Gets the requested finality signature from storage.
@@ -1774,25 +1774,25 @@ impl<REv> EffectBuilder<REv> {
         self,
         id: Box<FinalitySignatureId>,
     ) -> Option<FinalitySignature>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetFinalitySignature { id, responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn is_finality_signature_stored(self, id: Box<FinalitySignatureId>) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::IsFinalitySignatureStored { id, responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Fetches an item from a fetcher.
@@ -1802,9 +1802,9 @@ impl<REv> EffectBuilder<REv> {
         peer: NodeId,
         validation_metadata: Box<T::ValidationMetadata>,
     ) -> FetchResult<T>
-        where
-            REv: From<FetcherRequest<T>>,
-            T: FetchItem + 'static,
+    where
+        REv: From<FetcherRequest<T>>,
+        T: FetchItem + 'static,
     {
         self.make_request(
             |responder| FetcherRequest {
@@ -1815,7 +1815,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Fetch,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn fetch_trie(
@@ -1823,8 +1823,8 @@ impl<REv> EffectBuilder<REv> {
         hash: Digest,
         peers: Vec<NodeId>,
     ) -> Result<TrieAccumulatorResponse, TrieAccumulatorError>
-        where
-            REv: From<TrieAccumulatorRequest>,
+    where
+        REv: From<TrieAccumulatorRequest>,
     {
         self.make_request(
             |responder| TrieAccumulatorRequest {
@@ -1834,7 +1834,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::SyncGlobalState,
         )
-            .await
+        .await
     }
 
     /// Passes the timestamp of a future block for which transactions are to be proposed.
@@ -1843,8 +1843,8 @@ impl<REv> EffectBuilder<REv> {
         timestamp: Timestamp,
         era_id: EraId,
     ) -> AppendableBlock
-        where
-            REv: From<TransactionBufferRequest>,
+    where
+        REv: From<TransactionBufferRequest>,
     {
         self.make_request(
             |responder| TransactionBufferRequest::GetAppendableBlock {
@@ -1854,7 +1854,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Consensus,
         )
-            .await
+        .await
     }
 
     /// Enqueues a finalized block execution.
@@ -1897,7 +1897,8 @@ impl<REv> EffectBuilder<REv> {
         parent_hash: BlockHash,
         parent_seed: Digest,
     ) where
-        REv: From<ContractRuntimeRequest>, {
+        REv: From<ContractRuntimeRequest>,
+    {
         self.event_queue
             .schedule(
                 ContractRuntimeRequest::DoProtocolUpgrade {
@@ -1919,8 +1920,8 @@ impl<REv> EffectBuilder<REv> {
         proposed_block_height: u64,
         block: ProposedBlock<ClContext>,
     ) -> bool
-        where
-            REv: From<BlockValidationRequest>,
+    where
+        REv: From<BlockValidationRequest>,
     {
         self.make_request(
             |responder| BlockValidationRequest {
@@ -1931,13 +1932,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Regular,
         )
-            .await
+        .await
     }
 
     /// Announces that a block has been proposed.
     pub(crate) async fn announce_proposed_block(self, proposed_block: ProposedBlock<ClContext>)
-        where
-            REv: From<ConsensusAnnouncement>,
+    where
+        REv: From<ConsensusAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -1949,8 +1950,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces that a block has been finalized.
     pub(crate) async fn announce_finalized_block(self, finalized_block: FinalizedBlock)
-        where
-            REv: From<ConsensusAnnouncement>,
+    where
+        REv: From<ConsensusAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -1962,8 +1963,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announces that a meta block has been created or its state has changed.
     pub(crate) async fn announce_meta_block(self, meta_block: MetaBlock)
-        where
-            REv: From<MetaBlockAnnouncement>,
+    where
+        REv: From<MetaBlockAnnouncement>,
     {
         self.event_queue
             .schedule(MetaBlockAnnouncement(meta_block), QueueKind::Regular)
@@ -1973,8 +1974,8 @@ impl<REv> EffectBuilder<REv> {
     /// Announces that a finalized block has been created, but it was not
     /// executed.
     pub(crate) async fn announce_unexecuted_block(self, block_height: u64)
-        where
-            REv: From<UnexecutedBlockAnnouncement>,
+    where
+        REv: From<UnexecutedBlockAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -2029,8 +2030,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Gets the next scheduled upgrade, if any.
     pub(crate) async fn get_next_upgrade(self) -> Option<NextUpgrade>
-        where
-            REv: From<UpgradeWatcherRequest> + Send,
+    where
+        REv: From<UpgradeWatcherRequest> + Send,
     {
         self.make_request(UpgradeWatcherRequest, QueueKind::Control)
             .await
@@ -2038,14 +2039,14 @@ impl<REv> EffectBuilder<REv> {
 
     /// Requests a query be executed on the Contract Runtime component.
     pub(crate) async fn query_global_state(self, request: QueryRequest) -> QueryResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::Query { request, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Retrieves an `AddressableEntity` from under the given key in global state if present.
@@ -2054,8 +2055,8 @@ impl<REv> EffectBuilder<REv> {
         state_root_hash: Digest,
         key: Key,
     ) -> AddressableEntityResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetAddressableEntity {
@@ -2065,7 +2066,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Retrieves an `EntryPointValue` from under the given key in global state if present.
@@ -2074,8 +2075,8 @@ impl<REv> EffectBuilder<REv> {
         state_root_hash: Digest,
         key: Key,
     ) -> EntryPointsResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetEntryPoint {
@@ -2085,13 +2086,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Retrieves a `Package` from under the given key in global state if present.
     pub(crate) async fn get_package(self, state_root_hash: Digest, key: Key) -> Option<Box<Package>>
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         let query_request = QueryRequest::new(state_root_hash, key, vec![]);
 
@@ -2104,14 +2105,14 @@ impl<REv> EffectBuilder<REv> {
 
     /// Requests a query be executed on the Contract Runtime component.
     pub(crate) async fn get_balance(self, request: BalanceRequest) -> BalanceResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetBalance { request, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Returns a map of validators weights for all eras as known from `root_hash`.
@@ -2121,40 +2122,40 @@ impl<REv> EffectBuilder<REv> {
         self,
         request: EraValidatorsRequest,
     ) -> EraValidatorsResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetEraValidators { request, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Requests a query be executed on the Contract Runtime component.
     pub(crate) async fn get_tagged_values(self, request: TaggedValuesRequest) -> TaggedValuesResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetTaggedValues { request, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     pub(crate) async fn get_prefixed_values(
         self,
         request: PrefixedValuesRequest,
     ) -> PrefixedValuesResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::QueryByPrefix { request, responder },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Returns the value of the execution results checksum stored in the ChecksumRegistry for the
@@ -2163,8 +2164,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         state_root_hash: Digest,
     ) -> ExecutionResultsChecksumResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetExecutionResultsChecksum {
@@ -2173,13 +2174,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Get our public key from consensus, and if we're a validator, the next round length.
     pub(crate) async fn consensus_status(self) -> Option<ConsensusStatus>
-        where
-            REv: From<ConsensusRequest>,
+    where
+        REv: From<ConsensusRequest>,
     {
         self.make_request(ConsensusRequest::Status, QueueKind::Consensus)
             .await
@@ -2187,8 +2188,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Returns a list of validator status changes, by public key.
     pub(crate) async fn get_consensus_validator_changes(self) -> ConsensusValidatorChanges
-        where
-            REv: From<ConsensusRequest>,
+    where
+        REv: From<ConsensusRequest>,
     {
         self.make_request(ConsensusRequest::ValidatorChanges, QueueKind::Consensus)
             .await
@@ -2201,8 +2202,8 @@ impl<REv> EffectBuilder<REv> {
         era_id: Option<EraId>,
         serialize: fn(&EraDump<'_>) -> Result<Vec<u8>, Cow<'static, str>>,
     ) -> Result<Vec<u8>, Cow<'static, str>>
-        where
-            REv: From<DumpConsensusStateRequest>,
+    where
+        REv: From<DumpConsensusStateRequest>,
     {
         self.make_request(
             |responder| DumpConsensusStateRequest {
@@ -2212,13 +2213,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Control,
         )
-            .await
+        .await
     }
 
     /// Dump the event queue contents to the diagnostics port, using the given serializer.
     pub(crate) async fn diagnostics_port_dump_queue(self, dump_format: QueueDumpFormat)
-        where
-            REv: From<ControlAnnouncement>,
+    where
+        REv: From<ControlAnnouncement>,
     {
         self.make_request(
             |responder| ControlAnnouncement::QueueDumpRequest {
@@ -2227,13 +2228,13 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::Control,
         )
-            .await
+        .await
     }
 
     /// Activates/deactivates a failpoint from a given activation.
     pub(crate) async fn activate_failpoint(self, activation: FailpointActivation)
-        where
-            REv: From<ControlAnnouncement>,
+    where
+        REv: From<ControlAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -2245,8 +2246,8 @@ impl<REv> EffectBuilder<REv> {
 
     /// Announce that the node be shut down due to a request from a user.
     pub(crate) async fn announce_user_shutdown_request(self)
-        where
-            REv: From<ControlAnnouncement>,
+    where
+        REv: From<ControlAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -2259,8 +2260,8 @@ impl<REv> EffectBuilder<REv> {
     /// Announce that a block which wasn't previously stored on this node has been fetched and
     /// stored.
     pub(crate) async fn announce_fetched_new_block(self, block: Arc<Block>, peer: NodeId)
-        where
-            REv: From<FetchedNewBlockAnnouncement>,
+    where
+        REv: From<FetchedNewBlockAnnouncement>,
     {
         self.event_queue
             .schedule(
@@ -2293,14 +2294,14 @@ impl<REv> EffectBuilder<REv> {
     /// Get the bytes for the chainspec file and genesis_accounts
     /// and global_state bytes if the files are present.
     pub(crate) async fn get_chainspec_raw_bytes(self) -> Arc<ChainspecRawBytes>
-        where
-            REv: From<ChainspecRawBytesRequest> + Send,
+    where
+        REv: From<ChainspecRawBytesRequest> + Send,
     {
         self.make_request(
             ChainspecRawBytesRequest::GetChainspecRawBytes,
             QueueKind::NetworkInfo,
         )
-            .await
+        .await
     }
 
     /// Stores a set of given finalized approvals in storage.
@@ -2311,8 +2312,8 @@ impl<REv> EffectBuilder<REv> {
         transaction_hash: TransactionHash,
         finalized_approvals: BTreeSet<Approval>,
     ) -> bool
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::StoreFinalizedApprovals {
@@ -2322,7 +2323,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ToStorage,
         )
-            .await
+        .await
     }
 
     /// Requests execution of a single transaction, without committing its effects.  Intended to be
@@ -2332,8 +2333,8 @@ impl<REv> EffectBuilder<REv> {
         block_header: Box<BlockHeader>,
         transaction: Box<Transaction>,
     ) -> SpeculativeExecutionResult
-        where
-            REv: From<ContractRuntimeRequest>,
+    where
+        REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
             |responder| ContractRuntimeRequest::SpeculativelyExecute {
@@ -2343,7 +2344,7 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::ContractRuntime,
         )
-            .await
+        .await
     }
 
     /// Reads block execution results (or chunk) from Storage component.
@@ -2351,14 +2352,14 @@ impl<REv> EffectBuilder<REv> {
         self,
         id: BlockExecutionResultsOrChunkId,
     ) -> Option<BlockExecutionResultsOrChunk>
-        where
-            REv: From<StorageRequest>,
+    where
+        REv: From<StorageRequest>,
     {
         self.make_request(
             |responder| StorageRequest::GetBlockExecutionResultsOrChunk { id, responder },
             QueueKind::FromStorage,
         )
-            .await
+        .await
     }
 
     /// Gets peers for a given block from the block accumulator.
@@ -2366,8 +2367,8 @@ impl<REv> EffectBuilder<REv> {
         self,
         block_hash: BlockHash,
     ) -> Option<Vec<NodeId>>
-        where
-            REv: From<BlockAccumulatorRequest>,
+    where
+        REv: From<BlockAccumulatorRequest>,
     {
         self.make_request(
             |responder| BlockAccumulatorRequest::GetPeersForBlock {
@@ -2376,21 +2377,21 @@ impl<REv> EffectBuilder<REv> {
             },
             QueueKind::NetworkInfo,
         )
-            .await
+        .await
     }
 
     /// Set a new stopping point for the node.
     ///
     /// Returns a potentially previously set stop-at spec.
     pub(crate) async fn set_node_stop_at(self, stop_at: Option<StopAtSpec>) -> Option<StopAtSpec>
-        where
-            REv: From<SetNodeStopRequest>,
+    where
+        REv: From<SetNodeStopRequest>,
     {
         self.make_request(
             |responder| SetNodeStopRequest { stop_at, responder },
             QueueKind::Control,
         )
-            .await
+        .await
     }
 }
 

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1906,7 +1906,7 @@ impl<REv> EffectBuilder<REv> {
                     parent_hash,
                     parent_seed,
                 },
-                QueueKind::ContractRuntime,
+                QueueKind::Control,
             )
             .await
     }

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use serde::Serialize;
 
 use casper_types::{
-    execution::Effects, Block, Digest, EraId, FinalitySignature, FinalitySignatureV2, NextUpgrade,
+    execution::Effects, Block, EraId, FinalitySignature, FinalitySignatureV2, NextUpgrade,
     PublicKey, Timestamp, Transaction, TransactionHash, U512,
 };
 

--- a/node/src/effect/announcements.rs
+++ b/node/src/effect/announcements.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use serde::Serialize;
 
 use casper_types::{
-    execution::Effects, Block, EraId, FinalitySignature, FinalitySignatureV2, NextUpgrade,
+    execution::Effects, Block, Digest, EraId, FinalitySignature, FinalitySignatureV2, NextUpgrade,
     PublicKey, Timestamp, Transaction, TransactionHash, U512,
 };
 
@@ -375,8 +375,11 @@ pub(crate) enum ContractRuntimeAnnouncement {
         /// The validators for the eras after the `era_that_is_ending` era.
         upcoming_era_validators: BTreeMap<EraId, BTreeMap<PublicKey, U512>>,
     },
+    /// New gas price for an upcoming era has been determined.
     NextEraGasPrice {
+        /// The era id for which the gas price has been determined
         era_id: EraId,
+        /// The gas price as determined by chain utilization.
         next_era_gas_price: u8,
     },
 }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -135,8 +135,8 @@ impl<P> NetworkRequest<P> {
     ///
     /// This is a replacement for a `From` conversion that is not possible without specialization.
     pub(crate) fn map_payload<F, P2>(self, wrap_payload: F) -> NetworkRequest<P2>
-        where
-            F: FnOnce(P) -> P2,
+    where
+        F: FnOnce(P) -> P2,
     {
         match self {
             NetworkRequest::SendMessage {
@@ -177,8 +177,8 @@ impl<P> NetworkRequest<P> {
 }
 
 impl<P> Display for NetworkRequest<P>
-    where
-        P: Display,
+where
+    P: Display,
 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -243,8 +243,8 @@ impl Display for NetworkInfoRequest {
 #[derive(Debug, Serialize)]
 #[must_use]
 pub(crate) struct BeginGossipRequest<T>
-    where
-        T: GossipItem,
+where
+    T: GossipItem,
 {
     pub(crate) item_id: T::Id,
     pub(crate) source: Source,
@@ -253,8 +253,8 @@ pub(crate) struct BeginGossipRequest<T>
 }
 
 impl<T> Display for BeginGossipRequest<T>
-    where
-        T: GossipItem,
+where
+    T: GossipItem,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "begin gossip of {} from {}", self.item_id, self.source)
@@ -630,7 +630,7 @@ impl Display for StorageRequest {
                 write!(formatter, "put block header: {}", block_header)
             }
             StorageRequest::GetAvailableBlockRange { .. } => {
-                write!(formatter, "get available block range", )
+                write!(formatter, "get available block range",)
             }
             StorageRequest::StoreFinalizedApprovals {
                 transaction_hash, ..
@@ -642,7 +642,7 @@ impl Display for StorageRequest {
                 )
             }
             StorageRequest::PutExecutedBlock { block, .. } => {
-                write!(formatter, "put executed block {}", block.hash(), )
+                write!(formatter, "put executed block {}", block.hash(),)
             }
             StorageRequest::GetKeyBlockHeightForActivationPoint { .. } => {
                 write!(
@@ -954,7 +954,8 @@ impl Display for ContractRuntimeRequest {
                 )
             }
             ContractRuntimeRequest::DoProtocolUpgrade {
-                protocol_upgrade_config, ..
+                protocol_upgrade_config,
+                ..
             } => {
                 write!(
                     formatter,
@@ -962,10 +963,12 @@ impl Display for ContractRuntimeRequest {
                     protocol_upgrade_config
                 )
             }
-            ContractRuntimeRequest::UpdatePreState {
-                new_pre_state
-            } => {
-                write!(formatter, "Updating contract runtimes execution presate: {:?}", new_pre_state)
+            ContractRuntimeRequest::UpdatePreState { new_pre_state } => {
+                write!(
+                    formatter,
+                    "Updating contract runtimes execution presate: {:?}",
+                    new_pre_state
+                )
             }
         }
     }
@@ -1015,7 +1018,7 @@ pub(crate) struct SyncGlobalStateRequest {
     pub(crate) state_root_hash: Digest,
     #[serde(skip)]
     pub(crate) responder:
-    Responder<Result<GlobalStateSynchronizerResponse, GlobalStateSynchronizerError>>,
+        Responder<Result<GlobalStateSynchronizerResponse, GlobalStateSynchronizerError>>,
 }
 
 impl Display for SyncGlobalStateRequest {

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use tracing::{debug, error, info, trace};
 
-use casper_storage::data_access_layer::{GenesisResult};
+use casper_storage::data_access_layer::GenesisResult;
 use casper_types::{BlockHash, BlockHeader, Digest, EraId, PublicKey, Timestamp};
 
 use crate::{
@@ -39,7 +39,7 @@ impl MainReactor {
                     tokio::time::sleep(delay).await
                 }
             }
-                .event(|_| MainEvent::ReactorCrank),
+            .event(|_| MainEvent::ReactorCrank),
         );
         effects
     }
@@ -439,12 +439,16 @@ impl MainReactor {
             Ok(cfg) => {
                 let mut effects = Effects::new();
                 let next_block_height = header.height() + 1;
-                effects.extend(effect_builder.enqueue_protocol_upgrade(
-                    cfg,
-                    next_block_height,
-                    header.block_hash(),
-                    *header.accumulated_seed(),
-                ).ignore());
+                effects.extend(
+                    effect_builder
+                        .enqueue_protocol_upgrade(
+                            cfg,
+                            next_block_height,
+                            header.block_hash(),
+                            *header.accumulated_seed(),
+                        )
+                        .ignore(),
+                );
                 Ok(effects)
             }
             Err(msg) => Err(msg),
@@ -468,8 +472,8 @@ impl MainReactor {
                 self.storage.highest_complete_block_height() == Some(block_header.height());
             return highest_block_complete
                 && self
-                .upgrade_watcher
-                .should_upgrade_after(block_header.era_id());
+                    .upgrade_watcher
+                    .should_upgrade_after(block_header.era_id());
         }
         false
     }

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use tracing::{debug, error, info, trace};
 
-use casper_storage::data_access_layer::{GenesisResult, ProtocolUpgradeResult};
+use casper_storage::data_access_layer::{GenesisResult};
 use casper_types::{BlockHash, BlockHeader, Digest, EraId, PublicKey, Timestamp};
 
 use crate::{
@@ -429,7 +429,7 @@ impl MainReactor {
             }
         };
 
-        let network_name = self.chainspec.network_config.name.clone();
+        let _network_name = self.chainspec.network_config.name.clone();
         match self.chainspec.upgrade_config_from_parts(
             *header.state_root_hash(),
             header.protocol_version(),
@@ -445,7 +445,7 @@ impl MainReactor {
                     header.block_hash(),
                     *header.accumulated_seed(),
                 ).ignore());
-                return Ok(effects);
+                Ok(effects)
                 // // apply protocol changes to global state
                 // match self.contract_runtime.commit_upgrade(cfg) {
                 //     ProtocolUpgradeResult::RootNotFound => Err("Root not found".to_string()),

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -446,43 +446,6 @@ impl MainReactor {
                     *header.accumulated_seed(),
                 ).ignore());
                 Ok(effects)
-                // // apply protocol changes to global state
-                // match self.contract_runtime.commit_upgrade(cfg) {
-                //     ProtocolUpgradeResult::RootNotFound => Err("Root not found".to_string()),
-                //     ProtocolUpgradeResult::Failure(err) => Err(err.to_string()),
-                //     ProtocolUpgradeResult::Success {
-                //         post_state_hash, ..
-                //     } => {
-                //         info!(%network_name, %post_state_hash, "{:?}: committed upgrade",
-                // self.state);
-                //
-                //         let next_block_height = header.height() + 1;
-                //         self.initialize_contract_runtime(
-                //             next_block_height,
-                //             post_state_hash,
-                //             header.block_hash(),
-                //             *header.accumulated_seed(),
-                //         );
-                //
-                //         let finalized_block = FinalizedBlock::new(
-                //             BlockPayload::default(),
-                //             Some(InternalEraReport::default()),
-                //             header.timestamp(),
-                //             header.next_block_era_id(),
-                //             next_block_height,
-                //             PublicKey::System,
-                //         );
-                //         Ok(effect_builder
-                //             .enqueue_block_for_execution(
-                //                 ExecutableBlock::from_finalized_block_and_transactions(
-                //                     finalized_block,
-                //                     vec![],
-                //                 ),
-                //                 MetaBlockState::new_not_to_be_gossiped(),
-                //             )
-                //             .ignore())
-                //     }
-                // }
             }
             Err(msg) => Err(msg),
         }

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -194,7 +194,7 @@ max_timestamp_leeway = '5 seconds'
 # [4] -> The maximum number of transactions the lane can contain
 native_mint_lane = [0, 1024, 1024, 65_000_000_000, 650]
 native_auction_lane = [1, 2048, 2048, 362_500_000_000, 145]
-wasm_lanes = [[2, 1_048_576, 2048, 1_000_000_000_00, 2], [3, 262_144, 1024, 100_000_000_000, 3], [4, 131_072, 1024, 50_000_000_000, 5], [5, 8_192, 512, 1_500_000_000, 15]]
+wasm_lanes = [[2, 1_048_576, 2048, 1_000_000_000_000, 2], [3, 262_144, 1024, 100_000_000_000, 3], [4, 131_072, 1024, 50_000_000_000, 5], [5, 8_192, 512, 1_500_000_000, 15]]
 
 [transactions.deploy]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -204,7 +204,7 @@ max_timestamp_leeway = '5 seconds'
 # [4] -> The maximum number of transactions the lane can contain
 native_mint_lane = [0, 1024, 1024, 65_000_000_000, 650]
 native_auction_lane = [1, 2048, 2048, 362_500_000_000, 145]
-wasm_lanes = [[2, 1_048_576, 2048, 1_000_000_000_00, 2], [3, 262_144, 1024, 100_000_000_000, 3], [4, 131_072, 1024, 50_000_000_000, 5], [5, 8_192, 512, 1_500_000_000, 15]]
+wasm_lanes = [[2, 1_048_576, 2048, 1_000_000_000_000, 2], [3, 262_144, 1024, 100_000_000_000, 3], [4, 131_072, 1024, 50_000_000_000, 5], [5, 8_192, 512, 1_500_000_000, 15]]
 
 [transactions.deploy]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -563,7 +563,7 @@ pub trait CommitProvider: StateProvider {
 /// A trait expressing operations over the trie.
 pub trait StateProvider {
     /// Associated reader type for `StateProvider`.
-    type Reader: StateReader<Key, StoredValue, Error = GlobalStateError>;
+    type Reader: StateReader<Key, StoredValue, Error=GlobalStateError>;
 
     /// Flush the state provider.
     fn flush(&self, request: FlushRequest) -> FlushResult;
@@ -1036,7 +1036,7 @@ pub trait StateProvider {
                 match k.as_uref() {
                     Some(uref) => entity_access_rights.extend(&[*uref]),
                     None => {
-                        return BiddingResult::Failure(TrackingCopyError::UnexpectedKeyVariant(k))
+                        return BiddingResult::Failure(TrackingCopyError::UnexpectedKeyVariant(k));
                     }
                 }
                 entity_named_keys.insert(ERA_END_TIMESTAMP_MILLIS_KEY.into(), k);
@@ -1044,7 +1044,7 @@ pub trait StateProvider {
             Ok(None) => {
                 return BiddingResult::Failure(TrackingCopyError::NamedKeyNotFound(
                     ERA_END_TIMESTAMP_MILLIS_KEY.into(),
-                ))
+                ));
             }
             Err(tce) => {
                 return BiddingResult::Failure(tce);
@@ -1059,7 +1059,7 @@ pub trait StateProvider {
                 match k.as_uref() {
                     Some(uref) => entity_access_rights.extend(&[*uref]),
                     None => {
-                        return BiddingResult::Failure(TrackingCopyError::UnexpectedKeyVariant(k))
+                        return BiddingResult::Failure(TrackingCopyError::UnexpectedKeyVariant(k));
                     }
                 }
                 entity_named_keys.insert(ERA_ID_KEY.into(), k);
@@ -1067,7 +1067,7 @@ pub trait StateProvider {
             Ok(None) => {
                 return BiddingResult::Failure(TrackingCopyError::NamedKeyNotFound(
                     ERA_ID_KEY.into(),
-                ))
+                ));
             }
             Err(tce) => {
                 return BiddingResult::Failure(tce);
@@ -2049,11 +2049,11 @@ pub fn put_stored_values<'a, R, S, E>(
     prestate_hash: Digest,
     stored_values: BTreeMap<Key, StoredValue>,
 ) -> Result<Digest, E>
-where
-    R: TransactionSource<'a, Handle = S::Handle>,
-    S: TrieStore<Key, StoredValue>,
-    S::Error: From<R::Error>,
-    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<CommitError>,
+    where
+        R: TransactionSource<'a, Handle=S::Handle>,
+        S: TrieStore<Key, StoredValue>,
+        S::Error: From<R::Error>,
+        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<CommitError>,
 {
     let mut txn = environment.create_read_write_txn()?;
     let mut state_root = prestate_hash;
@@ -2085,11 +2085,11 @@ pub fn commit<'a, R, S, E>(
     prestate_hash: Digest,
     effects: Effects,
 ) -> Result<Digest, E>
-where
-    R: TransactionSource<'a, Handle = S::Handle>,
-    S: TrieStore<Key, StoredValue>,
-    S::Error: From<R::Error>,
-    E: From<R::Error>
+    where
+        R: TransactionSource<'a, Handle=S::Handle>,
+        S: TrieStore<Key, StoredValue>,
+        S::Error: From<R::Error>,
+        E: From<R::Error>
         + From<S::Error>
         + From<bytesrepr::Error>
         + From<CommitError>
@@ -2111,7 +2111,6 @@ where
         let instruction = match (read_result, kind) {
             (_, TransformKindV2::Identity) => {
                 // effectively a noop.
-                debug!(?state_root, ?key, "commit: attempt to commit a read.");
                 continue;
             }
             (ReadResult::NotFound, TransformKindV2::Write(new_value)) => {

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -563,7 +563,7 @@ pub trait CommitProvider: StateProvider {
 /// A trait expressing operations over the trie.
 pub trait StateProvider {
     /// Associated reader type for `StateProvider`.
-    type Reader: StateReader<Key, StoredValue, Error=GlobalStateError>;
+    type Reader: StateReader<Key, StoredValue, Error = GlobalStateError>;
 
     /// Flush the state provider.
     fn flush(&self, request: FlushRequest) -> FlushResult;
@@ -2049,11 +2049,11 @@ pub fn put_stored_values<'a, R, S, E>(
     prestate_hash: Digest,
     stored_values: BTreeMap<Key, StoredValue>,
 ) -> Result<Digest, E>
-    where
-        R: TransactionSource<'a, Handle=S::Handle>,
-        S: TrieStore<Key, StoredValue>,
-        S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<CommitError>,
+where
+    R: TransactionSource<'a, Handle = S::Handle>,
+    S: TrieStore<Key, StoredValue>,
+    S::Error: From<R::Error>,
+    E: From<R::Error> + From<S::Error> + From<bytesrepr::Error> + From<CommitError>,
 {
     let mut txn = environment.create_read_write_txn()?;
     let mut state_root = prestate_hash;
@@ -2085,11 +2085,11 @@ pub fn commit<'a, R, S, E>(
     prestate_hash: Digest,
     effects: Effects,
 ) -> Result<Digest, E>
-    where
-        R: TransactionSource<'a, Handle=S::Handle>,
-        S: TrieStore<Key, StoredValue>,
-        S::Error: From<R::Error>,
-        E: From<R::Error>
+where
+    R: TransactionSource<'a, Handle = S::Handle>,
+    S: TrieStore<Key, StoredValue>,
+    S::Error: From<R::Error>,
+    E: From<R::Error>
         + From<S::Error>
         + From<bytesrepr::Error>
         + From<CommitError>

--- a/storage/src/global_state/state/scratch.rs
+++ b/storage/src/global_state/state/scratch.rs
@@ -269,7 +269,7 @@ impl CommitProvider for ScratchGlobalState {
                         LmdbTrieStore,
                         GlobalStateError,
                     >(
-                        &txn, self.trie_store.deref(), &state_hash, &key,
+                        &txn, self.trie_store.deref(), &state_hash, &key
                     )? {
                         ReadResult::Found(current_value) => {
                             match transform_kind.apply(current_value.clone()) {
@@ -531,7 +531,7 @@ pub(crate) mod tests {
                 DEFAULT_MAX_READERS,
                 true,
             )
-                .unwrap(),
+            .unwrap(),
         );
         let trie_store =
             Arc::new(LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap());
@@ -541,7 +541,7 @@ pub(crate) mod tests {
             trie_store,
             crate::global_state::DEFAULT_MAX_QUERY_DEPTH,
         )
-            .unwrap();
+        .unwrap();
         let mut current_root = state.empty_root_hash;
         {
             let mut txn = state.environment.create_read_write_txn().unwrap();
@@ -554,7 +554,7 @@ pub(crate) mod tests {
                     key,
                     value,
                 )
-                    .unwrap()
+                .unwrap()
                 {
                     WriteResult::Written(root_hash) => {
                         current_root = root_hash;

--- a/storage/src/global_state/state/scratch.rs
+++ b/storage/src/global_state/state/scratch.rs
@@ -255,11 +255,6 @@ impl CommitProvider for ScratchGlobalState {
             let instruction = match (cached_value, kind) {
                 (_, TransformKindV2::Identity) => {
                     // effectively a noop.
-                    debug!(
-                        ?state_hash,
-                        ?key,
-                        "scratch commit: attempt to commit a read."
-                    );
                     continue;
                 }
                 (None, TransformKindV2::Write(new_value)) => TransformInstruction::store(new_value),
@@ -274,7 +269,7 @@ impl CommitProvider for ScratchGlobalState {
                         LmdbTrieStore,
                         GlobalStateError,
                     >(
-                        &txn, self.trie_store.deref(), &state_hash, &key
+                        &txn, self.trie_store.deref(), &state_hash, &key,
                     )? {
                         ReadResult::Found(current_value) => {
                             match transform_kind.apply(current_value.clone()) {
@@ -536,7 +531,7 @@ pub(crate) mod tests {
                 DEFAULT_MAX_READERS,
                 true,
             )
-            .unwrap(),
+                .unwrap(),
         );
         let trie_store =
             Arc::new(LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap());
@@ -546,7 +541,7 @@ pub(crate) mod tests {
             trie_store,
             crate::global_state::DEFAULT_MAX_QUERY_DEPTH,
         )
-        .unwrap();
+            .unwrap();
         let mut current_root = state.empty_root_hash;
         {
             let mut txn = state.environment.create_read_write_txn().unwrap();
@@ -559,7 +554,7 @@ pub(crate) mod tests {
                     key,
                     value,
                 )
-                .unwrap()
+                    .unwrap()
                 {
                     WriteResult::Written(root_hash) => {
                         current_root = root_hash;

--- a/storage/src/system/protocol_upgrade.rs
+++ b/storage/src/system/protocol_upgrade.rs
@@ -378,8 +378,6 @@ where
             }
         }
 
-        println!("writing entry points");
-
         let entry_points = system_entity_type.entry_points();
 
         for entry_point in entry_points.take_entry_points() {

--- a/storage/src/tracking_copy/ext_entity.rs
+++ b/storage/src/tracking_copy/ext_entity.rs
@@ -662,6 +662,12 @@ where
             let entity_key = Key::contract_entity_key(entity_hash);
             self.write(entity_key, StoredValue::AddressableEntity(updated_entity));
 
+            // Prune the legacy records.
+            // Prune the legacy contract.
+            self.prune(Key::Hash(contract_hash.value()));
+            // Prune the legacy Wasm record.
+            self.prune(Key::Hash(contract_wasm_hash.value()));
+
             package.insert_entity_version(protocol_version.value().major, entity_hash);
         }
 

--- a/types/src/chainspec/upgrade_config.rs
+++ b/types/src/chainspec/upgrade_config.rs
@@ -1,6 +1,6 @@
 use num_rational::Ratio;
-use std::collections::BTreeMap;
 use serde::Serialize;
+use std::collections::BTreeMap;
 
 use crate::{
     ChainspecRegistry, Digest, EraId, FeeHandling, HoldBalanceHandling, Key, ProtocolVersion,

--- a/types/src/chainspec/upgrade_config.rs
+++ b/types/src/chainspec/upgrade_config.rs
@@ -1,5 +1,6 @@
 use num_rational::Ratio;
 use std::collections::BTreeMap;
+use serde::Serialize;
 
 use crate::{
     ChainspecRegistry, Digest, EraId, FeeHandling, HoldBalanceHandling, Key, ProtocolVersion,
@@ -7,7 +8,7 @@ use crate::{
 };
 
 /// Represents the configuration of a protocol upgrade.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProtocolUpgradeConfig {
     pre_state_hash: Digest,
     current_protocol_version: ProtocolVersion,


### PR DESCRIPTION
CHANGELOG:

- Changed the upgrade logic to flow through the reactor loop and trigger the upgrade in a non blocking way
- Tweaking contract migration logic to also prune the legacy contracts and wasm records post migration
- Removed spurious print and noisy log messages

