### PR TITLE
Remove 'highway.reduced_reward_multiplier' from the chainspec

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Removed
 * Remove the JSON-RPC and speculative execution interfaces.
 * Remove chainspec setting `highway.performance_meter.blocks_to_consider` and the entire `highway.performance_meter` section.
+* Remove chainspec setting `highway.reduced_reward_multiplier`
 
 
 

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -45,10 +45,7 @@ pub fn validate_chainspec(chainspec: &Chainspec) -> bool {
         match chainspec.highway_config.is_valid() {
             Ok(_) => return true,
             Err(msg) => {
-                error!(
-                    rrm = %chainspec.highway_config.reduced_reward_multiplier,
-                    msg,
-                );
+                error!(msg);
                 return false;
             }
         }
@@ -619,10 +616,6 @@ mod tests {
         assert_eq!(
             spec.highway_config.maximum_round_length,
             TimeDiff::from_seconds(525)
-        );
-        assert_eq!(
-            spec.highway_config.reduced_reward_multiplier,
-            Ratio::new(1, 5)
         );
 
         assert_eq!(

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -162,8 +162,6 @@ administrators = []
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.
 maximum_round_length = '17 seconds'
 # The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
-# Expressed as a fraction (1/5 by default).
-reduced_reward_multiplier = [1, 5]
 
 [transactions]
 # The duration after the transaction timestamp that it can be included in a block.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -161,7 +161,6 @@ administrators = []
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.
 maximum_round_length = '17 seconds'
-# The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
 
 [transactions]
 # The duration after the transaction timestamp that it can be included in a block.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -171,9 +171,6 @@ administrators = []
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.
 maximum_round_length = '66 seconds'
-# The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e. no finality.
-# Expressed as a fraction (1/5 by default).
-reduced_reward_multiplier = [1, 5]
 
 [transactions]
 # The duration after the transaction timestamp that it can be included in a block.

--- a/resources/test/valid/0_9_0/chainspec.toml
+++ b/resources/test/valid/0_9_0/chainspec.toml
@@ -34,7 +34,6 @@ administrators = []
 
 [highway]
 maximum_round_length = '525seconds'
-reduced_reward_multiplier = [1, 5]
 
 [transactions]
 max_ttl = '18hours'

--- a/resources/test/valid/0_9_0_unordered/chainspec.toml
+++ b/resources/test/valid/0_9_0_unordered/chainspec.toml
@@ -34,7 +34,6 @@ administrators = []
 
 [highway]
 maximum_round_length = '525seconds'
-reduced_reward_multiplier = [1, 5]
 
 [transactions]
 max_ttl = '18hours'

--- a/resources/test/valid/1_0_0/chainspec.toml
+++ b/resources/test/valid/1_0_0/chainspec.toml
@@ -34,7 +34,6 @@ administrators = []
 
 [highway]
 maximum_round_length = '525seconds'
-reduced_reward_multiplier = [1, 5]
 
 [transactions]
 max_ttl = '18hours'

--- a/types/src/chainspec/highway_config.rs
+++ b/types/src/chainspec/highway_config.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use num::rational::Ratio;
 
 #[cfg(any(feature = "testing", test))]
 use rand::Rng;
@@ -21,31 +20,21 @@ use crate::{
 pub struct HighwayConfig {
     /// The upper limit for Highway round lengths.
     pub maximum_round_length: TimeDiff,
-    /// The factor by which rewards for a round are multiplied if the greatest summit has ≤50%
-    /// quorum, i.e. no finality.
-    #[cfg_attr(feature = "datasize", data_size(skip))]
-    pub reduced_reward_multiplier: Ratio<u64>,
 }
 
 impl HighwayConfig {
     /// Checks whether the values set in the config make sense and returns `false` if they don't.
     pub fn is_valid(&self) -> Result<(), String> {
-        if self.reduced_reward_multiplier > Ratio::new(1, 1) {
-            Err("reduced reward multiplier is not in the range [0, 1]".to_string())
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 
     /// Returns a random `HighwayConfig`.
     #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
         let maximum_round_length = TimeDiff::from_seconds(rng.gen_range(60..600));
-        let reduced_reward_multiplier = Ratio::new(rng.gen_range(0..10), 10);
 
         HighwayConfig {
             maximum_round_length,
-            reduced_reward_multiplier,
         }
     }
 }
@@ -54,23 +43,19 @@ impl ToBytes for HighwayConfig {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
         buffer.extend(self.maximum_round_length.to_bytes()?);
-        buffer.extend(self.reduced_reward_multiplier.to_bytes()?);
         Ok(buffer)
     }
 
     fn serialized_length(&self) -> usize {
         self.maximum_round_length.serialized_length()
-            + self.reduced_reward_multiplier.serialized_length()
     }
 }
 
 impl FromBytes for HighwayConfig {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (maximum_round_length, remainder) = TimeDiff::from_bytes(bytes)?;
-        let (reduced_reward_multiplier, remainder) = Ratio::<u64>::from_bytes(remainder)?;
         let config = HighwayConfig {
             maximum_round_length,
-            reduced_reward_multiplier,
         };
         Ok((config, remainder))
     }
@@ -87,25 +72,5 @@ mod tests {
         let mut rng = TestRng::from_entropy();
         let config = HighwayConfig::random(&mut rng);
         bytesrepr::test_serialization_roundtrip(&config);
-    }
-
-    #[test]
-    fn should_validate_for_reduced_reward_multiplier() {
-        let mut rng = TestRng::from_entropy();
-        let mut highway_config = HighwayConfig::random(&mut rng);
-
-        // Should be valid for 0 <= RRM <= 1.
-        highway_config.reduced_reward_multiplier = Ratio::new(0, 1);
-        assert!(highway_config.is_valid().is_ok());
-        highway_config.reduced_reward_multiplier = Ratio::new(1, 1);
-        assert!(highway_config.is_valid().is_ok());
-        highway_config.reduced_reward_multiplier = Ratio::new(u64::MAX, u64::MAX);
-        assert!(highway_config.is_valid().is_ok());
-
-        highway_config.reduced_reward_multiplier = Ratio::new(u64::MAX, u64::MAX - 1);
-        assert!(
-            highway_config.is_valid().is_err(),
-            "Should be invalid for RRM > 1."
-        );
     }
 }


### PR DESCRIPTION
This parameter was a part of the 1.x rewards calculation scheme and is no longer used.