### PR TITLE
Remove revert on deser in try_get_named_arg introduced in #4569

### DIFF
--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -194,6 +194,37 @@ pub fn get_named_arg<T: FromBytes>(name: &str) -> T {
     bytesrepr::deserialize(arg_bytes).unwrap_or_revert_with(ApiError::InvalidArgument)
 }
 
+/// Returns given named argument passed to the host for the current module invocation.
+/// If the argument is not found, returns `None`.
+///
+/// Note that this is only relevant to contracts stored on-chain since a contract deployed directly
+/// is not invoked with any arguments.
+pub fn try_get_named_arg<T: FromBytes>(name: &str) -> Option<T> {
+    let arg_size = get_named_arg_size(name)?;
+    let arg_bytes = if arg_size > 0 {
+        let res = {
+            let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
+            let ret = unsafe {
+                ext_ffi::casper_get_named_arg(
+                    name.as_bytes().as_ptr(),
+                    name.len(),
+                    data_non_null_ptr.as_ptr(),
+                    arg_size,
+                )
+            };
+            let data =
+                unsafe { Vec::from_raw_parts(data_non_null_ptr.as_ptr(), arg_size, arg_size) };
+            api_error::result_from(ret).map(|_| data)
+        };
+        // Assumed to be safe as `get_named_arg_size` checks the argument already
+        res.unwrap_or_revert()
+    } else {
+        // Avoids allocation with 0 bytes and a call to get_named_arg
+        Vec::new()
+    };
+    bytesrepr::deserialize(arg_bytes).ok()
+}
+
 /// Returns the caller of the current context, i.e. the [`AccountHash`] of the account which made
 /// the deploy request.
 pub fn get_caller() -> AccountHash {

--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -194,37 +194,6 @@ pub fn get_named_arg<T: FromBytes>(name: &str) -> T {
     bytesrepr::deserialize(arg_bytes).unwrap_or_revert_with(ApiError::InvalidArgument)
 }
 
-/// Returns given named argument passed to the host for the current module invocation.
-/// If the argument is not found, returns `None`.
-///
-/// Note that this is only relevant to contracts stored on-chain since a contract deployed directly
-/// is not invoked with any arguments.
-pub fn try_get_named_arg<T: FromBytes>(name: &str) -> Option<T> {
-    let arg_size = get_named_arg_size(name)?;
-    let arg_bytes = if arg_size > 0 {
-        let res = {
-            let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
-            let ret = unsafe {
-                ext_ffi::casper_get_named_arg(
-                    name.as_bytes().as_ptr(),
-                    name.len(),
-                    data_non_null_ptr.as_ptr(),
-                    arg_size,
-                )
-            };
-            let data =
-                unsafe { Vec::from_raw_parts(data_non_null_ptr.as_ptr(), arg_size, arg_size) };
-            api_error::result_from(ret).map(|_| data)
-        };
-        // Assumed to be safe as `get_named_arg_size` checks the argument already
-        res.unwrap_or_revert()
-    } else {
-        // Avoids allocation with 0 bytes and a call to get_named_arg
-        Vec::new()
-    };
-    bytesrepr::deserialize(arg_bytes).unwrap_or_revert_with(ApiError::InvalidArgument)
-}
-
 /// Returns the caller of the current context, i.e. the [`AccountHash`] of the account which made
 /// the deploy request.
 pub fn get_caller() -> AccountHash {

--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -200,10 +200,7 @@ pub fn get_named_arg<T: FromBytes>(name: &str) -> T {
 /// Note that this is only relevant to contracts stored on-chain since a contract deployed directly
 /// is not invoked with any arguments.
 pub fn try_get_named_arg<T: FromBytes>(name: &str) -> Result<T, ApiError> {
-    let arg_size = match get_named_arg_size(name) {
-        Some(size) => size,
-        _ => 0,
-    };
+    let arg_size = get_named_arg_size(name).unwrap_or(0);
     let arg_bytes = if arg_size > 0 {
         let res = {
             let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
@@ -225,10 +222,7 @@ pub fn try_get_named_arg<T: FromBytes>(name: &str) -> Result<T, ApiError> {
         // Avoids allocation with 0 bytes and a call to get_named_arg
         Vec::new()
     };
-    match bytesrepr::deserialize(arg_bytes) {
-        Ok(value) => Ok(value),
-        Err(_) => Err(ApiError::InvalidArgument),
-    }
+    bytesrepr::deserialize(arg_bytes).map_err(|_| ApiError::InvalidArgument)
 }
 
 /// Returns the caller of the current context, i.e. the [`AccountHash`] of the account which made

--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -199,8 +199,8 @@ pub fn get_named_arg<T: FromBytes>(name: &str) -> T {
 ///
 /// Note that this is only relevant to contracts stored on-chain since a contract deployed directly
 /// is not invoked with any arguments.
-pub fn try_get_named_arg<T: FromBytes>(name: &str) -> Result<T, ApiError> {
-    let arg_size = get_named_arg_size(name).unwrap_or(0);
+pub fn try_get_named_arg<T: FromBytes>(name: &str) -> Option<T> {
+    let arg_size = get_named_arg_size(name)?;
     let arg_bytes = if arg_size > 0 {
         let res = {
             let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
@@ -222,7 +222,7 @@ pub fn try_get_named_arg<T: FromBytes>(name: &str) -> Result<T, ApiError> {
         // Avoids allocation with 0 bytes and a call to get_named_arg
         Vec::new()
     };
-    bytesrepr::deserialize(arg_bytes).map_err(|_| ApiError::InvalidArgument)
+    bytesrepr::deserialize(arg_bytes).ok()
 }
 
 /// Returns the caller of the current context, i.e. the [`AccountHash`] of the account which made


### PR DESCRIPTION
Remove revert in try_get_named_arg introduced in #4569

https://github.com/casper-network/casper-node/pull/4569#discussion_r1662435826

method unused yet in contracts
