### PR TITLE
[BUGFIX]: Fix in account hash indirection for addressable entity

### DIFF
--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -111,7 +111,7 @@ pub struct Runtime<'a, R> {
 
 impl<'a, R> Runtime<'a, R>
 where
-    R: StateReader<Key, StoredValue, Error = GlobalStateError>,
+    R: StateReader<Key, StoredValue, Error=GlobalStateError>,
 {
     /// Creates a new runtime instance.
     pub(crate) fn new(context: RuntimeContext<'a, R>) -> Self {
@@ -657,15 +657,15 @@ where
                 ExecError::GasLimit
             }
             ApiError::AuctionError(auction_error)
-                if auction_error == auction::Error::GasLimit as u8 =>
-            {
-                ExecError::GasLimit
-            }
+            if auction_error == auction::Error::GasLimit as u8 =>
+                {
+                    ExecError::GasLimit
+                }
             ApiError::HandlePayment(handle_payment_error)
-                if handle_payment_error == handle_payment::Error::GasLimit as u8 =>
-            {
-                ExecError::GasLimit
-            }
+            if handle_payment_error == handle_payment::Error::GasLimit as u8 =>
+                {
+                    ExecError::GasLimit
+                }
             api_error => ExecError::Revert(api_error),
         }
     }
@@ -952,7 +952,7 @@ where
                     runtime_args,
                     auction::ARG_MINIMUM_DELEGATION_AMOUNT,
                 )?
-                .unwrap_or(global_minimum_delegation_amount);
+                    .unwrap_or(global_minimum_delegation_amount);
 
                 let global_maximum_delegation_amount =
                     self.context.engine_config().maximum_delegation_amount();
@@ -960,7 +960,7 @@ where
                     runtime_args,
                     auction::ARG_MAXIMUM_DELEGATION_AMOUNT,
                 )?
-                .unwrap_or(global_maximum_delegation_amount);
+                    .unwrap_or(global_maximum_delegation_amount);
 
                 if minimum_delegation_amount < global_minimum_delegation_amount
                     || maximum_delegation_amount > global_maximum_delegation_amount
@@ -2600,9 +2600,9 @@ where
         if !allow_unrestricted_transfers
             && self.context.get_caller() != PublicKey::System.to_account_hash()
             && !self
