### PR TITLE
Provide more visibility into error codes in binary port

### DIFF
--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -217,6 +217,54 @@ pub enum ErrorCode {
     /// Transactions parameters are missing or incorrect
     #[error("missing or incorrect transaction parameters")]
     MissingOrIncorrectParameters = 66,
+    /// No such addressable entity
+    #[error("no such addressable entity")]
+    NoSuchAddressableEntity = 67,
+    // No such contract at hash
+    #[error("no such contract at hash")]
+    NoSuchContractAtHash = 68,
+    /// No such entry point
+    #[error("no such entry point")]
+    NoSuchEntryPoint = 69,
+    /// No such package at hash
+    #[error("no such package at hash")]
+    NoSuchPackageAtHash = 70,
+    /// Invalid entity at version
+    #[error("invalid entity at version")]
+    InvalidEntityAtVersion = 71,
+    /// Disabled entity at version
+    #[error("disabled entity at version")]
+    DisabledEntityAtVersion = 72,
+    /// Missing entity at version
+    #[error("missing entity at version")]
+    MissingEntityAtVersion = 73,
+    /// Invalid associated keys
+    #[error("invalid associated keys")]
+    InvalidAssociatedKeys = 74,
+    /// Insufficient signature weight
+    #[error("insufficient signature weight")]
+    InsufficientSignatureWeight = 75,
+    /// Insufficient balance
+    #[error("insufficient balance")]
+    InsufficientBalance = 76,
+    /// Unknown balance
+    #[error("unknown balance")]
+    UnknownBalance = 77,
+    /// Invalid payment variant for deploy
+    #[error("invalid payment variant for deploy")]
+    DeployInvalidPaymentVariant = 78,
+    /// Missing payment amount for deploy
+    #[error("missing payment amount for deploy")]
+    DeployMissingPaymentAmount = 79,
+    /// Failed to parse payment amount for deploy
+    #[error("failed to parse payment amount for deploy")]
+    DeployFailedToParsePaymentAmount = 80,
+    /// Missing transfer target for deploy
+    #[error("missing transfer target for deploy")]
+    DeployMissingTransferTarget = 81,
+    /// Missing module bytes for deploy
+    #[error("missing module bytes for deploy")]
+    DeployMissingModuleBytes = 82,
 }
 
 impl TryFrom<u16> for ErrorCode {
@@ -291,6 +339,22 @@ impl TryFrom<u16> for ErrorCode {
             64 => Ok(ErrorCode::ExpectedTransaction),
             65 => Ok(ErrorCode::TransactionExpired),
             66 => Ok(ErrorCode::MissingOrIncorrectParameters),
+            67 => Ok(ErrorCode::NoSuchAddressableEntity),
+            68 => Ok(ErrorCode::NoSuchContractAtHash),
+            69 => Ok(ErrorCode::NoSuchEntryPoint),
+            70 => Ok(ErrorCode::NoSuchPackageAtHash),
+            71 => Ok(ErrorCode::InvalidEntityAtVersion),
+            72 => Ok(ErrorCode::DisabledEntityAtVersion),
+            73 => Ok(ErrorCode::MissingEntityAtVersion),
+            74 => Ok(ErrorCode::InvalidAssociatedKeys),
+            75 => Ok(ErrorCode::InsufficientSignatureWeight),
+            76 => Ok(ErrorCode::InsufficientBalance),
+            77 => Ok(ErrorCode::UnknownBalance),
+            78 => Ok(ErrorCode::DeployInvalidPaymentVariant),
+            79 => Ok(ErrorCode::DeployMissingPaymentAmount),
+            80 => Ok(ErrorCode::DeployFailedToParsePaymentAmount),
+            81 => Ok(ErrorCode::DeployMissingTransferTarget),
+            82 => Ok(ErrorCode::DeployMissingModuleBytes),
             _ => Err(UnknownErrorCode),
         }
     }

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -265,6 +265,12 @@ pub enum ErrorCode {
     /// Missing module bytes for deploy
     #[error("missing module bytes for deploy")]
     DeployMissingModuleBytes = 82,
+    /// Entry point cannot be 'call'
+    #[error("entry point cannot be 'call'")]
+    InvalidTransactionEntryPointCannotBeCall = 83,
+    /// Invalid transaction kind
+    #[error("invalid transaction kind")]
+    InvalidTransactionInvalidTransactionKind = 84,
 }
 
 impl TryFrom<u16> for ErrorCode {
@@ -355,6 +361,8 @@ impl TryFrom<u16> for ErrorCode {
             80 => Ok(ErrorCode::DeployFailedToParsePaymentAmount),
             81 => Ok(ErrorCode::DeployMissingTransferTarget),
             82 => Ok(ErrorCode::DeployMissingModuleBytes),
+            83 => Ok(ErrorCode::InvalidTransactionEntryPointCannotBeCall),
+            84 => Ok(ErrorCode::InvalidTransactionInvalidTransactionKind),
             _ => Err(UnknownErrorCode),
         }
     }
