### PR TITLE
Fix flaky 'should_fetch_from_multiple_peers' test

### DIFF
--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -8,7 +8,8 @@ use casper_types::{
     bytesrepr::Bytes, runtime_args, system::standard_payment::ARG_AMOUNT, testing::TestRng, Block,
     BlockSignatures, BlockSignaturesV2, Chainspec, ChainspecRawBytes, Deploy, ExecutableDeployItem,
     FinalitySignatureV2, RuntimeArgs, SecretKey, TestBlockBuilder, TimeDiff, Transaction,
-    TransactionV1, AUCTION_LANE_ID, INSTALL_UPGRADE_LANE_ID, MINT_LANE_ID, U512,
+    TransactionV1, TransactionV1Config, AUCTION_LANE_ID, INSTALL_UPGRADE_LANE_ID, MINT_LANE_ID,
+    U512,
 };
 
 use crate::{
@@ -1002,7 +1003,17 @@ async fn should_fetch_from_multiple_peers() {
         let reactor = MockReactor::new(secret_key, vec![public_key]);
         let effect_builder =
             EffectBuilder::new(EventQueueHandle::without_shutdown(reactor.scheduler));
-        let (chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
+        let (mut chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
+
+        chainspec.transaction_config.block_gas_limit = 100_000_000_000_000;
+        let transaction_v1_config = TransactionV1Config::default().with_count_limits(
+            Some(3000),
+            Some(3000),
+            Some(3000),
+            Some(3000),
+        );
+        chainspec.transaction_config.transaction_v1_config = transaction_v1_config;
+
         let mut block_validator = BlockValidator::new(
             Arc::new(chainspec),
             reactor.validator_matrix.clone(),

--- a/types/src/chainspec/transaction_config.rs
+++ b/types/src/chainspec/transaction_config.rs
@@ -81,9 +81,9 @@ impl TransactionConfig {
 
 impl Default for TransactionConfig {
     fn default() -> Self {
-        let eighteeen_hours = TimeDiff::from_seconds(18 * 60 * 60);
+        let eighteen_hours = TimeDiff::from_seconds(18 * 60 * 60);
         TransactionConfig {
-            max_ttl: eighteeen_hours,
+            max_ttl: eighteen_hours,
             block_max_approval_count: 2600,
             max_block_size: 10_485_760,
             block_gas_limit: 10_000_000_000_000,


### PR DESCRIPTION
This PR updates the 'should_fetch_from_multiple_peers' which was failing with `CL_TEST_SEED=3a110c8a84699e489929a89b4193ff92` due to too many transactions of a given category being created.

The solution was to modify chainspec for this test to bump the limits.