### PR TITLE
BUGFIX: wasm v1 result err fix

### DIFF
--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -125,6 +125,8 @@ impl ExecutionArtifactBuilder {
         }
         if let (None, Some(err)) = (&self.error_message, wasm_v1_result.error()) {
             self.error_message = Some(format!("{}", err));
+            self.with_added_consumed(wasm_v1_result.consumed());
+            return Ok(self);
         }
         self.with_added_consumed(wasm_v1_result.consumed())
             .with_appended_messages(&mut wasm_v1_result.messages().clone())


### PR DESCRIPTION
This PR alters the behavior of `with_wasm_v1_result` function of the `ExecutionArtifactBuilder` to not include userland side effects if execution error occurred. 