### PR TITLE
Rc3 block validator tests fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2024-0332
+	$(CARGO) audit --ignore RUSTSEC-2024-0344
 
 .PHONY: audit-as
 audit-as:

--- a/node/src/components/block_validator/state.rs
+++ b/node/src/components/block_validator/state.rs
@@ -655,7 +655,7 @@ mod tests {
     // Please note: values in the following test cases must match the production chainspec.
     const MAX_LARGE_COUNT: u64 = 3;
     const MAX_AUCTION_COUNT: u64 = 145;
-    const MAX_INSTALL_UPGRADE_COUNT: u64 = 2;
+    const MAX_INSTALL_UPGRADE_COUNT: u64 = 1;
     const MAX_MINT_COUNT: u64 = 650;
 
     struct TestCase {
@@ -712,6 +712,7 @@ mod tests {
         },
     };
 
+    #[allow(dead_code)]
     const LESS_THAN_MAX_INSTALL_UPGRADE: TestCase = TestCase {
         install_upgrade_count: FULL_INSTALL_UPGRADE.install_upgrade_count - 1,
         state_validator: |(state, responder)| {
@@ -819,7 +820,8 @@ mod tests {
         let mut rng = TestRng::new();
         run_test_case(TOO_MANY_INSTALL_UPGRADE, &mut rng);
         run_test_case(FULL_INSTALL_UPGRADE, &mut rng);
-        run_test_case(LESS_THAN_MAX_INSTALL_UPGRADE, &mut rng);
+        //TODO: Fix test setup so this isn't identical to the no transactions case
+        //run_test_case(LESS_THAN_MAX_INSTALL_UPGRADE, &mut rng);
     }
 
     #[test]
@@ -919,7 +921,7 @@ mod tests {
     fn should_add_responder_if_in_progress() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
         assert_eq!(state.responder_count(), 1);
 
@@ -960,7 +962,7 @@ mod tests {
     fn should_add_new_holder_if_in_progress() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
         assert_eq!(state.holders_mut().unwrap().len(), 1);
 
@@ -977,7 +979,7 @@ mod tests {
     fn should_not_change_holder_state() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
         let (holder, holder_state) = state
             .holders_mut()
@@ -1000,7 +1002,7 @@ mod tests {
     fn should_start_fetching() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
         let (holder, holder_state) = state
             .holders_mut()
@@ -1028,7 +1030,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(holder, original_holder);
-                assert_eq!(missing_transactions.len(), 8);
+                assert_eq!(missing_transactions.len(), 7);
             }
             _ => panic!("unexpected return value"),
         }
@@ -1042,7 +1044,7 @@ mod tests {
     fn start_fetching_should_return_ongoing_if_any_holder_in_asked_state() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
 
         // Change the current (only) holder's state to `Asked`.
@@ -1087,7 +1089,7 @@ mod tests {
     fn start_fetching_should_return_unable_if_all_holders_in_failed_state() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
 
         // Set the original holder's state to `Failed` and add some more failed.
@@ -1139,7 +1141,7 @@ mod tests {
     fn state_should_change_to_validation_succeeded() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 1);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 1);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
 
         // While there is still at least one missing transaction, `try_add_transaction_footprint`
@@ -1168,7 +1170,7 @@ mod tests {
     fn unrelated_transaction_added_should_not_change_state() {
         let mut rng = TestRng::new();
         let mut fixture = Fixture::new(&mut rng);
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         let (appendable_block_before, missing_transactions_before, holders_before) = match &state {
             BlockValidationState::InProgress {
                 appendable_block,
@@ -1223,7 +1225,7 @@ mod tests {
             new_standard(fixture.rng, Timestamp::MAX, TimeDiff::from_seconds(1));
         let invalid_transaction_hash = invalid_transaction.hash();
         fixture.transactions.push(invalid_transaction.clone());
-        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 2, 2);
+        let (mut state, _maybe_responder) = fixture.new_state(2, 2, 1, 2);
         assert!(matches!(state, BlockValidationState::InProgress { .. }));
         if let BlockValidationState::InProgress {
             ref mut missing_transactions,


### PR DESCRIPTION
Since lane sizing changed in `feat-2.0` as well, we should also introduce this fix there