-                .context
-                .engine_config()
-                .is_administrator(&self.context.get_caller())
+            .context
+            .engine_config()
+            .is_administrator(&self.context.get_caller())
             && !self.context.engine_config().is_administrator(&target)
         {
             return Err(ExecError::DisabledUnrestrictedTransfers);
@@ -2639,7 +2639,7 @@ where
             Ok(()) => {
                 let protocol_version = self.context.protocol_version();
                 let byte_code_hash = ByteCodeHash::default();
-                let entity_hash = AddressableEntityHash::new(self.context.new_hash_address()?);
+                let entity_hash = AddressableEntityHash::new(target.value());
                 let package_hash = PackageHash::new(self.context.new_hash_address()?);
                 let main_purse = target_purse;
                 let associated_keys = AssociatedKeys::new(target, Weight::new(1));
@@ -3530,9 +3530,9 @@ where
         // Check if the topic exists and get the summary.
         let Some(StoredValue::MessageTopic(prev_topic_summary)) =
             self.context.read_gs(&topic_key)?
-            else {
-                return Ok(Err(ApiError::MessageTopicNotRegistered));
-            };
+        else {
+            return Ok(Err(ApiError::MessageTopicNotRegistered));
+        };
 
         let current_blocktime = self.context.get_blocktime();
         let topic_message_index = if prev_topic_summary.blocktime() != current_blocktime {
@@ -3553,7 +3553,7 @@ where
                 let (prev_block_time, prev_count): (BlockTime, u64) = CLValue::into_t(
                     CLValue::try_from(stored_value).map_err(ExecError::TypeMismatch)?,
                 )
-                .map_err(ExecError::CLValue)?;
+                    .map_err(ExecError::CLValue)?;
                 if prev_block_time == current_blocktime {
                     prev_count
                 } else {

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -111,7 +111,7 @@ pub struct Runtime<'a, R> {
 
 impl<'a, R> Runtime<'a, R>
 where
-    R: StateReader<Key, StoredValue, Error=GlobalStateError>,
+    R: StateReader<Key, StoredValue, Error = GlobalStateError>,
 {
     /// Creates a new runtime instance.
     pub(crate) fn new(context: RuntimeContext<'a, R>) -> Self {
@@ -657,15 +657,15 @@ where
                 ExecError::GasLimit
             }
             ApiError::AuctionError(auction_error)
-            if auction_error == auction::Error::GasLimit as u8 =>
-                {
-                    ExecError::GasLimit
-                }
+                if auction_error == auction::Error::GasLimit as u8 =>
+            {
+                ExecError::GasLimit
+            }
             ApiError::HandlePayment(handle_payment_error)
-            if handle_payment_error == handle_payment::Error::GasLimit as u8 =>
-                {
-                    ExecError::GasLimit
-                }
+                if handle_payment_error == handle_payment::Error::GasLimit as u8 =>
+            {
+                ExecError::GasLimit
+            }
             api_error => ExecError::Revert(api_error),
         }
     }
@@ -952,7 +952,7 @@ where
                     runtime_args,
                     auction::ARG_MINIMUM_DELEGATION_AMOUNT,
                 )?
-                    .unwrap_or(global_minimum_delegation_amount);
+                .unwrap_or(global_minimum_delegation_amount);
 
                 let global_maximum_delegation_amount =
                     self.context.engine_config().maximum_delegation_amount();
@@ -960,7 +960,7 @@ where
                     runtime_args,
                     auction::ARG_MAXIMUM_DELEGATION_AMOUNT,
                 )?
-                    .unwrap_or(global_maximum_delegation_amount);
+                .unwrap_or(global_maximum_delegation_amount);
 
                 if minimum_delegation_amount < global_minimum_delegation_amount
                     || maximum_delegation_amount > global_maximum_delegation_amount
@@ -2600,9 +2600,9 @@ where
         if !allow_unrestricted_transfers
             && self.context.get_caller() != PublicKey::System.to_account_hash()
             && !self
-            .context
-            .engine_config()
-            .is_administrator(&self.context.get_caller())
+                .context
+                .engine_config()
+                .is_administrator(&self.context.get_caller())
             && !self.context.engine_config().is_administrator(&target)
         {
             return Err(ExecError::DisabledUnrestrictedTransfers);
@@ -3553,7 +3553,7 @@ where
                 let (prev_block_time, prev_count): (BlockTime, u64) = CLValue::into_t(
                     CLValue::try_from(stored_value).map_err(ExecError::TypeMismatch)?,
                 )
-                    .map_err(ExecError::CLValue)?;
+                .map_err(ExecError::CLValue)?;
                 if prev_block_time == current_blocktime {
                     prev_count
                 } else {

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -68,7 +68,7 @@ fn should_run_genesis() {
         GENESIS_CUSTOM_ACCOUNTS.clone(),
         protocol_version,
     )
-        .expect("must create genesis request");
+    .expect("must create genesis request");
 
     let mut builder = LmdbWasmTestBuilder::default();
 

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -68,7 +68,7 @@ fn should_run_genesis() {
         GENESIS_CUSTOM_ACCOUNTS.clone(),
         protocol_version,
     )
-    .expect("must create genesis request");
+        .expect("must create genesis request");
 
     let mut builder = LmdbWasmTestBuilder::default();
 
@@ -77,6 +77,12 @@ fn should_run_genesis() {
     let _system_account = builder
         .get_entity_by_account_hash(PublicKey::System.to_account_hash())
         .expect("system account should exist");
+
+    let account_1_addr = builder
+        .get_entity_hash_by_account_hash(*ACCOUNT_1_ADDR)
+        .expect("must get addr for entity account 1");
+
+    assert_eq!(account_1_addr.value(), ACCOUNT_1_ADDR.value());
 
     let account_1 = builder
         .get_entity_by_account_hash(*ACCOUNT_1_ADDR)

--- a/storage/src/system/genesis.rs
+++ b/storage/src/system/genesis.rs
@@ -351,7 +351,7 @@ where
                 validators: genesis_validators.len(),
                 validator_slots: self.config.validator_slots(),
             }
-            .into());
+                .into());
         }
 
         let genesis_delegators: Vec<_> = self.config.get_bonded_delegators().collect();
