### PR TITLE
Derive `Serialize` for some of the types

### DIFF
--- a/binary_port/src/global_state_query_result.rs
+++ b/binary_port/src/global_state_query_result.rs
@@ -11,9 +11,10 @@ use casper_types::testing::TestRng;
 
 #[cfg(test)]
 use casper_types::{ByteCode, ByteCodeKind};
+use serde::Serialize;
 
 /// Carries the successful result of the global state query.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct GlobalStateQueryResult {
     /// Stored value.
     value: StoredValue,

--- a/binary_port/src/node_status.rs
+++ b/binary_port/src/node_status.rs
@@ -8,11 +8,12 @@ use casper_types::{
 use casper_types::testing::TestRng;
 #[cfg(test)]
 use rand::Rng;
+use serde::Serialize;
 
 use crate::{minimal_block_info::MinimalBlockInfo, type_wrappers::ReactorStateName};
 
 /// Status information about the node.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct NodeStatus {
     /// The node ID and network address of each connected peer.
     pub peers: Peers,

--- a/binary_port/src/type_wrappers.rs
+++ b/binary_port/src/type_wrappers.rs
@@ -8,6 +8,7 @@ use casper_types::{
     bytesrepr::{self, Bytes, FromBytes, ToBytes},
     EraId, ExecutionInfo, Key, PublicKey, TimeDiff, Timestamp, Transaction, ValidatorChange, U512,
 };
+use serde::Serialize;
 
 use super::GlobalStateQueryResult;
 
@@ -39,7 +40,7 @@ macro_rules! impl_bytesrepr_for_type_wrapper {
 }
 
 /// Type representing uptime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct Uptime(u64);
 
 impl Uptime {
@@ -69,7 +70,7 @@ impl TryFrom<Uptime> for TimeDiff {
 }
 
 /// Type representing changes in consensus validators.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct ConsensusValidatorChanges(BTreeMap<PublicKey, Vec<(EraId, ValidatorChange)>>);
 
@@ -92,7 +93,7 @@ impl From<ConsensusValidatorChanges> for BTreeMap<PublicKey, Vec<(EraId, Validat
 }
 
 /// Type representing network name.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct NetworkName(String);
 
 impl NetworkName {
@@ -114,7 +115,7 @@ impl From<NetworkName> for String {
 }
 
 /// Type representing the reactor state name.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct ReactorStateName(String);
 
 impl ReactorStateName {
@@ -136,7 +137,7 @@ impl From<ReactorStateName> for String {
 }
 
 /// Type representing last progress of the sync process.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct LastProgress(Timestamp);
 
 impl LastProgress {
@@ -174,7 +175,7 @@ impl GetTrieFullResult {
 }
 
 /// Type representing the reward of a validator or a delegator.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct RewardResponse {
     amount: U512,
     era_id: EraId,
@@ -223,7 +224,7 @@ impl FromBytes for RewardResponse {
 }
 
 /// Describes the consensus status.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct ConsensusStatus {
     validator_public_key: PublicKey,
     round_length: Option<TimeDiff>,
@@ -278,7 +279,7 @@ impl FromBytes for ConsensusStatus {
 }
 
 /// A transaction with execution info.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct TransactionWithExecutionInfo {
     transaction: Transaction,
     execution_info: Option<ExecutionInfo>,


### PR DESCRIPTION
This PR will enable some additional types in the `types` crate to be serde-serialized. It'll allow presenting these types in an user-friendly form, for example a Json representation for`RewardResponse`:
```
{
  "amount": "8446000000000002",
  "era_id": 1
}
```
