### PR TITLE
Fix incorrect handling of large bids and unbonds

### DIFF
--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -444,7 +444,7 @@ impl<T: StateReader> StateTracker<T> {
         unbonder_key: &PublicKey,
         amount: U512,
     ) {
-        let account_hash = validator_key.to_account_hash();
+        let account_hash = unbonder_key.to_account_hash();
         let unbonding_era = self.read_snapshot().1.keys().next().copied().unwrap();
         let unbonding_purses = match self.unbonds_cache.entry(account_hash) {
             Entry::Occupied(entry) => entry.into_mut(),

--- a/utils/global-state-update-gen/src/generic/update.rs
+++ b/utils/global-state-update-gen/src/generic/update.rs
@@ -195,7 +195,7 @@ impl Update {
         unbonder_key: &PublicKey,
         amount: u64,
     ) {
-        let account_hash = validator_key.to_account_hash();
+        let account_hash = unbonder_key.to_account_hash();
         let unbonds = self
             .entries
             .get(&Key::Unbond(account_hash))


### PR DESCRIPTION
This fixes two bugs in the `global-state-update-gen` tool:
- Unbonds were being created under the validator's account hash instead of the unbonder's account hash,
- If a validator was to be a validator both before and after the upgrade, and the upgrade was decreasing their stake, their bid was being zeroed instead of set to the new, smaller stake.