### PR TITLE
BUGFIX: include validator credit in snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2024-0332
+	$(CARGO) audit --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0344
 
 .PHONY: audit-as
 audit-as:

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -5536,9 +5536,10 @@ fn credits_are_considered_when_determining_validators() {
 
     // Add a credit for node 1 artificially (assume it has proposed a block with a transaction and
     // received credit).
+    let credit_amount = U512::from(2001);
     let add_credit = HandleFeeMode::credit(
         Box::new(ACCOUNT_1_PK.clone()),
-        U512::from(2001),
+        credit_amount,
         INITIAL_ERA_ID,
     );
     builder.handle_fee(
@@ -5566,8 +5567,9 @@ fn credits_are_considered_when_determining_validators() {
         Some(&U512::from(ACCOUNT_2_BOND))
     );
     assert!(!new_validator_weights.contains_key(&BID_ACCOUNT_1_PK));
+    let expected_amount = credit_amount.saturating_add(U512::from(ACCOUNT_1_BOND));
     assert_eq!(
         new_validator_weights.get(&ACCOUNT_1_PK),
-        Some(&U512::from(ACCOUNT_1_BOND))
+        Some(&expected_amount)
     );
 }

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error, warn};
 
 use crate::system::auction::detail::{
     process_with_vesting_schedule, read_delegator_bid, read_delegator_bids, read_validator_bid,
-    seigniorage_recipient,
+    seigniorage_recipients,
 };
 use casper_types::{
     account::AccountHash,
@@ -616,7 +616,7 @@ pub trait Auction:
         let (validator_bids, validator_credits) = validator_bids_detail.destructure();
 
         // call prune BEFORE incrementing the era
-        detail::prune_validator_credits(self, era_id, validator_credits);
+        detail::prune_validator_credits(self, era_id, &validator_credits);
 
         // Increment era
         era_id = era_id.checked_add(1).ok_or(Error::ArithmeticOverflow)?;
@@ -628,16 +628,7 @@ pub trait Auction:
         // Update seigniorage recipients for current era
         {
             let mut snapshot = detail::get_seigniorage_recipients_snapshot(self)?;
-            let mut recipients = SeigniorageRecipients::new();
-
-            for era_validator in winners.keys() {
-                let seigniorage_recipient = match validator_bids.get(era_validator) {
-                    Some(validator_bid) => seigniorage_recipient(self, validator_bid)?,
-                    None => return Err(Error::BidNotFound.into()),
-                };
-                recipients.insert(era_validator.clone(), seigniorage_recipient);
-            }
-
+            let recipients = seigniorage_recipients(self, &winners, &validator_bids)?;
             let previous_recipients = snapshot.insert(delayed_era, recipients);
             assert!(previous_recipients.is_none());
 
@@ -942,17 +933,18 @@ fn rewards_per_validator(
         let Some(recipient) = seigniorage_recipients_snapshot
             .get(&rewarded_era)
             .ok_or(Error::MissingSeigniorageRecipients)?
-            .get(validator).cloned()
-            else {
-                // We couldn't find the validator. If the reward amount is zero, we don't care -
-                // the validator wasn't supposed to be rewarded in this era, anyway. Otherwise,
-                // return an error.
-                if reward_amount.is_zero() {
-                    continue;
-                } else {
-                    return Err(Error::ValidatorNotFound);
-                }
-            };
+            .get(validator)
+            .cloned()
+        else {
+            // We couldn't find the validator. If the reward amount is zero, we don't care -
+            // the validator wasn't supposed to be rewarded in this era, anyway. Otherwise,
+            // return an error.
+            if reward_amount.is_zero() {
+                continue;
+            } else {
+                return Err(Error::ValidatorNotFound);
+            }
+        };
 
         let total_stake = recipient.total_stake().ok_or(Error::ArithmeticOverflow)?;
 

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -573,7 +573,6 @@ pub trait Auction:
         // Compute next auction winners
         let winners: ValidatorWeights = {
             let locked_validators = validator_bids_detail.validator_weights(
-                self,
                 era_id,
                 era_end_timestamp_millis,
                 vesting_schedule_period_millis,
@@ -585,7 +584,6 @@ pub trait Auction:
             let remaining_auction_slots = validator_slots.saturating_sub(locked_validators.len());
             if remaining_auction_slots > 0 {
                 let unlocked_validators = validator_bids_detail.validator_weights(
-                    self,
                     era_id,
                     era_end_timestamp_millis,
                     vesting_schedule_period_millis,
@@ -613,7 +611,8 @@ pub trait Auction:
             }
         };
 
-        let (validator_bids, validator_credits) = validator_bids_detail.destructure();
+        let (validator_bids, validator_credits, delegator_bids) =
+            validator_bids_detail.destructure();
 
         // call prune BEFORE incrementing the era
         detail::prune_validator_credits(self, era_id, &validator_credits);
@@ -628,7 +627,7 @@ pub trait Auction:
         // Update seigniorage recipients for current era
         {
             let mut snapshot = detail::get_seigniorage_recipients_snapshot(self)?;
-            let recipients = seigniorage_recipients(self, &winners, &validator_bids)?;
+            let recipients = seigniorage_recipients(&winners, &validator_bids, &delegator_bids)?;
             let previous_recipients = snapshot.insert(delayed_era, recipients);
             assert!(previous_recipients.is_none());
 

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -936,18 +936,6 @@ pub fn seigniorage_recipients(
             }
         }
 
-        // for delegator_bid in read_delegator_bids(provider, validator_public_key)? {
-        //     if delegator_bid.staked_amount().is_zero() {
-        //         continue;
-        //     }
-        //     let delegator_staked_amount = delegator_bid.staked_amount();
-        //     delegators_weight = delegators_weight.saturating_add(delegator_staked_amount);
-        //     delegators_stake.insert(
-        //         delegator_bid.delegator_public_key().clone(),
-        //         delegator_staked_amount,
-        //     );
-        // }
-
         // determine validator's personal stake (total weight - sum of delegators weight)
         let validator_stake = validator_total_weight.saturating_sub(delegators_weight);
         let seigniorage_recipient = SeigniorageRecipient::new(

--- a/types/src/system/auction.rs
+++ b/types/src/system/auction.rs
@@ -49,6 +49,9 @@ pub type DelegationRate = u8;
 /// Validators mapped to their bids.
 pub type ValidatorBids = BTreeMap<PublicKey, Box<ValidatorBid>>;
 
+/// Delegator bids mapped to their validator.
+pub type DelegatorBids = BTreeMap<PublicKey, Vec<Box<Delegator>>>;
+
 /// Validators mapped to their credits by era.
 pub type ValidatorCredits = BTreeMap<PublicKey, BTreeMap<EraId, Box<ValidatorCredit>>>;
 


### PR DESCRIPTION
In NoFee mode, the validator credit amount is supposed to be used for both determining a validator's weight and also be included in that era's staked amount. However, the logic was only doing the former. This PR corrects to apply the credit in both places.