@@ -364,7 +364,7 @@ where
                 return Err(GenesisError::InvalidDelegatedAmount {
                     public_key: (*delegator_public_key).clone(),
                 }
-                .into());
+                    .into());
             }
 
             let orphan_condition = genesis_validators.iter().find(|genesis_validator| {
@@ -376,7 +376,7 @@ where
                     validator_public_key: (*validator_public_key).clone(),
                     delegator_public_key: (*delegator_public_key).clone(),
                 }
-                .into());
+                    .into());
             }
         }
 
@@ -400,7 +400,7 @@ where
                         public_key,
                         delegation_rate,
                     }
-                    .into());
+                        .into());
                 }
                 debug_assert_ne!(public_key, PublicKey::System);
 
@@ -448,7 +448,7 @@ where
                                     validator_public_key: (*validator_public_key).clone(),
                                     delegator_public_key: (*delegator_public_key).clone(),
                                 }
-                                .into());
+                                    .into());
                             }
                         }
                     }
@@ -617,9 +617,9 @@ where
 
         if administrative_accounts.peek().is_some()
             && administrative_accounts
-                .duplicates_by(|admin| admin.public_key())
-                .next()
-                .is_some()
+            .duplicates_by(|admin| admin.public_key())
+            .next()
+            .is_some()
         {
             // Ensure no duplicate administrator accounts are specified as this might raise errors
             // during genesis process when administrator accounts are added to associated keys.
@@ -731,11 +731,19 @@ where
         } else {
             ByteCodeHash::new(self.address_generator.borrow_mut().new_hash_address())
         };
-        let entity_hash = if entity_kind.is_system_account() {
-            let entity_hash_addr = PublicKey::System.to_account_hash().value();
-            AddressableEntityHash::new(entity_hash_addr)
-        } else {
-            AddressableEntityHash::new(self.address_generator.borrow_mut().new_hash_address())
+
+        let entity_hash = match entity_kind {
+            EntityKind::System(_) | EntityKind::SmartContract(_) => {
+                AddressableEntityHash::new(self.address_generator.borrow_mut().new_hash_address())
+            }
+            EntityKind::Account(account_hash) => {
+                if entity_kind.is_system_account() {
+                    let entity_hash_addr = PublicKey::System.to_account_hash().value();
+                    AddressableEntityHash::new(entity_hash_addr)
+                } else {
+                    AddressableEntityHash::new(account_hash.value())
+                }
+            }
         };
 
         let package_hash = PackageHash::new(self.address_generator.borrow_mut().new_hash_address());

--- a/storage/src/system/genesis.rs
+++ b/storage/src/system/genesis.rs
@@ -351,7 +351,7 @@ where
                 validators: genesis_validators.len(),
                 validator_slots: self.config.validator_slots(),
             }
-                .into());
+            .into());
         }
 
         let genesis_delegators: Vec<_> = self.config.get_bonded_delegators().collect();
@@ -364,7 +364,7 @@ where
                 return Err(GenesisError::InvalidDelegatedAmount {
                     public_key: (*delegator_public_key).clone(),
                 }
-                    .into());
+                .into());
             }
 
             let orphan_condition = genesis_validators.iter().find(|genesis_validator| {
@@ -376,7 +376,7 @@ where
                     validator_public_key: (*validator_public_key).clone(),
                     delegator_public_key: (*delegator_public_key).clone(),
                 }
-                    .into());
+                .into());
             }
         }
 
@@ -400,7 +400,7 @@ where
                         public_key,
                         delegation_rate,
                     }
-                        .into());
+                    .into());
                 }
                 debug_assert_ne!(public_key, PublicKey::System);
 
@@ -448,7 +448,7 @@ where
                                     validator_public_key: (*validator_public_key).clone(),
                                     delegator_public_key: (*delegator_public_key).clone(),
                                 }
-                                    .into());
+                                .into());
                             }
                         }
                     }
@@ -617,9 +617,9 @@ where
 
         if administrative_accounts.peek().is_some()
             && administrative_accounts
