### PR TITLE
Fix a bug in rewards calculation and add a test

### DIFF
--- a/node/src/components/contract_runtime/rewards.rs
+++ b/node/src/components/contract_runtime/rewards.rs
@@ -533,7 +533,7 @@ pub(crate) fn rewards_for_era(
                 )?;
                 increase_value_for_key_and_era(
                     block.proposer.clone(),
-                    signed_block_era,
+                    current_era_id,
                     collection_reward,
                 )?;
             }

--- a/node/src/components/contract_runtime/rewards/tests.rs
+++ b/node/src/components/contract_runtime/rewards/tests.rs
@@ -283,10 +283,8 @@ fn all_signatures_rewards_without_contribution_fee() {
         ratio(1)
             * ratio(era_2_reward_per_round)
             * ratio(core_config.production_rewards_proportion())
-    };
-    let validator_1_expected_payout_prev_era = {
-        // All finality signature collected:
-        ratio(era_1_reward_per_round) * ratio(core_config.collection_rewards_proportion())
+        // All finality signature collected (paid out in era 2):
+        + ratio(era_1_reward_per_round) * ratio(core_config.collection_rewards_proportion())
     };
     let validator_2_expected_payout = {
         // 1 block produced:
@@ -303,8 +301,7 @@ fn all_signatures_rewards_without_contribution_fee() {
 
     assert_eq!(
         map! {
-            VALIDATOR_1.clone() => vec![validator_1_expected_payout.to_integer(),
-                                        validator_1_expected_payout_prev_era.to_integer()],
+            VALIDATOR_1.clone() => vec![validator_1_expected_payout.to_integer()],
             VALIDATOR_2.clone() => vec![validator_2_expected_payout.to_integer()],
             VALIDATOR_3.clone() => vec![validator_3_expected_payout.to_integer()],
         },
@@ -634,6 +631,10 @@ fn mixed_signatures_pattern() {
                     + ratio(1) * constructor.weight(era, VALIDATOR_3.deref())
                     + ratio(1) * constructor.weight(era, VALIDATOR_4.deref())
                 ) * ratio(era_2_reward_per_round)
+                // collected one signature from era 1
+                + (
+                    ratio(1) * constructor.weight(1, VALIDATOR_1.deref())
+                ) * ratio(era_1_reward_per_round)
             }
             // Finality signed:
             + contribution * {
@@ -641,12 +642,7 @@ fn mixed_signatures_pattern() {
                 ratio(3) * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_3.deref())
             }).to_integer(),
             // for era 1
-            (collection * {
-                (
-                    ratio(1) * constructor.weight(1, VALIDATOR_1.deref())
-                ) * ratio(era_1_reward_per_round)
-            }
-            + contribution * {
+            (contribution * {
                 // 1 in previous era:
                 ratio(1) * ratio(era_1_reward_per_round) * constructor.weight(1, VALIDATOR_3.deref())
             }).to_integer()
@@ -663,16 +659,14 @@ fn mixed_signatures_pattern() {
                     + ratio(2) * constructor.weight(era, VALIDATOR_3.deref())
                     + ratio(1) * constructor.weight(era, VALIDATOR_4.deref())
                 ) * ratio(era_2_reward_per_round)
+                // collected one signature from era 1
+                + (
+                    ratio(1) * constructor.weight(1, VALIDATOR_3.deref())
+                ) * ratio(era_1_reward_per_round)
             }
             // 3 finality signed:
             + ratio(2) * contribution * ratio(era_2_reward_per_round) * constructor.weight(era, VALIDATOR_4.deref()))
             .to_integer(),
-            // for era 1
-            (collection * {
-                (
-                    ratio(1) * constructor.weight(1, VALIDATOR_3.deref())
-                ) * ratio(era_1_reward_per_round)
-            }).to_integer()
         ];
 
         assert_eq!(

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -2472,9 +2472,11 @@ async fn run_rewards_network_scenario(
                                         .expect("expected current era validator"),
                                     total_previous_era_weights,
                                 );
+                                // collection always goes to the era in which the block citing the
+                                // reward was created
                                 add_to_rewards(
                                     proposer.clone(),
-                                    switch_blocks.headers[i - 1].era_id(),
+                                    block.era_id(),
                                     fixture.chainspec.core_config.finders_fee.into_u512()
                                         * contributor_proportion
                                         * previous_signatures_reward,

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -46,8 +46,8 @@ use crate::runtime_args;
 use crate::{
     bytesrepr::Bytes,
     system::auction::{
-        ARG_AMOUNT as ARG_AUCTION_AMOUNT, ARG_DELEGATOR, ARG_NEW_VALIDATOR,
-        ARG_PUBLIC_KEY as ARG_AUCTION_PUBLIC_KEY, ARG_VALIDATOR, METHOD_DELEGATE,
+        ARG_AMOUNT as ARG_AUCTION_AMOUNT, ARG_DELEGATION_RATE, ARG_DELEGATOR, ARG_NEW_VALIDATOR,
+        ARG_PUBLIC_KEY as ARG_AUCTION_PUBLIC_KEY, ARG_VALIDATOR, METHOD_ADD_BID, METHOD_DELEGATE,
         METHOD_REDELEGATE, METHOD_UNDELEGATE, METHOD_WITHDRAW_BID,
     },
     testing::TestRng,
@@ -1005,6 +1005,44 @@ impl Deploy {
             session,
             &secret_key,
             None,
+        )
+    }
+
+    /// Creates an add bid deploy, for testing.
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
+    pub fn add_bid(
+        chain_name: String,
+        auction_contract_hash: AddressableEntityHash,
+        public_key: PublicKey,
+        amount: U512,
+        delegation_rate: u8,
+        timestamp: Timestamp,
+        ttl: TimeDiff,
+    ) -> Self {
+        let payment = ExecutableDeployItem::ModuleBytes {
+            module_bytes: Bytes::new(),
+            args: runtime_args! { ARG_AMOUNT => U512::from(3_000_000_000_u64) },
+        };
+        let args = runtime_args! {
+            ARG_AUCTION_AMOUNT => amount,
+            ARG_AUCTION_PUBLIC_KEY => public_key.clone(),
+            ARG_DELEGATION_RATE => delegation_rate,
+        };
+        let session = ExecutableDeployItem::StoredContractByHash {
+            hash: auction_contract_hash,
+            entry_point: METHOD_ADD_BID.to_string(),
+            args,
+        };
+
+        Deploy::build(
+            timestamp,
+            ttl,
+            1,
+            vec![],
+            chain_name,
+            payment,
+            session,
+            InitiatorAddrAndSecretKey::InitiatorAddr(InitiatorAddr::PublicKey(public_key)),
         )
     }
 


### PR DESCRIPTION
This fixes a bug which caused the signature collection reward to be applied to the era of signature creation instead of the era of collection. Because of that, if a validator joined the network and proposed a block citing a signature from a previous era, the auction contract would fail to distribute the rewards.

The PR also adds a test exercising a scenario in which that would happen (it should be roughly equivalent to the NCTL test `itst13`).
