### PR TITLE
Lower verbosity of a repeated log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2023-0045 --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0348 --ignore RUSTSEC-2024-0349 --ignore RUSTSEC-2024-0351 --ignore RUSTSEC-2024-0350 --ignore RUSTSEC-2024-0352 --ignore RUSTSEC-2024-0353
+	$(CARGO) audit --ignore RUSTSEC-2024-0357 --ignore RUSTSEC-2023-0045 --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0348 --ignore RUSTSEC-2024-0349 --ignore RUSTSEC-2024-0351 --ignore RUSTSEC-2024-0350 --ignore RUSTSEC-2024-0352 --ignore RUSTSEC-2024-0353
 
 .PHONY: audit-as
 audit-as:

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0348 --ignore RUSTSEC-2024-0349 --ignore RUSTSEC-2024-0351 --ignore RUSTSEC-2024-0350 --ignore RUSTSEC-2024-0352 --ignore RUSTSEC-2024-0353
+	$(CARGO) audit --ignore RUSTSEC-2023-0045 --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0348 --ignore RUSTSEC-2024-0349 --ignore RUSTSEC-2024-0351 --ignore RUSTSEC-2024-0350 --ignore RUSTSEC-2024-0352 --ignore RUSTSEC-2024-0353
 
 .PHONY: audit-as
 audit-as:

--- a/node/src/components/consensus/protocols/zug.rs
+++ b/node/src/components/consensus/protocols/zug.rs
@@ -79,7 +79,7 @@ use datasize::DataSize;
 use either::Either;
 use itertools::Itertools;
 use rand::{seq::IteratorRandom, Rng};
-use tracing::{debug, error, event, info, warn, Level};
+use tracing::{debug, error, event, info, trace, warn, Level};
 
 use casper_types::{Chainspec, TimeDiff, Timestamp, U512};
 
@@ -424,7 +424,7 @@ impl<C: Context + 'static> Zug<C> {
         if self.evidence_only || self.finalized_switch_block() {
             return vec![]; // Era has ended. No further progress is expected.
         }
-        debug!(
+        trace!(
             our_idx = self.our_idx(),
             instance_id = ?self.instance_id(),
             "syncing with random peer",


### PR DESCRIPTION
These logs can be seen multiple times a second and it makes it difficult to operate a local nctl network. By lowering the verbosity these can be still observed, but the default debug verbosity wouldn't show them.

Example series of logs from a local network:

```json
{"timestamp":"2024-06-27T10:27:00.538153Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277078,"ev":7277092,"name":"dispatch"},"spa
ns":[{"a":7277078,"ev":7277092,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.589789Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277092,"ev":7277103,"name":"dispatch"},"spa
ns":[{"a":7277092,"ev":7277103,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.590281Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277091,"ev":7277104,"name":"dispatch"},"spa
ns":[{"a":7277091,"ev":7277104,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.641687Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277104,"ev":7277116,"name":"dispatch"},"spa
ns":[{"a":7277104,"ev":7277116,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.641904Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277103,"ev":7277117,"name":"dispatch"},"spa
ns":[{"a":7277103,"ev":7277117,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.693753Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277116,"ev":7277128,"name":"dispatch"},"spa
ns":[{"a":7277116,"ev":7277128,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.694087Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277117,"ev":7277129,"name":"dispatch"},"spa
ns":[{"a":7277117,"ev":7277129,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.748127Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277129,"ev":7277138,"name":"dispatch"},"spa
ns":[{"a":7277129,"ev":7277138,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.748549Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277128,"ev":7277139,"name":"dispatch"},"spa
ns":[{"a":7277128,"ev":7277139,"name":"dispatch"}]}
{"timestamp":"2024-06-27T10:27:00.813592Z","level":"DEBUG","fields":{"message":"syncing with random peer","our_idx":1,"instance_id":"6639f6a9b81b853e3763cb34055f2638b50cf18154ef1b1e84f91f3cf415b21c"},"target":"casper_node::components::consensus::protocols::zug","span":{"a":7277139,"ev":7277156,"name":"dispatch"},"spa
ns":[{"a":7277139,"ev":7277156,"name":"dispatch"}]}
```