### PR TITLE
Fix the "No such contract" error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,6 +2339,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gh-4771-regression"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -130,6 +130,7 @@ run_test_and_count 'start_run_teardown "swap_validator_set.sh"'
 run_test_and_count 'start_run_teardown "sync_upgrade_test.sh node=6 era=5 timeout=500"'
 run_test_and_count 'start_run_teardown "validators_disconnect.sh"'
 run_test_and_count 'start_run_teardown "event_stream.sh"'
+run_test_and_count 'start_run_teardown "regression_4771.sh"'
 # Without start_run_teardown - these ones perform their own assets setup, network start and teardown
 run_test_and_count 'source "$SCENARIOS_DIR/upgrade_after_emergency_upgrade_test_pre_1.5.sh"'
 run_test_and_count 'source "$SCENARIOS_DIR/regression_3976.sh"'

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -396,7 +396,7 @@ impl ContractRuntime {
                 async move {
                     let start = Instant::now();
                     let entity_key = match entity_addr {
-                        EntityAddr::SmartContract(_)|EntityAddr::System(_) => Key::AddressableEntity(entity_addr),
+                        EntityAddr::SmartContract(_) | EntityAddr::System(_) => Key::AddressableEntity(entity_addr),
                         EntityAddr::Account(account) => Key::Account(AccountHash::new(account)),
                     };
                     let request = AddressableEntityRequest::new(state_root_hash, entity_key);

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -841,7 +841,7 @@ impl reactor::Reactor for Reactor {
                 }
                 ContractRuntimeRequest::GetAddressableEntity {
                     state_root_hash: _,
-                    key,
+                    entity_addr,
                     responder,
                 } => {
                     let result = if matches!(
@@ -852,12 +852,13 @@ impl reactor::Reactor for Reactor {
                         TestScenario::FromPeerMissingAccount(_)
                     ) {
                         AddressableEntityResult::ValueNotFound("missing account".to_string())
-                    } else if let Key::Account(account_hash) = key {
-                        let account = create_account(account_hash, self.test_scenario);
+                    } else if let EntityAddr::Account(account_hash) = entity_addr {
+                        let account =
+                            create_account(AccountHash::new(account_hash), self.test_scenario);
                         AddressableEntityResult::Success {
                             entity: AddressableEntity::from(account),
                         }
-                    } else if let Key::Hash(..) = key {
+                    } else if let EntityAddr::SmartContract(..) = entity_addr {
                         match self.test_scenario {
                             TestScenario::FromPeerCustomPaymentContract(
                                 ContractScenario::MissingContractAtHash,
@@ -894,10 +895,12 @@ impl reactor::Reactor for Reactor {
                                     entity: AddressableEntity::from(contract),
                                 }
                             }
-                            _ => panic!("unexpected GetAddressableEntity: {:?}", key),
+                            _ => panic!("unexpected GetAddressableEntity: {:?}", entity_addr),
                         }
                     } else {
-                        panic!("should GetAddressableEntity using Key's Account or Hash variant");
+                        panic!(
+                            "should GetAddressableEntity using Account or SmartContract variant"
+                        );
                     };
                     responder.respond(result).ignore()
                 }

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -132,9 +132,9 @@ use casper_storage::{
 use casper_types::{
     execution::{Effects as ExecutionEffects, ExecutionResult},
     Approval, AvailableBlockRange, Block, BlockHash, BlockHeader, BlockSignatures,
-    BlockSynchronizerStatus, BlockV2, ChainspecRawBytes, DeployHash, Digest, EraId, ExecutionInfo,
-    FinalitySignature, FinalitySignatureId, FinalitySignatureV2, Key, NextUpgrade, Package,
-    ProtocolUpgradeConfig, ProtocolVersion, PublicKey, TimeDiff, Timestamp, Transaction,
+    BlockSynchronizerStatus, BlockV2, ChainspecRawBytes, DeployHash, Digest, EntityAddr, EraId,
+    ExecutionInfo, FinalitySignature, FinalitySignatureId, FinalitySignatureV2, Key, NextUpgrade,
+    Package, ProtocolUpgradeConfig, ProtocolVersion, PublicKey, TimeDiff, Timestamp, Transaction,
     TransactionHash, TransactionHeader, TransactionId, Transfer, U512,
 };
 
@@ -2050,11 +2050,12 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    /// Retrieves an `AddressableEntity` from under the given key in global state if present.
+    /// Retrieves an `AddressableEntity` from under the given entity address (or key, if the former
+    /// is not found) in global state.
     pub(crate) async fn get_addressable_entity(
         self,
         state_root_hash: Digest,
-        key: Key,
+        entity_addr: EntityAddr,
     ) -> AddressableEntityResult
     where
         REv: From<ContractRuntimeRequest>,
@@ -2062,7 +2063,7 @@ impl<REv> EffectBuilder<REv> {
         self.make_request(
             |responder| ContractRuntimeRequest::GetAddressableEntity {
                 state_root_hash,
-                key,
+                entity_addr,
                 responder,
             },
             QueueKind::ContractRuntime,

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -33,9 +33,9 @@ use casper_storage::{
 use casper_types::{
     execution::ExecutionResult, Approval, AvailableBlockRange, Block, BlockHash, BlockHeader,
     BlockSignatures, BlockSynchronizerStatus, BlockV2, ChainspecRawBytes, DeployHash, Digest,
-    DisplayIter, EraId, ExecutionInfo, FinalitySignature, FinalitySignatureId, Key, NextUpgrade,
-    ProtocolUpgradeConfig, ProtocolVersion, PublicKey, TimeDiff, Timestamp, Transaction,
-    TransactionHash, TransactionHeader, TransactionId, Transfer,
+    DisplayIter, EntityAddr, EraId, ExecutionInfo, FinalitySignature, FinalitySignatureId, Key,
+    NextUpgrade, ProtocolUpgradeConfig, ProtocolVersion, PublicKey, TimeDiff, Timestamp,
+    Transaction, TransactionHash, TransactionHeader, TransactionId, Transfer,
 };
 
 use super::{AutoClosingResponder, GossipTarget, Responder};
@@ -822,13 +822,13 @@ pub(crate) enum ContractRuntimeRequest {
         state_root_hash: Digest,
         responder: Responder<ExecutionResultsChecksumResult>,
     },
-    /// Returns an `AddressableEntity` if found under the given key.  If a legacy `Account`
+    /// Returns an `AddressableEntity` if found under the given entity_addr.  If a legacy `Account`
     /// or contract exists under the given key, it will be migrated to an `AddressableEntity`
     /// and returned. However, global state is not altered and the migrated record does not
     /// actually exist.
     GetAddressableEntity {
         state_root_hash: Digest,
-        key: Key,
+        entity_addr: EntityAddr,
         responder: Responder<AddressableEntityResult>,
     },
     /// Returns a singular entry point based under the given state root hash and entry
@@ -925,13 +925,13 @@ impl Display for ContractRuntimeRequest {
             ),
             ContractRuntimeRequest::GetAddressableEntity {
                 state_root_hash,
-                key,
+                entity_addr,
                 ..
             } => {
                 write!(
                     formatter,
                     "get addressable_entity {} under {}",
-                    key, state_root_hash
+                    entity_addr, state_root_hash
                 )
             }
             ContractRuntimeRequest::GetTrie { request, .. } => {

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -311,7 +311,7 @@ fn get_entity_by_account_hash(
         .data_access_layer()
         .addressable_entity(AddressableEntityRequest::new(
             state_root_hash,
-            Key::Account(account_hash),
+            Key::AddressableEntity(EntityAddr::Account(account_hash.value())),
         ))
         .into_option()
         .unwrap_or_else(|| {

--- a/smart_contracts/contracts/test/gh-4771-regression/Cargo.toml
+++ b/smart_contracts/contracts/test/gh-4771-regression/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gh-4771-regression"
+version = "0.1.0"
+authors = ["Rafał Chabowski <rafal@casperlabs.io>"]
+edition = "2021"
+
+[[bin]]
+name = "gh_4771_regression"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/gh-4771-regression/src/main.rs
+++ b/smart_contracts/contracts/test/gh-4771-regression/src/main.rs
@@ -1,0 +1,45 @@
+#![no_main]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::ToString;
+use casper_contract::contract_api::{runtime, storage};
+use casper_types::{
+    addressable_entity::Parameters, CLType, EntryPoint, EntryPointAccess, EntryPointPayment,
+    EntryPointType, EntryPoints, Key,
+};
+
+const METHOD_TEST_ENTRY_POINT: &str = "test_entry_point";
+const NEW_KEY_NAME: &str = "Hello";
+const NEW_KEY_VALUE: &str = "World";
+const CONTRACT_PACKAGE_KEY: &str = "contract_package";
+const CONTRACT_HASH_KEY: &str = "contract_hash";
+
+#[no_mangle]
+fn test_entry_point() {
+    let value = storage::new_uref(NEW_KEY_VALUE);
+    runtime::put_key(NEW_KEY_NAME, value.into());
+}
+
+#[no_mangle]
+fn call() {
+    let mut entry_points = EntryPoints::new();
+    entry_points.add_entry_point(EntryPoint::new(
+        METHOD_TEST_ENTRY_POINT,
+        Parameters::new(),
+        CLType::Unit,
+        EntryPointAccess::Public,
+        EntryPointType::Called,
+        EntryPointPayment::Caller,
+    ));
+
+    let (contract_hash, _version) = storage::new_contract(
+        entry_points,
+        None,
+        Some(CONTRACT_PACKAGE_KEY.to_string()),
+        None,
+        None,
+    );
+    runtime::put_key(CONTRACT_HASH_KEY, Key::contract_entity_key(contract_hash));
+}

--- a/types/src/addressable_entity.rs
+++ b/types/src/addressable_entity.rs
@@ -850,6 +850,16 @@ impl EntityAddr {
             || self.value() == PublicKey::System.to_account_hash().value()
     }
 
+    /// Is this a contract entity address?
+    pub fn is_contract(&self) -> bool {
+        self.tag() == EntityKindTag::SmartContract
+    }
+
+    /// Is this an account entity address?
+    pub fn is_account(&self) -> bool {
+        self.tag() == EntityKindTag::Account
+    }
+
     /// Returns the 32 bytes of the [`EntityAddr`].
     pub fn value(&self) -> HashAddr {
         match self {


### PR DESCRIPTION
This PR fixes the "no such contract at hash" error when trying to invoke an entrypoint of a contract.

Contract could not be not found because the system attempted to access it via `Key::Hash` which does not exist if the contract is newly installed on the contrary to the contract being migrated from 1.x.

The fix solves this by trying to access the contract via the `Key::AddressableEntity`, falling back to the indirection via `Key::Hash` upon getting the `ValueNotFound` error.

It also provides a test contract used in the regression test available here: https://github.com/casper-network/casper-nctl/pull/9

Fixes https://github.com/casper-network/casper-node/issues/4771