### PR TITLE
Fix an issue where a switch block was executing very slowly (minutes)

### DIFF
--- a/storage/src/global_state/state/lmdb.rs
+++ b/storage/src/global_state/state/lmdb.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use std::{collections::BTreeMap, ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc};
 
 use lmdb::{DatabaseFlags, RwTransaction};
 
@@ -118,7 +118,7 @@ impl LmdbGlobalState {
     pub fn put_stored_values(
         &self,
         prestate_hash: Digest,
-        stored_values: BTreeMap<Key, StoredValue>,
+        stored_values: Vec<(Key, StoredValue)>,
     ) -> Result<Digest, GlobalStateError> {
         let scratch_trie = self.get_scratch_store();
         let new_state_root = put_stored_values::<_, _, GlobalStateError>(

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -703,10 +703,18 @@ pub trait StateProvider {
                 };
                 let balance_holds = match request.balance_handling() {
                     BalanceHandling::Total => BTreeMap::new(),
-                    BalanceHandling::Available => match tc.get_balance_holds(purse_addr) {
-                        Ok(holds) => holds,
-                        Err(tce) => return tce.into(),
-                    },
+                    BalanceHandling::Available => {
+                        match tc.get_balance_hold_config(BalanceHoldAddrTag::Gas) {
+                            Ok(Some((block_time, _, interval))) => {
+                                match tc.get_balance_holds(purse_addr, block_time, interval) {
+                                    Ok(holds) => holds,
+                                    Err(tce) => return tce.into(),
+                                }
+                            }
+                            Ok(None) => BTreeMap::new(),
+                            Err(tce) => return tce.into(),
+                        }
+                    }
                 };
                 (total_balance, ProofsResult::NotRequested { balance_holds })
             }

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -2158,7 +2158,7 @@ pub fn put_stored_values<'a, R, S, E>(
     environment: &'a R,
     store: &S,
     prestate_hash: Digest,
-    stored_values: BTreeMap<Key, StoredValue>,
+    stored_values: Vec<(Key, StoredValue)>,
 ) -> Result<Digest, E>
 where
     R: TransactionSource<'a, Handle = S::Handle>,

--- a/storage/src/global_state/state/scratch.rs
+++ b/storage/src/global_state/state/scratch.rs
@@ -830,7 +830,7 @@ pub(crate) mod tests {
 
         assert_eq!(
             trie.keys_with_prefix(b"ap"),
-            vec![key_app, key_apple, key_apron]
+            vec![key_apron, key_app, key_apple]
         );
         assert_eq!(trie.keys_with_prefix(b"app"), vec![key_app, key_apple]);
     }

--- a/storage/src/global_state/state/scratch.rs
+++ b/storage/src/global_state/state/scratch.rs
@@ -363,15 +363,14 @@ impl CommitProvider for ScratchGlobalState {
                 (None, transform_kind) => {
                     // It might be the case that for `Add*` operations we don't have the previous
                     // value in cache yet.
-                    let instruction = match read::<
+                    match read::<
                         Key,
                         StoredValue,
                         lmdb::RoTransaction,
                         LmdbTrieStore,
                         GlobalStateError,
-                    >(
-                        &txn, self.trie_store.deref(), &state_hash, &key
-                    )? {
+                    >(&txn, self.trie_store.deref(), &state_hash, &key)?
+                    {
                         ReadResult::Found(current_value) => {
                             match transform_kind.apply(current_value.clone()) {
                                 Ok(instruction) => instruction,
@@ -393,8 +392,7 @@ impl CommitProvider for ScratchGlobalState {
                             error!(root_hash=?state_hash, "root not found");
                             return Err(CommitError::ReadRootNotFound(state_hash).into());
                         }
-                    };
-                    instruction
+                    }
                 }
                 (Some(current_value), transform_kind) => {
                     match transform_kind.apply(current_value) {

--- a/storage/src/global_state/state/scratch.rs
+++ b/storage/src/global_state/state/scratch.rs
@@ -1,6 +1,6 @@
 use lmdb::RwTransaction;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     mem,
     ops::Deref,
     sync::{Arc, RwLock},
@@ -9,7 +9,7 @@ use std::{
 use tracing::{debug, error};
 
 use casper_types::{
-    bytesrepr::ToBytes,
+    bytesrepr::{self, ToBytes},
     execution::{Effects, TransformInstruction, TransformKindV2, TransformV2},
     global_state::TrieMerkleProof,
     Digest, Key, StoredValue,
@@ -42,6 +42,98 @@ type SharedCache = Arc<RwLock<Cache>>;
 struct Cache {
     cached_values: BTreeMap<Key, (bool, StoredValue)>,
     pruned: BTreeSet<Key>,
+    cached_keys: CacheTrie<Key>,
+}
+
+use std::collections::HashMap;
+
+struct CacheTrieNode<T> {
+    children: HashMap<u8, CacheTrieNode<T>>,
+    value: Option<T>,
+}
+
+impl<T> CacheTrieNode<T> {
+    fn new() -> Self {
+        CacheTrieNode {
+            children: HashMap::new(),
+            value: None,
+        }
+    }
+
+    fn remove(&mut self, bytes: &[u8], depth: usize) -> bool {
+        if depth == bytes.len() {
+            if self.value.is_some() {
+                self.value = None;
+                return self.children.is_empty();
+            }
+            return false;
+        }
+
+        if let Some(child_node) = self.children.get_mut(&bytes[depth]) {
+            if child_node.remove(bytes, depth + 1) {
+                self.children.remove(&bytes[depth]);
+                return self.value.is_none() && self.children.is_empty();
+            }
+        }
+        false
+    }
+}
+
+struct CacheTrie<T: Copy> {
+    root: CacheTrieNode<T>,
+}
+
+impl<T: Copy> CacheTrie<T> {
+    fn new() -> Self {
+        CacheTrie {
+            root: CacheTrieNode::new(),
+        }
+    }
+
+    fn insert(&mut self, key_bytes: &[u8], key: T) {
+        let mut current_node = &mut self.root;
+        for &byte in key_bytes {
+            current_node = current_node
+                .children
+                .entry(byte)
+                .or_insert(CacheTrieNode::new());
+        }
+        current_node.value = Some(key);
+    }
+
+    fn keys_with_prefix(&self, prefix: &[u8]) -> Vec<T> {
+        let mut current_node = &self.root;
+        let mut result = Vec::new();
+
+        for &byte in prefix {
+            match current_node.children.get(&byte) {
+                Some(node) => current_node = node,
+                None => return result,
+            }
+        }
+
+        self.collect_keys(current_node, &mut result);
+        result
+    }
+
+    fn collect_keys(&self, start_node: &CacheTrieNode<T>, result: &mut Vec<T>) {
+        let mut stack = VecDeque::new();
+        stack.push_back(start_node);
+
+        while let Some(node) = stack.pop_back() {
+            if let Some(key) = node.value {
+                result.push(key);
+            }
+
+            for child_node in node.children.values() {
+                stack.push_back(child_node);
+            }
+        }
+    }
+
+    fn remove(&mut self, key_bytes: &[u8]) -> bool {
+        self.root.remove(key_bytes, 0)
+    }
 }
 
 impl Cache {
@@ -49,6 +141,7 @@ impl Cache {
         Cache {
             cached_values: BTreeMap::new(),
             pruned: BTreeSet::new(),
+            cached_keys: CacheTrie::new(),
         }
     }
 
@@ -57,18 +150,27 @@ impl Cache {
         self.cached_values.is_empty() && self.pruned.is_empty()
     }
 
-    fn insert_write(&mut self, key: Key, value: StoredValue) {
+    fn insert_write(&mut self, key: Key, value: StoredValue) -> Result<(), bytesrepr::Error> {
         self.pruned.remove(&key);
-        self.cached_values.insert(key, (true, value));
+        if self.cached_values.insert(key, (true, value)).is_none() {
+            let key_bytes = key.to_bytes()?;
+            self.cached_keys.insert(&key_bytes, key);
+        };
+        Ok(())
     }
 
-    fn insert_read(&mut self, key: Key, value: StoredValue) {
+    fn insert_read(&mut self, key: Key, value: StoredValue) -> Result<(), bytesrepr::Error> {
+        let key_bytes = key.to_bytes()?;
+        self.cached_keys.insert(&key_bytes, key);
         self.cached_values.entry(key).or_insert((false, value));
+        Ok(())
     }
 
-    fn prune(&mut self, key: Key) {
+    fn prune(&mut self, key: Key) -> Result<(), bytesrepr::Error> {
         self.cached_values.remove(&key);
+        self.cached_keys.remove(&key.to_bytes()?);
         self.pruned.insert(key);
+        Ok(())
     }
 
     fn get(&self, key: &Key) -> Option<&StoredValue> {
@@ -175,7 +277,10 @@ impl StateReader<Key, StoredValue> for ScratchGlobalStateView {
             key,
         )? {
             ReadResult::Found(value) => {
-                self.cache.write().unwrap().insert_read(*key, value.clone());
+                self.cache
+                    .write()
+                    .expect("poisoned scratch cache lock")
+                    .insert_read(*key, value.clone())?;
                 Some(value)
             }
             ReadResult::NotFound => None,
@@ -213,13 +318,9 @@ impl StateReader<Key, StoredValue> for ScratchGlobalStateView {
 
     fn keys_with_prefix(&self, prefix: &[u8]) -> Result<Vec<Key>, Self::Error> {
         let mut ret = Vec::new();
-        let cache = self.cache.read().unwrap();
-        for cached_key in cache.cached_values.keys() {
-            let serialized_key = cached_key.to_bytes()?;
-            if serialized_key.starts_with(prefix) && !cache.pruned.contains(cached_key) {
-                ret.push(*cached_key)
-            }
-        }
+        let cache = self.cache.read().expect("poisoned scratch cache mutex");
+        let cached_keys = cache.cached_keys.keys_with_prefix(prefix);
+        ret.extend(cached_keys);
 
         let txn = self.environment.create_read_txn()?;
         let keys_iter = keys_with_prefix::<Key, StoredValue, _, _>(
@@ -250,6 +351,7 @@ impl CommitProvider for ScratchGlobalState {
     /// State hash returned is the one provided, as we do not write to lmdb with this kind of global
     /// state. Note that the state hash is NOT used, and simply passed back to the caller.
     fn commit(&self, state_hash: Digest, effects: Effects) -> Result<Digest, GlobalStateError> {
+        let txn = self.environment.create_read_txn()?;
         for (key, kind) in effects.value().into_iter().map(TransformV2::destructure) {
             let cached_value = self.cache.read().unwrap().get(&key).cloned();
             let instruction = match (cached_value, kind) {
@@ -261,7 +363,6 @@ impl CommitProvider for ScratchGlobalState {
                 (None, transform_kind) => {
                     // It might be the case that for `Add*` operations we don't have the previous
                     // value in cache yet.
-                    let txn = self.environment.create_read_txn()?;
                     let instruction = match read::<
                         Key,
                         StoredValue,
@@ -293,7 +394,6 @@ impl CommitProvider for ScratchGlobalState {
                             return Err(CommitError::ReadRootNotFound(state_hash).into());
                         }
                     };
-                    txn.commit()?;
                     instruction
                 }
                 (Some(current_value), transform_kind) => {
@@ -309,13 +409,14 @@ impl CommitProvider for ScratchGlobalState {
             let mut cache = self.cache.write().unwrap();
             match instruction {
                 TransformInstruction::Store(value) => {
-                    cache.insert_write(key, value);
+                    cache.insert_write(key, value)?;
                 }
                 TransformInstruction::Prune(key) => {
-                    cache.prune(key);
+                    cache.prune(key)?;
                 }
             }
         }
+        txn.commit()?;
         Ok(state_hash)
     }
 }
@@ -701,5 +802,84 @@ pub(crate) mod tests {
             None,
             original_checkout.read(&test_pairs_updated[2].key).unwrap()
         );
+    }
+
+    #[test]
+    fn cache_trie_basic_insert_get() {
+        let mut trie = CacheTrie::new();
+        let key_hello = Key::Hash(*b"hello...........................");
+        let key_world = Key::Hash(*b"world...........................");
+        let key_hey = Key::Hash(*b"hey.............................");
+
+        trie.insert(b"hello", key_hello);
+        trie.insert(b"world", key_world);
+        trie.insert(b"hey", key_hey);
+
+        assert_eq!(trie.keys_with_prefix(b"he"), vec![key_hello, key_hey]);
+        assert_eq!(trie.keys_with_prefix(b"wo"), vec![key_world]);
+    }
+
+    #[test]
+    fn cache_trie_overlapping_prefix() {
+        let mut trie = CacheTrie::new();
+        let key_apple = Key::Hash(*b"apple...........................");
+        let key_app = Key::Hash(*b"app.............................");
+        let key_apron = Key::Hash(*b"apron...........................");
+
+        trie.insert(b"apple", key_apple);
+        trie.insert(b"app", key_app);
+        trie.insert(b"apron", key_apron);
+
+        assert_eq!(
+            trie.keys_with_prefix(b"ap"),
+            vec![key_app, key_apple, key_apron]
+        );
+        assert_eq!(trie.keys_with_prefix(b"app"), vec![key_app, key_apple]);
+    }
+
+    #[test]
+    fn cache_trie_leaf_removal() {
+        let mut trie = CacheTrie::new();
+        let key_cat = Key::Hash(*b"cat.............................");
+        let key_category = Key::Hash(*b"category........................");
+
+        trie.insert(b"cat", key_cat);
+        trie.insert(b"category", key_category);
+
+        trie.remove(b"category");
+        assert_eq!(trie.keys_with_prefix(b"ca"), vec![key_cat]);
+    }
+
+    #[test]
+    fn cache_trie_internal_node_removal() {
+        let mut trie = CacheTrie::new();
+        let key_be = Key::Hash(*b"be..............................");
+        let key_berry = Key::Hash(*b"berry...........................");
+
+        trie.insert(b"be", key_be);
+        trie.insert(b"berry", key_berry);
+
+        trie.remove(b"be");
+        assert_eq!(trie.keys_with_prefix(b"be"), vec![key_berry]);
+    }
+
+    #[test]
+    fn cache_trie_non_existent_prefix() {
+        let mut trie = CacheTrie::new();
+
+        let key_apple = Key::Hash(*b"apple...........................");
+        let key_mango = Key::Hash(*b"mango...........................");
+
+        trie.insert(b"apple", key_apple);
+        trie.insert(b"mango", key_mango);
+
+        assert_eq!(trie.keys_with_prefix(b"b"), Vec::<Key>::new());
+    }
+
+    #[test]
+    fn cache_trie_empty_trie_search() {
+        let trie = CacheTrie::<Key>::new();
+
+        assert_eq!(trie.keys_with_prefix(b""), Vec::<Key>::new());
     }
 }

--- a/storage/src/system/mint.rs
+++ b/storage/src/system/mint.rs
@@ -285,7 +285,7 @@ pub trait Mint: RuntimeProvider + StorageProvider + SystemProvider {
             // treat as noop
             return Ok(());
         }
-        if self.available_balance(existing_purse)?.is_none() {
+        if !self.purse_exists(existing_purse)? {
             return Err(Error::PurseNotFound);
         }
         self.add_balance(existing_purse, amount)?;
@@ -304,4 +304,7 @@ pub trait Mint: RuntimeProvider + StorageProvider + SystemProvider {
         self.add(total_supply_uref, amount)?;
         Ok(())
     }
+
+    /// Check if a purse exists.
+    fn purse_exists(&mut self, uref: URef) -> Result<bool, Error>;
 }

--- a/storage/src/system/mint/mint_native.rs
+++ b/storage/src/system/mint/mint_native.rs
@@ -266,7 +266,7 @@ where
         {
             Some(StoredValue::CLValue(value)) => Ok(*value.cl_type() == U512::cl_type()),
             Some(_non_cl_value) => Err(Error::CLValue),
-            None => return Ok(false),
+            None => Ok(false),
         }
     }
 }

--- a/storage/src/system/mint/mint_native.rs
+++ b/storage/src/system/mint/mint_native.rs
@@ -252,4 +252,21 @@ where
     }
 }
 
-impl<S> Mint for RuntimeNative<S> where S: StateReader<Key, StoredValue, Error = GlobalStateError> {}
+impl<S> Mint for RuntimeNative<S>
+where
+    S: StateReader<Key, StoredValue, Error = GlobalStateError>,
+{
+    fn purse_exists(&mut self, uref: URef) -> Result<bool, Error> {
+        let key = Key::Balance(uref.addr());
+        match self
+            .tracking_copy()
+            .borrow_mut()
+            .read(&key)
+            .map_err(|_| Error::Storage)?
+        {
+            Some(StoredValue::CLValue(value)) => Ok(*value.cl_type() == U512::cl_type()),
+            Some(_non_cl_value) => Err(Error::CLValue),
+            None => return Ok(false),
+        }
+    }
+}


### PR DESCRIPTION
During switch block execution, the rewards distribution was taking a lot of time when a switch block was executing.
This PR introduces several fixes that improve performance:
* Use a Trie in the Scratch cache to allow looking up keys by prefix more quickly
* Change the way we check if a purse exists by checking if we can read the key, rather than actually calculating the balance.
* Remove duplicate operations when checking balances.

In testing these changes reduce the rewards distribution calculation from 220-250s to 6-7s
