### PR TITLE
Use protocol version from the requested block in reward request

### DIFF
--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -829,7 +829,7 @@ where
             };
             let snapshot_request = SeigniorageRecipientsRequest::new(
                 *parent_header.state_root_hash(),
-                protocol_version,
+                parent_header.protocol_version(),
             );
 
             let snapshot = match effect_builder


### PR DESCRIPTION
We should request the `SeigniorageRecipientsRequest` with protocol version from the same block as the state root hash, because the underlying logic will issue a legacy contract request only when major version is 1. Right now this causes an issue when requesting a V1 block from V2 node. Note: we still don't support V1 rewards but this returns the correct error message.