-            .duplicates_by(|admin| admin.public_key())
-            .next()
-            .is_some()
+                .duplicates_by(|admin| admin.public_key())
+                .next()
+                .is_some()
         {
             // Ensure no duplicate administrator accounts are specified as this might raise errors
             // during genesis process when administrator accounts are added to associated keys.

--- a/storage/src/system/protocol_upgrade.rs
+++ b/storage/src/system/protocol_upgrade.rs
@@ -506,7 +506,7 @@ where
         let mut address_generator = AddressGenerator::new(pre_state_hash.as_ref(), Phase::System);
 
         let byte_code_hash = ByteCodeHash::default();
-        let entity_hash = AddressableEntityHash::new(address_generator.new_hash_address());
+        let entity_hash = AddressableEntityHash::new(PublicKey::System.to_account_hash().value());
         let package_hash = PackageHash::new(address_generator.new_hash_address());
 
         let byte_code = ByteCode::new(ByteCodeKind::Empty, vec![]);

--- a/storage/src/tracking_copy/ext_entity.rs
+++ b/storage/src/tracking_copy/ext_entity.rs
@@ -164,7 +164,7 @@ pub trait TrackingCopyEntityExt<R> {
 
 impl<R> TrackingCopyEntityExt<R> for TrackingCopy<R>
 where
-    R: StateReader<Key, StoredValue, Error=GlobalStateError>,
+    R: StateReader<Key, StoredValue, Error = GlobalStateError>,
 {
     type Error = TrackingCopyError;
 
@@ -320,9 +320,9 @@ where
 
         if !administrative_accounts.is_empty()
             && administrative_accounts
-            .intersection(authorization_keys)
-            .next()
-            .is_some()
+                .intersection(authorization_keys)
+                .next()
+                .is_some()
         {
             // Exit early if there's at least a single signature coming from an admin.
             return Ok((entity_record, entity_hash));
@@ -542,7 +542,7 @@ where
                     Weight::new(1u8),
                     Weight::new(account_threshold.key_management.value()),
                 )
-                    .map_err(Self::Error::SetThresholdFailure)?
+                .map_err(Self::Error::SetThresholdFailure)?
             };
 
             let associated_keys = AssociatedKeys::from(account.associated_keys().clone());

--- a/storage/src/tracking_copy/ext_entity.rs
+++ b/storage/src/tracking_copy/ext_entity.rs
@@ -164,7 +164,7 @@ pub trait TrackingCopyEntityExt<R> {
 
 impl<R> TrackingCopyEntityExt<R> for TrackingCopy<R>
 where
-    R: StateReader<Key, StoredValue, Error = GlobalStateError>,
+    R: StateReader<Key, StoredValue, Error=GlobalStateError>,
 {
     type Error = TrackingCopyError;
 
@@ -320,9 +320,9 @@ where
 
         if !administrative_accounts.is_empty()
             && administrative_accounts
-                .intersection(authorization_keys)
-                .next()
-                .is_some()
+            .intersection(authorization_keys)
+            .next()
+            .is_some()
         {
             // Exit early if there's at least a single signature coming from an admin.
             return Ok((entity_record, entity_hash));
@@ -449,7 +449,7 @@ where
         let mut generator = AddressGenerator::new(main_purse.addr().as_ref(), Phase::System);
 
         let byte_code_hash = ByteCodeHash::default();
-        let entity_hash = AddressableEntityHash::new(generator.new_hash_address());
+        let entity_hash = AddressableEntityHash::new(account_hash.value());
         let package_hash = PackageHash::new(generator.new_hash_address());
 
         let associated_keys = AssociatedKeys::new(account_hash, Weight::new(1));
@@ -542,7 +542,7 @@ where
                     Weight::new(1u8),
                     Weight::new(account_threshold.key_management.value()),
                 )
-                .map_err(Self::Error::SetThresholdFailure)?
+                    .map_err(Self::Error::SetThresholdFailure)?
             };
 
             let associated_keys = AssociatedKeys::from(account.associated_keys().clone());

--- a/utils/global-state-update-gen/src/generic/state_tracker.rs
+++ b/utils/global-state-update-gen/src/generic/state_tracker.rs
@@ -163,7 +163,7 @@ impl<T: StateReader> StateTracker<T> {
 
         let mut rng = rand::thread_rng();
 
-        let entity_hash = AddressableEntityHash::new(rng.gen());
+        let entity_hash = AddressableEntityHash::new(account_hash.value());
         let package_hash = PackageHash::new(rng.gen());
         let contract_wasm_hash = ByteCodeHash::new([0u8; 32]);
 


### PR DESCRIPTION
CHANGELOG:

- Fixed bugs when new addressable entities linked to accounts are written under a PRNG hash instead of correctly forwarding the account hash
- Added an assertion in genesis logic to make sure the carry-forward works