### PR TITLE
Initial implementation of a reward request

### DIFF
--- a/binary_port/src/era_identifier.rs
+++ b/binary_port/src/era_identifier.rs
@@ -1,0 +1,90 @@
+#[cfg(test)]
+use casper_types::testing::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
+use casper_types::{
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    BlockIdentifier, EraId,
+};
+
+const ERA_TAG: u8 = 0;
+const BLOCK_TAG: u8 = 1;
+
+/// Identifier for balance lookup.
+#[derive(Clone, Debug, PartialEq)]
+pub enum EraIdentifier {
+    Era(EraId),
+    Block(BlockIdentifier),
+}
+
+impl EraIdentifier {
+    #[cfg(test)]
+    pub(crate) fn random(rng: &mut TestRng) -> Self {
+        match rng.gen_range(0..2) {
+            ERA_TAG => EraIdentifier::Era(EraId::random(rng)),
+            BLOCK_TAG => EraIdentifier::Block(BlockIdentifier::random(rng)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl ToBytes for EraIdentifier {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            EraIdentifier::Era(era_id) => {
+                ERA_TAG.write_bytes(writer)?;
+                era_id.write_bytes(writer)
+            }
+            EraIdentifier::Block(block_id) => {
+                BLOCK_TAG.write_bytes(writer)?;
+                block_id.write_bytes(writer)
+            }
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                EraIdentifier::Era(era_id) => era_id.serialized_length(),
+                EraIdentifier::Block(block_id) => block_id.serialized_length(),
+            }
+    }
+}
+
+impl FromBytes for EraIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            ERA_TAG => {
+                let (era_id, remainder) = EraId::from_bytes(remainder)?;
+                Ok((EraIdentifier::Era(era_id), remainder))
+            }
+            BLOCK_TAG => {
+                let (block_id, remainder) = BlockIdentifier::from_bytes(remainder)?;
+                Ok((EraIdentifier::Block(block_id), remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use casper_types::testing::TestRng;
+
+    #[test]
+    fn bytesrepr_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let val = EraIdentifier::random(rng);
+        bytesrepr::test_serialization_roundtrip(&val);
+    }
+}

--- a/binary_port/src/era_identifier.rs
+++ b/binary_port/src/era_identifier.rs
@@ -11,7 +11,7 @@ use casper_types::{
 const ERA_TAG: u8 = 0;
 const BLOCK_TAG: u8 = 1;
 
-/// Identifier for balance lookup.
+/// Identifier for an era.
 #[derive(Clone, Debug, PartialEq)]
 pub enum EraIdentifier {
     Era(EraId),

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -186,6 +186,10 @@ pub enum ErrorCode {
     /// the case that nothing else works.
     #[error("The transaction or deploy sent to the network was invalid for an unspecified reason")]
     InvalidTransactionOrDeployUnspecified = 57,
+    #[error("Switch block not found for the provided identifier")]
+    SwitchBlockNotFound = 58,
+    #[error("Rewards v1 requests are not supported")]
+    UnsupportedRewardsV1Request = 59,
 }
 
 impl TryFrom<u8> for ErrorCode {
@@ -251,6 +255,8 @@ impl TryFrom<u8> for ErrorCode {
             55 => Ok(ErrorCode::InvalidTransactionPricingMode),
             56 => Ok(ErrorCode::InvalidTransactionUnspecified),
             57 => Ok(ErrorCode::InvalidTransactionOrDeployUnspecified),
+            58 => Ok(ErrorCode::SwitchBlockNotFound),
+            59 => Ok(ErrorCode::UnsupportedRewardsV1Request),
             _ => Err(UnknownErrorCode),
         }
     }

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -186,10 +186,12 @@ pub enum ErrorCode {
     /// the case that nothing else works.
     #[error("The transaction or deploy sent to the network was invalid for an unspecified reason")]
     InvalidTransactionOrDeployUnspecified = 57,
-    #[error("Switch block not found for the provided identifier")]
+    #[error("switch block not found for the provided identifier")]
     SwitchBlockNotFound = 58,
-    #[error("Rewards v1 requests are not supported")]
-    UnsupportedRewardsV1Request = 59,
+    #[error("parent block not found for the provided switch block identifier")]
+    SwitchBlockParentNotFound = 59,
+    #[error("rewards v1 requests are not supported")]
+    UnsupportedRewardsV1Request = 60,
 }
 
 impl TryFrom<u8> for ErrorCode {
@@ -256,7 +258,8 @@ impl TryFrom<u8> for ErrorCode {
             56 => Ok(ErrorCode::InvalidTransactionUnspecified),
             57 => Ok(ErrorCode::InvalidTransactionOrDeployUnspecified),
             58 => Ok(ErrorCode::SwitchBlockNotFound),
-            59 => Ok(ErrorCode::UnsupportedRewardsV1Request),
+            59 => Ok(ErrorCode::SwitchBlockParentNotFound),
+            60 => Ok(ErrorCode::UnsupportedRewardsV1Request),
             _ => Err(UnknownErrorCode),
         }
     }

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -186,11 +186,14 @@ pub enum ErrorCode {
     /// the case that nothing else works.
     #[error("The transaction or deploy sent to the network was invalid for an unspecified reason")]
     InvalidTransactionOrDeployUnspecified = 57,
+    /// The switch block for the requested era was not found
     #[error("the switch block for the requested era was not found")]
     SwitchBlockNotFound = 58,
     #[error("the parent of the switch block for the requested era was not found")]
+    /// The parent of the switch block for the requested era was not found
     SwitchBlockParentNotFound = 59,
     #[error("cannot serve rewards stored in V1 format")]
+    /// Cannot serve rewards stored in V1 format
     UnsupportedRewardsV1Request = 60,
 }
 

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -186,11 +186,11 @@ pub enum ErrorCode {
     /// the case that nothing else works.
     #[error("The transaction or deploy sent to the network was invalid for an unspecified reason")]
     InvalidTransactionOrDeployUnspecified = 57,
-    #[error("switch block not found for the provided identifier")]
+    #[error("the switch block for the requested era was not found")]
     SwitchBlockNotFound = 58,
-    #[error("parent block not found for the provided switch block identifier")]
+    #[error("the parent of the switch block for the requested era was not found")]
     SwitchBlockParentNotFound = 59,
-    #[error("rewards v1 requests are not supported")]
+    #[error("cannot serve rewards stored in V1 format")]
     UnsupportedRewardsV1Request = 60,
 }
 

--- a/binary_port/src/information_request.rs
+++ b/binary_port/src/information_request.rs
@@ -3,12 +3,12 @@ use core::convert::TryFrom;
 #[cfg(test)]
 use rand::Rng;
 
-use crate::get_request::GetRequest;
+use crate::{get_request::GetRequest, EraIdentifier};
 #[cfg(test)]
 use casper_types::testing::TestRng;
 use casper_types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    BlockIdentifier, TransactionHash,
+    BlockIdentifier, PublicKey, TransactionHash,
 };
 
 /// Request for information from the node.
@@ -51,6 +51,17 @@ pub enum InformationRequest {
     NodeStatus,
     /// Returns the latest switch block header.
     LatestSwitchBlockHeader,
+    /// Returns the reward for a validator or a delegator in a specific era.
+    Reward {
+        /// Identifier of the era to get the reward for. Must point to either a switch block or
+        /// a valid `EraId`. If `None`, the reward for the latest switch block is returned.
+        era_identifier: Option<EraIdentifier>,
+        /// Public key of the validator to get the reward for.
+        validator: Box<PublicKey>,
+        /// Public key of the delegator to get the reward for.
+        /// If `None`, the reward for the validator is returned.
+        delegator: Option<Box<PublicKey>>,
+    },
 }
 
 impl InformationRequest {
@@ -79,26 +90,19 @@ impl InformationRequest {
             InformationRequest::LatestSwitchBlockHeader => {
                 InformationRequestTag::LatestSwitchBlockHeader
             }
+            InformationRequest::Reward { .. } => InformationRequestTag::Reward,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn random(rng: &mut TestRng) -> Self {
         match InformationRequestTag::random(rng) {
-            InformationRequestTag::BlockHeader => {
-                if rng.gen() {
-                    InformationRequest::BlockHeader(None)
-                } else {
-                    InformationRequest::BlockHeader(Some(BlockIdentifier::random(rng)))
-                }
-            }
-            InformationRequestTag::SignedBlock => {
-                if rng.gen() {
-                    InformationRequest::SignedBlock(None)
-                } else {
-                    InformationRequest::SignedBlock(Some(BlockIdentifier::random(rng)))
-                }
-            }
+            InformationRequestTag::BlockHeader => InformationRequest::BlockHeader(
+                rng.gen::<bool>().then(|| BlockIdentifier::random(rng)),
+            ),
+            InformationRequestTag::SignedBlock => InformationRequest::SignedBlock(
+                rng.gen::<bool>().then(|| BlockIdentifier::random(rng)),
+            ),
             InformationRequestTag::Transaction => InformationRequest::Transaction {
                 hash: TransactionHash::random(rng),
                 with_finalized_approvals: rng.gen(),
@@ -122,6 +126,11 @@ impl InformationRequest {
             InformationRequestTag::LatestSwitchBlockHeader => {
                 InformationRequest::LatestSwitchBlockHeader
             }
+            InformationRequestTag::Reward => InformationRequest::Reward {
+                era_identifier: rng.gen::<bool>().then(|| EraIdentifier::random(rng)),
+                validator: PublicKey::random(rng).into(),
+                delegator: rng.gen::<bool>().then(|| PublicKey::random(rng).into()),
+            },
         }
     }
 }
@@ -161,6 +170,18 @@ impl ToBytes for InformationRequest {
             | InformationRequest::ChainspecRawBytes
             | InformationRequest::NodeStatus
             | InformationRequest::LatestSwitchBlockHeader => Ok(()),
+            InformationRequest::Reward {
+                era_identifier,
+                validator,
+                delegator,
+            } => {
+                era_identifier.write_bytes(writer)?;
+                validator.write_bytes(writer)?;
+                if let Some(delegator) = delegator {
+                    delegator.write_bytes(writer)?;
+                }
+                Ok(())
+            }
         }
     }
 
@@ -189,6 +210,15 @@ impl ToBytes for InformationRequest {
             | InformationRequest::ChainspecRawBytes
             | InformationRequest::NodeStatus
             | InformationRequest::LatestSwitchBlockHeader => 0,
+            InformationRequest::Reward {
+                era_identifier,
+                validator,
+                delegator,
+            } => {
+                era_identifier.serialized_length()
+                    + validator.serialized_length()
+                    + delegator.as_deref().serialized_length()
+            }
         }
     }
 }
@@ -241,6 +271,19 @@ impl TryFrom<(InformationRequestTag, &[u8])> for InformationRequest {
             InformationRequestTag::NodeStatus => (InformationRequest::NodeStatus, key_bytes),
             InformationRequestTag::LatestSwitchBlockHeader => {
                 (InformationRequest::LatestSwitchBlockHeader, key_bytes)
+            }
+            InformationRequestTag::Reward => {
+                let (era_identifier, remainder) = <Option<EraIdentifier>>::from_bytes(key_bytes)?;
+                let (validator, remainder) = PublicKey::from_bytes(remainder)?;
+                let (delegator, remainder) = <Option<PublicKey>>::from_bytes(remainder)?;
+                (
+                    InformationRequest::Reward {
+                        era_identifier,
+                        validator: Box::new(validator),
+                        delegator: delegator.map(Box::new),
+                    },
+                    remainder,
+                )
             }
         };
         if !remainder.is_empty() {
@@ -297,6 +340,8 @@ pub enum InformationRequestTag {
     NodeStatus = 14,
     /// Latest switch block header request.
     LatestSwitchBlockHeader = 15,
+    /// Reward for a validator or a delegator in a specific era.
+    Reward = 16,
 }
 
 impl InformationRequestTag {
@@ -319,6 +364,7 @@ impl InformationRequestTag {
             13 => InformationRequestTag::ChainspecRawBytes,
             14 => InformationRequestTag::NodeStatus,
             15 => InformationRequestTag::LatestSwitchBlockHeader,
+            16 => InformationRequestTag::Reward,
             _ => unreachable!(),
         }
     }
@@ -345,6 +391,7 @@ impl TryFrom<u16> for InformationRequestTag {
             13 => Ok(InformationRequestTag::ChainspecRawBytes),
             14 => Ok(InformationRequestTag::NodeStatus),
             15 => Ok(InformationRequestTag::LatestSwitchBlockHeader),
+            16 => Ok(InformationRequestTag::Reward),
             _ => Err(UnknownInformationRequestTag(value)),
         }
     }

--- a/binary_port/src/information_request.rs
+++ b/binary_port/src/information_request.rs
@@ -177,9 +177,7 @@ impl ToBytes for InformationRequest {
             } => {
                 era_identifier.write_bytes(writer)?;
                 validator.write_bytes(writer)?;
-                if let Some(delegator) = delegator {
-                    delegator.write_bytes(writer)?;
-                }
+                delegator.as_deref().write_bytes(writer)?;
                 Ok(())
             }
         }

--- a/binary_port/src/lib.rs
+++ b/binary_port/src/lib.rs
@@ -7,6 +7,7 @@ mod binary_response;
 mod binary_response_and_request;
 mod binary_response_header;
 mod dictionary_item_identifier;
+mod era_identifier;
 mod error;
 mod error_code;
 mod get_request;
@@ -29,6 +30,7 @@ pub use binary_response::BinaryResponse;
 pub use binary_response_and_request::BinaryResponseAndRequest;
 pub use binary_response_header::BinaryResponseHeader;
 pub use dictionary_item_identifier::DictionaryItemIdentifier;
+pub use era_identifier::EraIdentifier;
 pub use error::Error;
 pub use error_code::ErrorCode;
 pub use get_request::GetRequest;
@@ -44,5 +46,5 @@ pub use speculative_execution_result::SpeculativeExecutionResult;
 pub use state_request::GlobalStateRequest;
 pub use type_wrappers::{
     ConsensusStatus, ConsensusValidatorChanges, DictionaryQueryResult, GetTrieFullResult,
-    LastProgress, NetworkName, ReactorStateName, TransactionWithExecutionInfo, Uptime,
+    LastProgress, NetworkName, ReactorStateName, Reward, TransactionWithExecutionInfo, Uptime,
 };

--- a/binary_port/src/lib.rs
+++ b/binary_port/src/lib.rs
@@ -46,5 +46,6 @@ pub use speculative_execution_result::SpeculativeExecutionResult;
 pub use state_request::GlobalStateRequest;
 pub use type_wrappers::{
     ConsensusStatus, ConsensusValidatorChanges, DictionaryQueryResult, GetTrieFullResult,
-    LastProgress, NetworkName, ReactorStateName, RewardResponse, TransactionWithExecutionInfo, Uptime,
+    LastProgress, NetworkName, ReactorStateName, RewardResponse, TransactionWithExecutionInfo,
+    Uptime,
 };

--- a/binary_port/src/lib.rs
+++ b/binary_port/src/lib.rs
@@ -46,5 +46,5 @@ pub use speculative_execution_result::SpeculativeExecutionResult;
 pub use state_request::GlobalStateRequest;
 pub use type_wrappers::{
     ConsensusStatus, ConsensusValidatorChanges, DictionaryQueryResult, GetTrieFullResult,
-    LastProgress, NetworkName, ReactorStateName, Reward, TransactionWithExecutionInfo, Uptime,
+    LastProgress, NetworkName, ReactorStateName, RewardResponse, TransactionWithExecutionInfo, Uptime,
 };

--- a/binary_port/src/payload_type.rs
+++ b/binary_port/src/payload_type.rs
@@ -22,7 +22,7 @@ use crate::{
     speculative_execution_result::SpeculativeExecutionResult,
     type_wrappers::{
         ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult, LastProgress, NetworkName,
-        ReactorStateName, Reward,
+        ReactorStateName, RewardResponse,
     },
     BalanceResponse, DictionaryQueryResult, RecordId, TransactionWithExecutionInfo, Uptime,
 };
@@ -387,7 +387,7 @@ impl PayloadEntity for BalanceResponse {
     const PAYLOAD_TYPE: PayloadType = PayloadType::BalanceResponse;
 }
 
-impl PayloadEntity for Reward {
+impl PayloadEntity for RewardResponse {
     const PAYLOAD_TYPE: PayloadType = PayloadType::Reward;
 }
 

--- a/binary_port/src/payload_type.rs
+++ b/binary_port/src/payload_type.rs
@@ -22,7 +22,7 @@ use crate::{
     speculative_execution_result::SpeculativeExecutionResult,
     type_wrappers::{
         ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult, LastProgress, NetworkName,
-        ReactorStateName,
+        ReactorStateName, Reward,
     },
     BalanceResponse, DictionaryQueryResult, RecordId, TransactionWithExecutionInfo, Uptime,
 };
@@ -106,6 +106,8 @@ pub enum PayloadType {
     DictionaryQueryResult,
     /// Balance query response.
     BalanceResponse,
+    /// Reward response.
+    Reward,
 }
 
 impl PayloadType {
@@ -132,7 +134,7 @@ impl PayloadType {
 
     #[cfg(test)]
     pub(crate) fn random(rng: &mut TestRng) -> Self {
-        Self::try_from(rng.gen_range(0..37)).unwrap()
+        Self::try_from(rng.gen_range(0..38)).unwrap()
     }
 }
 
@@ -196,6 +198,7 @@ impl TryFrom<u8> for PayloadType {
             }
             x if x == PayloadType::WasmV1Result as u8 => Ok(PayloadType::WasmV1Result),
             x if x == PayloadType::BalanceResponse as u8 => Ok(PayloadType::BalanceResponse),
+            x if x == PayloadType::Reward as u8 => Ok(PayloadType::Reward),
             _ => Err(()),
         }
     }
@@ -249,6 +252,7 @@ impl fmt::Display for PayloadType {
             PayloadType::WasmV1Result => write!(f, "WasmV1Result"),
             PayloadType::DictionaryQueryResult => write!(f, "DictionaryQueryResult"),
             PayloadType::BalanceResponse => write!(f, "BalanceResponse"),
+            PayloadType::Reward => write!(f, "Reward"),
         }
     }
 }
@@ -381,6 +385,10 @@ impl PayloadEntity for ConsensusStatus {
 
 impl PayloadEntity for BalanceResponse {
     const PAYLOAD_TYPE: PayloadType = PayloadType::BalanceResponse;
+}
+
+impl PayloadEntity for Reward {
+    const PAYLOAD_TYPE: PayloadType = PayloadType::Reward;
 }
 
 #[cfg(test)]

--- a/binary_port/src/type_wrappers.rs
+++ b/binary_port/src/type_wrappers.rs
@@ -6,7 +6,7 @@ use datasize::DataSize;
 
 use casper_types::{
     bytesrepr::{self, Bytes, FromBytes, ToBytes},
-    EraId, ExecutionInfo, Key, PublicKey, TimeDiff, Timestamp, Transaction, ValidatorChange,
+    EraId, ExecutionInfo, Key, PublicKey, TimeDiff, Timestamp, Transaction, ValidatorChange, U512,
 };
 
 use super::GlobalStateQueryResult;
@@ -173,6 +173,22 @@ impl GetTrieFullResult {
     }
 }
 
+/// Type representing the reward of a validator or a delegator.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Reward(U512);
+
+impl Reward {
+    /// Constructs new reward.
+    pub fn new(value: U512) -> Self {
+        Self(value)
+    }
+
+    /// Retrieve the inner value.
+    pub fn into_inner(self) -> U512 {
+        self.0
+    }
+}
+
 /// Describes the consensus status.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ConsensusStatus {
@@ -329,6 +345,7 @@ impl_bytesrepr_for_type_wrapper!(NetworkName);
 impl_bytesrepr_for_type_wrapper!(ReactorStateName);
 impl_bytesrepr_for_type_wrapper!(LastProgress);
 impl_bytesrepr_for_type_wrapper!(GetTrieFullResult);
+impl_bytesrepr_for_type_wrapper!(Reward);
 
 #[cfg(test)]
 mod tests {
@@ -378,6 +395,12 @@ mod tests {
     fn get_trie_full_result_roundtrip() {
         let rng = &mut TestRng::new();
         bytesrepr::test_serialization_roundtrip(&GetTrieFullResult::new(rng.gen()));
+    }
+
+    #[test]
+    fn reward_roundtrip() {
+        let rng = &mut TestRng::new();
+        bytesrepr::test_serialization_roundtrip(&Reward::new(U512::from(rng.gen::<u64>())));
     }
 
     #[test]

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -805,15 +805,12 @@ where
             let Some(header) = resolve_era_switch_block_header(effect_builder, era_identifier).await else {
                 return BinaryResponse::new_error(ErrorCode::SwitchBlockNotFound, protocol_version);
             };
-            let Some(previous_height) = header.height().checked_sub(1) else {
+            let Some(parent_header) =
+                effect_builder.get_block_header_from_storage(*header.parent_hash(), true).await else {
                 return BinaryResponse::new_empty(protocol_version);
             };
-            let Some(previous_header) =
-                effect_builder.get_block_header_at_height_from_storage(previous_height, true).await else {
-                return BinaryResponse::new_error(ErrorCode::InternalError, protocol_version);
-            };
             let snapshot_request = SeigniorageRecipientsRequest::new(
-                *previous_header.state_root_hash(),
+                *parent_header.state_root_hash(),
                 protocol_version,
             );
 

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -1180,9 +1180,13 @@ where
         }
         Some(EraIdentifier::Block(block_identifier)) => {
             let header = resolve_block_header(effect_builder, Some(block_identifier)).await?;
-            effect_builder
-                .get_switch_block_header_by_era_id_from_storage(header.era_id())
-                .await
+            if header.is_switch_block() {
+                Some(header)
+            } else {
+                effect_builder
+                    .get_switch_block_header_by_era_id_from_storage(header.era_id())
+                    .await
+            }
         }
         None => {
             effect_builder

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -805,9 +805,13 @@ where
             let Some(header) = resolve_era_switch_block_header(effect_builder, era_identifier).await else {
                 return BinaryResponse::new_error(ErrorCode::SwitchBlockNotFound, protocol_version);
             };
-            let Some(parent_header) =
-                effect_builder.get_block_header_from_storage(*header.parent_hash(), true).await else {
+            let Some(previous_height) = header.height().checked_sub(1) else {
+                // there's not going to be any rewards for the genesis block
                 return BinaryResponse::new_empty(protocol_version);
+            };
+            let Some(parent_header) =
+                effect_builder.get_block_header_at_height_from_storage(previous_height, true).await else {
+                return BinaryResponse::new_error(ErrorCode::SwitchBlockParentNotFound, protocol_version);
             };
             let snapshot_request = SeigniorageRecipientsRequest::new(
                 *parent_header.state_root_hash(),

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -1162,7 +1162,7 @@ where
         }
         Some(EraIdentifier::Block(block_identifier)) => {
             let header = resolve_block_header(effect_builder, Some(block_identifier)).await?;
-            header.is_switch_block().then(|| header)
+            header.is_switch_block().then_some(header)
         }
         None => {
             effect_builder

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -372,6 +372,21 @@ impl ContractRuntime {
                 }
                 .ignore()
             }
+            ContractRuntimeRequest::GetSeigniorageRecipients { request, responder } => {
+                trace!(?request, "get seigniorage recipients request");
+                let metrics = Arc::clone(&self.metrics);
+                let data_access_layer = Arc::clone(&self.data_access_layer);
+                async move {
+                    let start = Instant::now();
+                    let result = data_access_layer.seigniorage_recipients(request);
+                    metrics
+                        .get_seigniorage_recipients
+                        .observe(start.elapsed().as_secs_f64());
+                    trace!(?result, "seigniorage recipients result");
+                    responder.respond(result).await
+                }
+                .ignore()
+            }
             ContractRuntimeRequest::GetExecutionResultsChecksum {
                 state_root_hash,
                 responder,

--- a/node/src/components/contract_runtime/metrics.rs
+++ b/node/src/components/contract_runtime/metrics.rs
@@ -61,6 +61,10 @@ const GET_ERA_VALIDATORS_NAME: &str = "contract_runtime_get_era_validators";
 const GET_ERA_VALIDATORS_HELP: &str =
     "time in seconds to get validators for a given era from global state";
 
+const GET_SEIGNIORAGE_RECIPIENTS_NAME: &str = "contract_runtime_get_seigniorage_recipients";
+const GET_SEIGNIORAGE_RECIPIENTS_HELP: &str =
+    "time in seconds to get seigniorage recipients from global state";
+
 const GET_ALL_VALUES_NAME: &str = "contract_runtime_get_all_values";
 const GET_ALL_VALUES_NAME_HELP: &str =
     "time in seconds to get all values under a give key from global state";
@@ -114,6 +118,7 @@ pub struct Metrics {
     pub(super) get_total_supply: Histogram,
     pub(super) get_round_seigniorage_rate: Histogram,
     pub(super) get_era_validators: Histogram,
+    pub(super) get_seigniorage_recipients: Histogram,
     pub(super) get_all_values: Histogram,
     pub(super) execution_results_checksum: Histogram,
     pub(super) addressable_entity: Histogram,
@@ -237,6 +242,12 @@ impl Metrics {
                 GET_ERA_VALIDATORS_HELP,
                 common_buckets.clone(),
             )?,
+            get_seigniorage_recipients: utils::register_histogram_metric(
+                registry,
+                GET_SEIGNIORAGE_RECIPIENTS_NAME,
+                GET_SEIGNIORAGE_RECIPIENTS_HELP,
+                common_buckets.clone(),
+            )?,
             get_all_values: utils::register_histogram_metric(
                 registry,
                 GET_ALL_VALUES_NAME,
@@ -297,6 +308,7 @@ impl Drop for Metrics {
         unregister_metric!(self.registry, self.get_total_supply);
         unregister_metric!(self.registry, self.get_round_seigniorage_rate);
         unregister_metric!(self.registry, self.get_era_validators);
+        unregister_metric!(self.registry, self.get_seigniorage_recipients);
         unregister_metric!(self.registry, self.get_all_values);
         unregister_metric!(self.registry, self.execution_results_checksum);
         unregister_metric!(self.registry, self.put_trie);

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -124,7 +124,8 @@ use casper_storage::{
         tagged_values::{TaggedValuesRequest, TaggedValuesResult},
         AddressableEntityResult, BalanceRequest, BalanceResult, EraValidatorsRequest,
         EraValidatorsResult, ExecutionResultsChecksumResult, PutTrieRequest, PutTrieResult,
-        QueryRequest, QueryResult, TrieRequest, TrieResult,
+        QueryRequest, QueryResult, SeigniorageRecipientsRequest, SeigniorageRecipientsResult,
+        TrieRequest, TrieResult,
     },
     DbRawBytesSpec,
 };
@@ -2092,6 +2093,20 @@ impl<REv> EffectBuilder<REv> {
     {
         self.make_request(
             |responder| ContractRuntimeRequest::GetEraValidators { request, responder },
+            QueueKind::ContractRuntime,
+        )
+        .await
+    }
+
+    pub(crate) async fn get_seigniorage_recipients_snapshot_from_contract_runtime(
+        self,
+        request: SeigniorageRecipientsRequest,
+    ) -> SeigniorageRecipientsResult
+    where
+        REv: From<ContractRuntimeRequest>,
+    {
+        self.make_request(
+            |responder| ContractRuntimeRequest::GetSeigniorageRecipients { request, responder },
             QueueKind::ContractRuntime,
         )
         .await

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -25,7 +25,8 @@ use casper_storage::{
         tagged_values::{TaggedValuesRequest, TaggedValuesResult},
         AddressableEntityResult, BalanceRequest, BalanceResult, EntryPointsResult,
         EraValidatorsRequest, EraValidatorsResult, ExecutionResultsChecksumResult, PutTrieRequest,
-        PutTrieResult, QueryRequest, QueryResult, TrieRequest, TrieResult,
+        PutTrieResult, QueryRequest, QueryResult, SeigniorageRecipientsRequest,
+        SeigniorageRecipientsResult, TrieRequest, TrieResult,
     },
     DbRawBytesSpec,
 };
@@ -794,6 +795,14 @@ pub(crate) enum ContractRuntimeRequest {
         /// Responder to call with the result.
         responder: Responder<EraValidatorsResult>,
     },
+    /// Returns the seigniorage recipients snapshot at the given state root hash.
+    GetSeigniorageRecipients {
+        /// Get seigniorage recipients request.
+        #[serde(skip_serializing)]
+        request: SeigniorageRecipientsRequest,
+        /// Responder to call with the result.
+        responder: Responder<SeigniorageRecipientsResult>,
+    },
     /// Return all values at a given state root hash and given key tag.
     GetTaggedValues {
         /// Get tagged values request.
@@ -879,6 +888,9 @@ impl Display for ContractRuntimeRequest {
             } => write!(formatter, "balance request: {:?}", balance_request),
             ContractRuntimeRequest::GetEraValidators { request, .. } => {
                 write!(formatter, "get era validators: {:?}", request)
+            }
+            ContractRuntimeRequest::GetSeigniorageRecipients { request, .. } => {
+                write!(formatter, "get seigniorage recipients for {:?}", request)
             }
             ContractRuntimeRequest::GetTaggedValues {
                 request: get_all_values_request,

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -9,10 +9,10 @@ use std::{
 use casper_binary_port::{
     BalanceResponse, BinaryMessage, BinaryMessageCodec, BinaryRequest, BinaryRequestHeader,
     BinaryResponse, BinaryResponseAndRequest, ConsensusStatus, ConsensusValidatorChanges,
-    DictionaryItemIdentifier, DictionaryQueryResult, ErrorCode, GetRequest, GetTrieFullResult,
-    GlobalStateQueryResult, GlobalStateRequest, InformationRequest, InformationRequestTag,
-    KeyPrefix, LastProgress, NetworkName, NodeStatus, PayloadType, PurseIdentifier,
-    ReactorStateName, RecordId, Uptime,
+    DictionaryItemIdentifier, DictionaryQueryResult, EraIdentifier, ErrorCode, GetRequest,
+    GetTrieFullResult, GlobalStateQueryResult, GlobalStateRequest, InformationRequest,
+    InformationRequestTag, KeyPrefix, LastProgress, NetworkName, NodeStatus, PayloadType,
+    PurseIdentifier, ReactorStateName, RecordId, RewardResponse, Uptime,
 };
 use casper_storage::global_state::state::CommitProvider;
 use casper_types::{
@@ -23,8 +23,9 @@ use casper_types::{
     testing::TestRng,
     Account, AvailableBlockRange, Block, BlockHash, BlockHeader, BlockIdentifier,
     BlockSynchronizerStatus, CLValue, CLValueDictionary, ChainspecRawBytes, DictionaryAddr, Digest,
-    EntityAddr, GlobalStateIdentifier, Key, KeyTag, NextUpgrade, Peers, ProtocolVersion, SecretKey,
-    SignedBlock, StoredValue, Transaction, TransactionV1Builder, Transfer, URef, U512,
+    EntityAddr, GlobalStateIdentifier, Key, KeyTag, NextUpgrade, Peers, ProtocolVersion, PublicKey,
+    Rewards, SecretKey, SignedBlock, StoredValue, Transaction, TransactionV1Builder, Transfer,
+    URef, U512,
 };
 use futures::{SinkExt, StreamExt};
 use rand::Rng;
@@ -39,9 +40,9 @@ use crate::{
     types::NodeId,
 };
 
-use super::{InitialStakes, TestFixture};
+use super::{InitialStakes, TestFixture, ERA_ONE};
 
-const GUARANTEED_BLOCK_HEIGHT: u64 = 2;
+const GUARANTEED_BLOCK_HEIGHT: u64 = 4;
 
 const TEST_DICT_NAME: &str = "test_dict";
 const TEST_DICT_ITEM_KEY: &str = "test_key";
@@ -56,6 +57,7 @@ struct TestData {
     test_account_hash: AccountHash,
     test_entity_addr: EntityAddr,
     test_dict_seed_uref: URef,
+    era_one_validator: PublicKey,
 }
 
 fn network_produced_blocks(
@@ -119,6 +121,17 @@ async fn setup() -> (
                 .read_highest_block()
         })
         .expect("should have highest block");
+    let era_end = first_node
+        .main_reactor()
+        .storage()
+        .get_switch_block_by_era_id(&ERA_ONE)
+        .expect("should not fail retrieving switch block")
+        .expect("should have switch block")
+        .clone_era_end()
+        .expect("should have era end");
+    let Rewards::V2(rewards) = era_end.rewards() else {
+        panic!("should have rewards V2");
+    };
 
     let effects = test_effects(&mut rng);
 
@@ -158,6 +171,11 @@ async fn setup() -> (
                 test_account_hash: effects.test_account_hash,
                 test_entity_addr: effects.test_entity_addr,
                 test_dict_seed_uref: effects.test_dict_seed_uref,
+                era_one_validator: rewards
+                    .last_key_value()
+                    .expect("should have at least one reward")
+                    .0
+                    .clone(),
             },
         ),
     )
@@ -287,6 +305,7 @@ async fn binary_port_component() {
                 test_account_hash,
                 test_entity_addr,
                 test_dict_seed_uref,
+                era_one_validator,
             },
         ),
     ) = setup().await;
@@ -301,7 +320,7 @@ async fn binary_port_component() {
         network_name(),
         consensus_validator_changes(),
         block_synchronizer_status(),
-        available_block_range(),
+        available_block_range(highest_block.height()),
         next_upgrade(),
         consensus_status(),
         chainspec_raw_bytes(network_chainspec_raw_bytes),
@@ -340,6 +359,7 @@ async fn binary_port_component() {
         try_accept_transaction(&secret_signing_key),
         get_balance(state_root_hash, test_account_hash),
         get_named_keys_by_prefix(state_root_hash, test_entity_addr),
+        get_reward(Some(EraIdentifier::Era(ERA_ONE)), era_one_validator, None),
     ];
 
     for TestCase {
@@ -536,18 +556,18 @@ fn block_synchronizer_status() -> TestCase {
     }
 }
 
-fn available_block_range() -> TestCase {
+fn available_block_range(expected_height: u64) -> TestCase {
     TestCase {
         name: "available_block_range",
         request: BinaryRequest::Get(GetRequest::Information {
             info_type_tag: InformationRequestTag::AvailableBlockRange.into(),
             key: vec![],
         }),
-        asserter: Box::new(|response| {
+        asserter: Box::new(move |response| {
             assert_response::<AvailableBlockRange, _>(
                 response,
                 Some(PayloadType::AvailableBlockRange),
-                |abr| abr.low() == 0 && abr.high() >= GUARANTEED_BLOCK_HEIGHT,
+                |abr| abr.low() == 0 && abr.high() >= expected_height,
             )
         }),
     }
@@ -866,6 +886,31 @@ fn get_named_keys_by_prefix(state_root_hash: Digest, entity_addr: EntityAddr) ->
                 Some(PayloadType::StoredValues),
                 |res| res.iter().all(|v| matches!(v, StoredValue::NamedKey(_))),
             )
+        }),
+    }
+}
+
+fn get_reward(
+    era_identifier: Option<EraIdentifier>,
+    validator: PublicKey,
+    delegator: Option<PublicKey>,
+) -> TestCase {
+    let key = InformationRequest::Reward {
+        era_identifier,
+        validator: validator.into(),
+        delegator: delegator.map(Box::new),
+    };
+
+    TestCase {
+        name: "get_reward",
+        request: BinaryRequest::Get(GetRequest::Information {
+            info_type_tag: key.tag().into(),
+            key: key.to_bytes().expect("should serialize key"),
+        }),
+        asserter: Box::new(move |response| {
+            assert_response::<RewardResponse, _>(response, Some(PayloadType::Reward), |reward| {
+                reward.amount() > U512::zero()
+            })
         }),
     }
 }

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -359,7 +359,18 @@ async fn binary_port_component() {
         try_accept_transaction(&secret_signing_key),
         get_balance(state_root_hash, test_account_hash),
         get_named_keys_by_prefix(state_root_hash, test_entity_addr),
-        get_reward(Some(EraIdentifier::Era(ERA_ONE)), era_one_validator, None),
+        get_reward(
+            Some(EraIdentifier::Era(ERA_ONE)),
+            era_one_validator.clone(),
+            None,
+        ),
+        get_reward(
+            Some(EraIdentifier::Block(BlockIdentifier::Hash(
+                *highest_block.hash(),
+            ))),
+            era_one_validator,
+            None,
+        ),
     ];
 
     for TestCase {

--- a/storage/src/data_access_layer.rs
+++ b/storage/src/data_access_layer.rs
@@ -28,6 +28,7 @@ mod protocol_upgrade;
 pub mod prune;
 pub mod query;
 mod round_seigniorage;
+mod seigniorage_recipients;
 pub mod step;
 mod system_entity_registry;
 pub mod tagged_values;
@@ -64,6 +65,7 @@ pub use protocol_upgrade::{ProtocolUpgradeRequest, ProtocolUpgradeResult};
 pub use prune::{PruneRequest, PruneResult};
 pub use query::{QueryRequest, QueryResult};
 pub use round_seigniorage::{RoundSeigniorageRateRequest, RoundSeigniorageRateResult};
+pub use seigniorage_recipients::{SeigniorageRecipientsRequest, SeigniorageRecipientsResult};
 pub use step::{EvictItem, RewardItem, SlashItem, StepError, StepRequest, StepResult};
 pub use system_entity_registry::{
     SystemEntityRegistryPayload, SystemEntityRegistryRequest, SystemEntityRegistryResult,

--- a/storage/src/data_access_layer/seigniorage_recipients.rs
+++ b/storage/src/data_access_layer/seigniorage_recipients.rs
@@ -1,10 +1,10 @@
-//! Support for querying era validators.
+//! Support for querying seigniorage recipients.
 
 use crate::tracking_copy::TrackingCopyError;
 use casper_types::{system::auction::SeigniorageRecipientsSnapshot, Digest, ProtocolVersion};
 use std::fmt::{Display, Formatter};
 
-/// Request for siegniorage recipients.
+/// Request for seigniorage recipients.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SeigniorageRecipientsRequest {
     state_hash: Digest,

--- a/storage/src/data_access_layer/seigniorage_recipients.rs
+++ b/storage/src/data_access_layer/seigniorage_recipients.rs
@@ -1,0 +1,86 @@
+//! Support for querying era validators.
+
+use crate::tracking_copy::TrackingCopyError;
+use casper_types::{system::auction::SeigniorageRecipientsSnapshot, Digest, ProtocolVersion};
+use std::fmt::{Display, Formatter};
+
+/// Request for siegniorage recipients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeigniorageRecipientsRequest {
+    state_hash: Digest,
+    protocol_version: ProtocolVersion,
+}
+
+impl SeigniorageRecipientsRequest {
+    /// Constructs a new SeigniorageRecipientsRequest.
+    pub fn new(state_hash: Digest, protocol_version: ProtocolVersion) -> Self {
+        SeigniorageRecipientsRequest {
+            state_hash,
+            protocol_version,
+        }
+    }
+
+    /// Get the state hash.
+    pub fn state_hash(&self) -> Digest {
+        self.state_hash
+    }
+
+    /// Get the protocol version.
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+}
+
+/// Result enum that represents all possible outcomes of a balance request.
+#[derive(Debug)]
+pub enum SeigniorageRecipientsResult {
+    /// Returned if auction is not found. This is a catastrophic outcome.
+    AuctionNotFound,
+    /// Returned if a passed state root hash is not found. This is recoverable.
+    RootNotFound,
+    /// Value not found. This is not erroneous if the record does not exist.
+    ValueNotFound(String),
+    /// There is no systemic issue, but the query itself errored.
+    Failure(TrackingCopyError),
+    /// The query succeeded.
+    Success {
+        /// Seigniorage recipients.
+        seigniorage_recipients: SeigniorageRecipientsSnapshot,
+    },
+}
+
+impl SeigniorageRecipientsResult {
+    /// Returns true if success.
+    pub fn is_success(&self) -> bool {
+        matches!(self, SeigniorageRecipientsResult::Success { .. })
+    }
+
+    /// Takes seigniorage recipients.
+    pub fn into_option(self) -> Option<SeigniorageRecipientsSnapshot> {
+        match self {
+            SeigniorageRecipientsResult::AuctionNotFound
+            | SeigniorageRecipientsResult::RootNotFound
+            | SeigniorageRecipientsResult::ValueNotFound(_)
+            | SeigniorageRecipientsResult::Failure(_) => None,
+            SeigniorageRecipientsResult::Success {
+                seigniorage_recipients,
+            } => Some(seigniorage_recipients),
+        }
+    }
+}
+
+impl Display for SeigniorageRecipientsResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SeigniorageRecipientsResult::AuctionNotFound => write!(f, "system auction not found"),
+            SeigniorageRecipientsResult::RootNotFound => write!(f, "state root not found"),
+            SeigniorageRecipientsResult::ValueNotFound(msg) => {
+                write!(f, "value not found: {}", msg)
+            }
+            SeigniorageRecipientsResult::Failure(tce) => write!(f, "{}", tce),
+            SeigniorageRecipientsResult::Success { .. } => {
+                write!(f, "success")
+            }
+        }
+    }
+}

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -4,6 +4,7 @@ pub mod providers;
 
 use std::collections::BTreeMap;
 
+use itertools::Itertools;
 use num_rational::Ratio;
 use num_traits::{CheckedMul, CheckedSub};
 use tracing::{debug, error, warn};
@@ -16,8 +17,8 @@ use casper_types::{
     account::AccountHash,
     system::auction::{
         BidAddr, BidKind, Bridge, DelegationRate, EraInfo, EraValidators, Error,
-        SeigniorageRecipients, UnbondingPurse, ValidatorBid, ValidatorCredit, ValidatorWeights,
-        DELEGATION_RATE_DENOMINATOR,
+        SeigniorageRecipients, SeigniorageRecipientsSnapshot, UnbondingPurse, ValidatorBid,
+        ValidatorCredit, ValidatorWeights, DELEGATION_RATE_DENOMINATOR,
     },
     ApiError, EraId, Key, PublicKey, U512,
 };
@@ -609,19 +610,22 @@ pub trait Auction:
         let mut era_info = EraInfo::new();
         let seigniorage_allocations = era_info.seigniorage_allocations_mut();
 
-        for (proposer, reward_amount, eras_back) in rewards
+        for item in rewards
             .into_iter()
             .filter(|(key, _amounts)| key != &PublicKey::System)
-            .flat_map(|(key, amounts)| {
-                amounts
-                    .into_iter()
-                    .enumerate()
-                    .map(move |(i, amount)| (key.clone(), amount, i as u64))
+            .map(|(proposer, amounts)| {
+                rewards_per_validator(
+                    &proposer,
+                    current_era_id,
+                    &amounts,
+                    &seigniorage_recipients_snapshot,
+                )
+                .map(|infos| infos.into_iter().map(move |info| (proposer.clone(), info)))
             })
-            // do not process zero amounts, unless they are for the current era (we still want to
-            // record zero allocations for the current validators in EraInfo)
-            .filter(|(_key, amount, eras_back)| !amount.is_zero() || *eras_back == 0)
+            .flatten_ok()
         {
+            let (proposer, reward_info) = item?;
+
             // fetch most recent validator public key if public key was changed
             // or the validator withdrew their bid completely
             let validator_public_key =
@@ -636,99 +640,22 @@ pub trait Auction:
                     Err(err) => return Err(err),
                 };
 
-            let total_reward = Ratio::from(reward_amount);
-            let rewarded_era = current_era_id
-                .checked_sub(eras_back)
-                .ok_or(Error::MissingSeigniorageRecipients)?;
-            let Some(recipient) = seigniorage_recipients_snapshot
-                .get(&rewarded_era)
-                .ok_or(Error::MissingSeigniorageRecipients)?
-                .get(&proposer).cloned()
-            else {
-                // We couldn't find the validator. If the reward amount is zero, we don't care -
-                // the validator wasn't supposed to be rewarded in this era, anyway. Otherwise,
-                // return an error.
-                if reward_amount.is_zero() {
-                    continue;
-                } else {
-                    return Err(Error::ValidatorNotFound);
-                }
-            };
-
-            let total_stake = recipient.total_stake().ok_or(Error::ArithmeticOverflow)?;
-
-            if total_stake.is_zero() {
-                // The validator has completely unbonded. We can't compute the delegators' part (as
-                // their stakes are also zero), so we just give the whole reward to the validator.
-                // Mint the reward into their bonding purse and increase their unbond request by the
-                // corresponding amount.
-                let validator_bonding_purse = detail::distribute_validator_rewards(
-                    self,
-                    seigniorage_allocations,
-                    validator_public_key.clone(),
-                    reward_amount,
-                )?;
-
-                // mint new token and put it to the recipients' purses
-                self.mint_into_existing_purse(reward_amount, validator_bonding_purse)
-                    .map_err(Error::from)?;
-
-                continue;
-            }
-
-            let delegator_total_stake: U512 = recipient
-                .delegator_total_stake()
-                .ok_or(Error::ArithmeticOverflow)?;
-
-            let delegators_part: Ratio<U512> = {
-                let commission_rate = Ratio::new(
-                    U512::from(*recipient.delegation_rate()),
-                    U512::from(DELEGATION_RATE_DENOMINATOR),
-                );
-                let reward_multiplier: Ratio<U512> = Ratio::new(delegator_total_stake, total_stake);
-                let delegator_reward: Ratio<U512> = total_reward
-                    .checked_mul(&reward_multiplier)
-                    .ok_or(Error::ArithmeticOverflow)?;
-                let commission: Ratio<U512> = delegator_reward
-                    .checked_mul(&commission_rate)
-                    .ok_or(Error::ArithmeticOverflow)?;
-                delegator_reward
-                    .checked_sub(&commission)
-                    .ok_or(Error::ArithmeticOverflow)?
-            };
-
-            let delegator_rewards =
-                recipient
-                    .delegator_stake()
-                    .iter()
-                    .map(|(delegator_key, delegator_stake)| {
-                        let reward_multiplier = Ratio::new(*delegator_stake, delegator_total_stake);
-                        let reward = delegators_part * reward_multiplier;
-                        (delegator_key.clone(), reward)
-                    });
-
             let delegator_payouts = detail::distribute_delegator_rewards(
                 self,
                 seigniorage_allocations,
                 validator_public_key.clone(),
-                delegator_rewards,
+                reward_info.delegator_rewards,
             )?;
 
-            let total_delegator_payout: U512 = delegator_payouts
-                .iter()
-                .map(|(_delegator_hash, amount, _bonding_purse)| *amount)
-                .sum();
-
-            let validator_reward = reward_amount - total_delegator_payout;
             let validator_bonding_purse = detail::distribute_validator_rewards(
                 self,
                 seigniorage_allocations,
                 validator_public_key.clone(),
-                validator_reward,
+                reward_info.validator_reward,
             )?;
 
             // mint new token and put it to the recipients' purses
-            self.mint_into_existing_purse(validator_reward, validator_bonding_purse)
+            self.mint_into_existing_purse(reward_info.validator_reward, validator_bonding_purse)
                 .map_err(Error::from)?;
 
             for (_delegator_account_hash, delegator_payout, bonding_purse) in delegator_payouts {
@@ -885,4 +812,130 @@ pub trait Auction:
         self.write_bid(credit_key, BidKind::Credit(credit_bid))
             .map(|_| Some(credit_addr))
     }
+}
+
+/// Retrieves the total reward for a given validator or delegator in a given era.
+pub fn reward(
+    validator: &PublicKey,
+    delegator: Option<&PublicKey>,
+    era_id: EraId,
+    rewards: &[U512],
+    seigniorage_recipients_snapshot: &SeigniorageRecipientsSnapshot,
+) -> Result<U512, Error> {
+    let reward =
+        rewards_per_validator(validator, era_id, rewards, seigniorage_recipients_snapshot)?
+            .into_iter()
+            .map(|reward_info| {
+                if let Some(delegator) = delegator {
+                    reward_info
+                        .delegator_rewards
+                        .get(delegator)
+                        .copied()
+                        .unwrap_or_default()
+                } else {
+                    reward_info.validator_reward
+                }
+            })
+            .sum();
+    Ok(reward)
+}
+
+fn rewards_per_validator(
+    validator: &PublicKey,
+    era_id: EraId,
+    rewards: &[U512],
+    seigniorage_recipients_snapshot: &SeigniorageRecipientsSnapshot,
+) -> Result<Vec<RewardsPerValidator>, Error> {
+    let mut results = Vec::with_capacity(rewards.len());
+
+    for (reward_amount, eras_back) in rewards
+        .iter()
+        .enumerate()
+        .map(move |(i, &amount)| (amount, i as u64))
+        // do not process zero amounts, unless they are for the current era (we still want to
+        // record zero allocations for the current validators in EraInfo)
+        .filter(|(amount, eras_back)| !amount.is_zero() || *eras_back == 0)
+    {
+        let total_reward = Ratio::from(reward_amount);
+        let rewarded_era = era_id
+            .checked_sub(eras_back)
+            .ok_or(Error::MissingSeigniorageRecipients)?;
+        let Some(recipient) = seigniorage_recipients_snapshot
+            .get(&rewarded_era)
+            .ok_or(Error::MissingSeigniorageRecipients)?
+            .get(validator).cloned()
+        else {
+            // We couldn't find the validator. If the reward amount is zero, we don't care -
+            // the validator wasn't supposed to be rewarded in this era, anyway. Otherwise,
+            // return an error.
+            if reward_amount.is_zero() {
+                continue;
+            } else {
+                return Err(Error::ValidatorNotFound);
+            }
+        };
+
+        let total_stake = recipient.total_stake().ok_or(Error::ArithmeticOverflow)?;
+
+        if total_stake.is_zero() {
+            // The validator has completely unbonded. We can't compute the delegators' part (as
+            // their stakes are also zero), so we just give the whole reward to the validator.
+            // When used from `distribute`, we will mint the reward into their bonding purse
+            // and increase their unbond request by the corresponding amount.
+
+            results.push(RewardsPerValidator {
+                validator_reward: reward_amount,
+                delegator_rewards: BTreeMap::new(),
+            });
+            continue;
+        }
+
+        let delegator_total_stake: U512 = recipient
+            .delegator_total_stake()
+            .ok_or(Error::ArithmeticOverflow)?;
+
+        let delegators_part: Ratio<U512> = {
+            let commission_rate = Ratio::new(
+                U512::from(*recipient.delegation_rate()),
+                U512::from(DELEGATION_RATE_DENOMINATOR),
+            );
+            let reward_multiplier: Ratio<U512> = Ratio::new(delegator_total_stake, total_stake);
+            let delegator_reward: Ratio<U512> = total_reward
+                .checked_mul(&reward_multiplier)
+                .ok_or(Error::ArithmeticOverflow)?;
+            let commission: Ratio<U512> = delegator_reward
+                .checked_mul(&commission_rate)
+                .ok_or(Error::ArithmeticOverflow)?;
+            delegator_reward
+                .checked_sub(&commission)
+                .ok_or(Error::ArithmeticOverflow)?
+        };
+
+        let delegator_rewards: BTreeMap<PublicKey, U512> = recipient
+            .delegator_stake()
+            .iter()
+            .map(|(delegator_key, delegator_stake)| {
+                let reward_multiplier = Ratio::new(*delegator_stake, delegator_total_stake);
+                let reward = delegators_part * reward_multiplier;
+                (delegator_key.clone(), reward.to_integer())
+            })
+            .collect();
+
+        let total_delegator_payout: U512 =
+            delegator_rewards.iter().map(|(_, &amount)| amount).sum();
+
+        let validator_reward = reward_amount - total_delegator_payout;
+
+        results.push(RewardsPerValidator {
+            validator_reward,
+            delegator_rewards,
+        });
+    }
+    Ok(results)
+}
+
+#[derive(Debug, Default)]
+pub struct RewardsPerValidator {
+    validator_reward: U512,
+    delegator_rewards: BTreeMap<PublicKey, U512>,
 }

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -547,18 +547,17 @@ pub fn distribute_delegator_rewards<P>(
     provider: &mut P,
     seigniorage_allocations: &mut Vec<SeigniorageAllocation>,
     validator_public_key: PublicKey,
-    rewards: impl Iterator<Item = (PublicKey, Ratio<U512>)>,
+    rewards: impl IntoIterator<Item = (PublicKey, U512)>,
 ) -> Result<Vec<(AccountHash, U512, URef)>, Error>
 where
     P: RuntimeProvider + StorageProvider,
 {
     let mut delegator_payouts = Vec::new();
-    for (delegator_public_key, delegator_reward) in rewards {
+    for (delegator_public_key, delegator_reward_trunc) in rewards {
         let bid_key =
             BidAddr::new_from_public_keys(&validator_public_key, Some(&delegator_public_key))
                 .into();
 
-        let delegator_reward_trunc = delegator_reward.to_integer();
         let delegator_bonding_purse = match read_delegator_bid(provider, &bid_key) {
             Ok(mut delegator_bid) if !delegator_bid.staked_amount().is_zero() => {
                 let purse = *delegator_bid.bonding_purse();

--- a/types/src/block/era_end/era_end_v1.rs
+++ b/types/src/block/era_end/era_end_v1.rs
@@ -76,7 +76,7 @@ impl EraEndV1 {
         self.era_report.inactive_validators()
     }
 
-    /// Retrieves the transfer hashes within the block.
+    /// Returns rewards for finalization of earlier blocks.
     pub fn rewards(&self) -> &BTreeMap<PublicKey, u64> {
         self.era_report.rewards()
     }


### PR DESCRIPTION
I've extracted a free function named `rewards_per_validator` from `Auction::distribute`, I use it in both `distribute` and a new function that calculates the reward for an individual validator/delegator - the shared function returns a `Vec` of reward amounts for the requested validator and every related delegator for each era they're being rewarded for.

I've also added a free function named `reward` that returns the total reward for a particular validator or a delegator.

Both functions are free functions and accept everything they need by parameters because they don't need anything from `RuntimeProvider`/`StorageProvider`, because these two traits do not provide access to historical seigniorage recipient snapshots and that's what we require for the new function (it might make sense to move the two functions elsewhere from the auction module). Instead of using the `Auction` trait, the snapshot is read beforehand by issuing a new kind of request to the contract runtime. The new state logic is almost identical to `StateProvider::era_validators`, so I've reimplemented `StateProvider::era_validators` using my new `StateProvider::seigniorage_recipients`.

I've also added the new binary request type, we expect the caller to provide a block identifier of a switch block or an era ID. We use the state root hash and era ID from the switch block to get the appopriate seigniorage recipient data and pass it to the `auction::reward` function.

Outstanding issues:
- not sure how to handle `Rewards::V1` (refer to this comment - https://github.com/casper-network/casper-node/pull/4736#discussion_r1631312021)
- errors from the auction module are private, so can't be matched on in the binary port