@@ -482,6 +490,12 @@ impl From<InvalidTransactionV1> for ErrorCode {
             }
             InvalidTransactionV1::InvalidPricingMode { .. } => {
                 ErrorCode::InvalidTransactionPricingMode
+            }
+            InvalidTransactionV1::EntryPointCannotBeCall => {
+                ErrorCode::InvalidTransactionEntryPointCannotBeCall
+            }
+            InvalidTransactionV1::InvalidTransactionKind(_) => {
+                ErrorCode::InvalidTransactionInvalidTransactionKind
             }
             _ => ErrorCode::InvalidTransactionUnspecified,
         }

--- a/node/src/components/transaction_acceptor/error.rs
+++ b/node/src/components/transaction_acceptor/error.rs
@@ -72,7 +72,54 @@ impl From<Error> for BinaryPortErrorCode {
             Error::ExpectedDeploy => BinaryPortErrorCode::ExpectedDeploy,
             Error::ExpectedTransactionV1 => BinaryPortErrorCode::ExpectedTransaction,
             Error::Expired { .. } => BinaryPortErrorCode::TransactionExpired,
-            Error::Parameters { .. } => BinaryPortErrorCode::MissingOrIncorrectParameters,
+            Error::Parameters { failure, .. } => match failure {
+                ParameterFailure::NoSuchAddressableEntity { .. } => {
+                    BinaryPortErrorCode::NoSuchAddressableEntity
+                }
+                ParameterFailure::NoSuchContractAtHash { .. } => {
+                    BinaryPortErrorCode::NoSuchContractAtHash
+                }
+                ParameterFailure::NoSuchEntryPoint { .. } => BinaryPortErrorCode::NoSuchEntryPoint,
+                ParameterFailure::NoSuchPackageAtHash { .. } => {
+                    BinaryPortErrorCode::NoSuchPackageAtHash
+                }
+                ParameterFailure::InvalidEntityAtVersion { .. } => {
+                    BinaryPortErrorCode::InvalidEntityAtVersion
+                }
+                ParameterFailure::DisabledEntityAtVersion { .. } => {
+                    BinaryPortErrorCode::DisabledEntityAtVersion
+                }
+                ParameterFailure::MissingEntityAtVersion { .. } => {
+                    BinaryPortErrorCode::MissingEntityAtVersion
+                }
+                ParameterFailure::InvalidAssociatedKeys => {
+                    BinaryPortErrorCode::InvalidAssociatedKeys
+                }
+                ParameterFailure::InsufficientSignatureWeight => {
+                    BinaryPortErrorCode::InsufficientSignatureWeight
+                }
+                ParameterFailure::InsufficientBalance { .. } => {
+                    BinaryPortErrorCode::InsufficientBalance
+                }
+                ParameterFailure::UnknownBalance { .. } => BinaryPortErrorCode::UnknownBalance,
+                ParameterFailure::Deploy(deploy_failure) => match deploy_failure {
+                    DeployParameterFailure::InvalidPaymentVariant => {
+                        BinaryPortErrorCode::DeployInvalidPaymentVariant
+                    }
+                    DeployParameterFailure::MissingPaymentAmount => {
+                        BinaryPortErrorCode::DeployMissingPaymentAmount
+                    }
+                    DeployParameterFailure::FailedToParsePaymentAmount => {
+                        BinaryPortErrorCode::DeployFailedToParsePaymentAmount
+                    }
+                    DeployParameterFailure::MissingTransferTarget => {
+                        BinaryPortErrorCode::DeployMissingTransferTarget
+                    }
+                    DeployParameterFailure::MissingModuleBytes => {
+                        BinaryPortErrorCode::DeployMissingModuleBytes
+                    }
+                },
+            },
             Error::InvalidTransaction(invalid_transaction) => {
                 BinaryPortErrorCode::from(invalid_transaction)
             }


### PR DESCRIPTION
This PR improves the error reporting in binary port. Instead of returning generic `BinaryPortErrorCode::MissingOrIncorrectParameters` we now return a specific variant.