### PR TITLE
Add a `decode` subcommand to `global-state-update-gen`

### DIFF
--- a/utils/global-state-update-gen/src/decode.rs
+++ b/utils/global-state-update-gen/src/decode.rs
@@ -32,7 +32,7 @@ impl fmt::Debug for Entries {
 
 pub(crate) fn decode_file(matches: &ArgMatches<'_>) {
     let file_name = matches.value_of("file").unwrap();
-    let mut file = File::open(&file_name).unwrap();
+    let mut file = File::open(file_name).unwrap();
 
     let mut contents = String::new();
     file.read_to_string(&mut contents).unwrap();

--- a/utils/global-state-update-gen/src/decode.rs
+++ b/utils/global-state-update-gen/src/decode.rs
@@ -1,0 +1,50 @@
+use std::{collections::BTreeMap, fmt, fs::File, io::Read};
+
+use clap::ArgMatches;
+
+use casper_types::{
+    bytesrepr::FromBytes, system::auction::SeigniorageRecipientsSnapshot, CLType,
+    GlobalStateUpdate, GlobalStateUpdateConfig, Key, StoredValue,
+};
+
+struct Entries(BTreeMap<Key, StoredValue>);
+
+impl fmt::Debug for Entries {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut map = f.debug_map();
+        for (k, v) in &self.0 {
+            let debug_v: Box<dyn fmt::Debug> = match v {
+                StoredValue::CLValue(clv) => match clv.cl_type() {
+                    CLType::Map { key, value: _ } if **key == CLType::U64 => {
+                        // this should be the seigniorage recipient snapshot
+                        let snapshot: SeigniorageRecipientsSnapshot = clv.clone().into_t().unwrap();
+                        Box::new(snapshot)
+                    }
+                    _ => Box::new(clv),
+                },
+                _ => Box::new(v),
+            };
+            map.key(k).value(&debug_v);
+        }
+        map.finish()
+    }
+}
+
+pub(crate) fn decode_file(matches: &ArgMatches<'_>) {
+    let file_name = matches.value_of("file").unwrap();
+    let mut file = File::open(&file_name).unwrap();
+
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+
+    let config: GlobalStateUpdateConfig = toml::from_str(&contents).unwrap();
+    let update_data: GlobalStateUpdate = config.try_into().unwrap();
+
+    println!("validators = {:#?}", &update_data.validators);
+    let entries: BTreeMap<_, _> = update_data
+        .entries
+        .iter()
+        .map(|(key, bytes)| (*key, StoredValue::from_bytes(bytes).unwrap().0))
+        .collect();
+    println!("entries = {:#?}", Entries(entries));
+}

--- a/utils/global-state-update-gen/src/main.rs
+++ b/utils/global-state-update-gen/src/main.rs
@@ -1,5 +1,6 @@
 mod admins;
 mod balances;
+mod decode;
 mod generic;
 mod system_entity_registry;
 mod utils;
@@ -9,7 +10,7 @@ use admins::generate_admins;
 use clap::{crate_version, App, Arg, SubCommand};
 
 use crate::{
-    balances::generate_balances_update, generic::generate_generic_update,
+    balances::generate_balances_update, decode::decode_file, generic::generate_generic_update,
     system_entity_registry::generate_system_entity_registry,
     validators::generate_validators_update,
 };
@@ -184,6 +185,17 @@ fn main() {
                         .number_of_values(1),
                 ),
         )
+        .subcommand(
+            SubCommand::with_name("decode")
+                .about("Decodes the global_state.toml file into a readable form")
+                .arg(
+                    Arg::with_name("file")
+                        .value_name("FILE")
+                        .index(1)
+                        .required(true)
+                        .help("The file to be decoded"),
+                ),
+        )
         .get_matches();
 
     match matches.subcommand() {
@@ -194,6 +206,7 @@ fn main() {
         }
         ("generic", Some(sub_matches)) => generate_generic_update(sub_matches),
         ("generate-admins", Some(sub_matches)) => generate_admins(sub_matches),
+        ("decode", Some(sub_matches)) => decode_file(sub_matches),
         (subcommand, _) => {
             println!("Unknown subcommand: \"{}\"", subcommand);
         }


### PR DESCRIPTION
This adds a new subcommand to `global-state-update-gen` that aids in debugging, to be called with:

`$ global-state-update-gen decode global_state.toml`

The command reads the generated `global_state.toml`, deserializes the entries and prints them out in the `Debug` format. This makes the contents of the file more human-readable, helping in analyzing it.