### PR TITLE
Drop effects if WASM module execution caused a revert and also add a test for this.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "endless-loop-with-effects"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "enum-iterator"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0344
+	$(CARGO) audit --ignore RUSTSEC-2024-0332 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0348 --ignore RUSTSEC-2024-0349 --ignore RUSTSEC-2024-0351 --ignore RUSTSEC-2024-0350 --ignore RUSTSEC-2024-0352 --ignore RUSTSEC-2024-0353
 
 .PHONY: audit-as
 audit-as:

--- a/execution_engine/src/execution/executor.rs
+++ b/execution_engine/src/execution/executor.rs
@@ -6,9 +6,10 @@ use casper_storage::{
     AddressGenerator,
 };
 use casper_types::{
-    account::AccountHash, addressable_entity::NamedKeys, execution::Effects, AddressableEntity,
-    AddressableEntityHash, BlockTime, ContextAccessRights, EntryPointType, Gas, Key, Phase,
-    ProtocolVersion, RuntimeArgs, StoredValue, Tagged, TransactionHash, U512,
+    account::AccountHash, addressable_entity::NamedKeys, contract_messages::Messages,
+    execution::Effects, AddressableEntity, AddressableEntityHash, BlockTime, ContextAccessRights,
+    EntryPointType, Gas, Key, Phase, ProtocolVersion, RuntimeArgs, StoredValue, Tagged,
+    TransactionHash, U512,
 };
 
 use crate::{
@@ -130,19 +131,24 @@ impl Executor {
             }
         };
 
-        let (err, effects) = match result {
-            Ok(_) => (None, runtime.context().effects()),
-            Err(error) => (Some(error.into()), Effects::new()),
-        };
-
-        return WasmV1Result::new(
-            gas_limit,
-            runtime.context().gas_counter(),
-            effects,
-            runtime.context().transfers().to_owned(),
-            runtime.context().messages(),
-            err,
-        );
+        match result {
+            Ok(_) => WasmV1Result::new(
+                gas_limit,
+                runtime.context().gas_counter(),
+                runtime.context().effects(),
+                runtime.context().transfers().to_owned(),
+                runtime.context().messages(),
+                None,
+            ),
+            Err(error) => WasmV1Result::new(
+                gas_limit,
+                runtime.context().gas_counter(),
+                Effects::new(),
+                vec![],
+                Messages::new(),
+                Some(error.into()),
+            ),
+        }
     }
 
     /// Creates new runtime context.

--- a/execution_engine/src/execution/executor.rs
+++ b/execution_engine/src/execution/executor.rs
@@ -130,15 +130,15 @@ impl Executor {
             }
         };
 
-        let err = match result {
-            Ok(_) => None,
-            Err(error) => Some(error.into()),
+        let (err, effects) = match result {
+            Ok(_) => (None, runtime.context().effects()),
+            Err(error) => (Some(error.into()), Effects::new()),
         };
 
         return WasmV1Result::new(
             gas_limit,
             runtime.context().gas_counter(),
-            runtime.context().effects(),
+            effects,
             runtime.context().transfers().to_owned(),
             runtime.context().messages(),
             err,

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -464,6 +464,24 @@ impl TestFixture {
             .expect("node 0 should have a complete block")
     }
 
+    /// Get block by height
+    fn get_block_by_height(&self, block_height: u64) -> Block {
+        let node_0 = self
+            .node_contexts
+            .first()
+            .expect("should have at least one node")
+            .id;
+
+        self.network
+            .nodes()
+            .get(&node_0)
+            .expect("should have node 0")
+            .main_reactor()
+            .storage()
+            .read_block_by_height(block_height)
+            .expect("failure to read block at height")
+    }
+
     #[track_caller]
     fn get_block_gas_price_by_public_key(&self, maybe_public_key: Option<&PublicKey>) -> u8 {
         let node_id = match maybe_public_key {

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -3613,7 +3613,7 @@ async fn out_of_gas_txn_does_not_produce_effects() {
         .join("target")
         .join("wasm32-unknown-unknown")
         .join("release")
-        .join("endless_loop.wasm");
+        .join("endless_loop_with_effects.wasm");
     let module_bytes =
         Bytes::from(std::fs::read(revert_contract).expect("cannot read module bytes"));
 

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -277,25 +277,37 @@ fn get_entity_named_key(
     state_root_hash: Digest,
     entity_addr: EntityAddr,
     named_key: &str,
-) -> Key {
+) -> Option<Key> {
+    let key = Key::NamedKey(
+        NamedKeyAddr::new_from_string(entity_addr, named_key.to_owned())
+            .expect("should be valid NamedKeyAddr"),
+    );
+
+    match query_global_state(fixture, state_root_hash, key) {
+        Some(val) => match &*val {
+            StoredValue::NamedKey(named_key) => {
+                Some(named_key.get_key().expect("should have a Key"))
+            }
+            value => panic!("Expected NamedKey but got {:?}", value),
+        },
+        None => None,
+    }
+}
+
+fn query_global_state(
+    fixture: &mut TestFixture,
+    state_root_hash: Digest,
+    key: Key,
+) -> Option<Box<StoredValue>> {
     let (_node_id, runner) = fixture.network.nodes().iter().next().unwrap();
     match runner
         .main_reactor()
         .contract_runtime()
         .data_access_layer()
-        .query(QueryRequest::new(
-            state_root_hash,
-            Key::NamedKey(
-                NamedKeyAddr::new_from_string(entity_addr, named_key.to_owned())
-                    .expect("should be valid NamedKeyAddr"),
-            ),
-            vec![],
-        )) {
-        QueryResult::Success { value, .. } => match &*value {
-            StoredValue::NamedKey(named_key) => named_key.get_key().expect("should have a Key"),
-            value => panic!("Expected NamedKey but got {:?}", value),
-        },
-        err => panic!("Expected QueryResult::Success but got {:?}", err),
+        .query(QueryRequest::new(state_root_hash, key, vec![]))
+    {
+        QueryResult::Success { value, .. } => Some(value),
+        _err => None,
     }
 }
 
@@ -3053,7 +3065,8 @@ async fn insufficient_funds_transfer_from_purse() {
         state_root_hash,
         BOB_PUBLIC_KEY.to_account_hash(),
     );
-    let key = get_entity_named_key(&mut test.fixture, state_root_hash, entity_addr, purse_name);
+    let key = get_entity_named_key(&mut test.fixture, state_root_hash, entity_addr, purse_name)
+        .expect("expected a key");
     let uref = *key.as_uref().expect("Expected a URef");
 
     // now we try to transfer from the purse we just created
@@ -3371,7 +3384,8 @@ async fn successful_purse_to_purse_transfer() {
         BOB_PUBLIC_KEY.to_account_hash(),
     );
     let bob_purse_key =
-        get_entity_named_key(&mut test.fixture, state_root_hash, bob_addr, purse_name);
+        get_entity_named_key(&mut test.fixture, state_root_hash, bob_addr, purse_name)
+            .expect("expected a key");
     let bob_purse = *bob_purse_key.as_uref().expect("Expected a URef");
 
     let alice_addr = get_entity_addr_from_account_hash(
@@ -3463,7 +3477,8 @@ async fn successful_purse_to_account_transfer() {
         BOB_PUBLIC_KEY.to_account_hash(),
     );
     let bob_purse_key =
-        get_entity_named_key(&mut test.fixture, state_root_hash, bob_addr, purse_name);
+        get_entity_named_key(&mut test.fixture, state_root_hash, bob_addr, purse_name)
+            .expect("expected a key");
     let bob_purse = *bob_purse_key.as_uref().expect("Expected a URef");
 
     // now we try to transfer from the purse we just created
@@ -3570,4 +3585,68 @@ async fn native_transfer_deploy_without_source_purse_should_succeed() {
     txn.sign(&BOB_SECRET_KEY);
     let (_txn_hash, _block_height, exec_result) = test.send_transaction(txn).await;
     assert!(exec_result_is_success(&exec_result), "{:?}", exec_result);
+}
+
+#[tokio::test]
+async fn out_of_gas_txn_does_not_produce_effects() {
+    let config = SingleTransactionTestCase::default_test_config()
+        .with_pricing_handling(PricingHandling::Fixed)
+        .with_refund_handling(RefundHandling::NoRefund)
+        .with_fee_handling(FeeHandling::PayToProposer);
+
+    let mut test = SingleTransactionTestCase::new(
+        ALICE_SECRET_KEY.clone(),
+        BOB_SECRET_KEY.clone(),
+        CHARLIE_SECRET_KEY.clone(),
+        Some(config),
+    )
+    .await;
+
+    test.fixture
+        .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
+        .await;
+
+    // This WASM creates named key called "new_key". Then it would loop endlessly trying to write a
+    // value to storage. Eventually it will run out of gas and it should exit causing a revert.
+    let revert_contract = RESOURCES_PATH
+        .join("..")
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release")
+        .join("endless_loop.wasm");
+    let module_bytes =
+        Bytes::from(std::fs::read(revert_contract).expect("cannot read module bytes"));
+
+    let mut txn = Transaction::from(
+        TransactionV1Builder::new_session(TransactionCategory::Large, module_bytes)
+            .with_chain_name(CHAIN_NAME)
+            .with_initiator_addr(BOB_PUBLIC_KEY.clone())
+            .build()
+            .unwrap(),
+    );
+    txn.sign(&BOB_SECRET_KEY);
+    let (_txn_hash, block_height, exec_result) = test.send_transaction(txn).await;
+    assert!(
+        matches!(
+            &exec_result,
+            ExecutionResult::V2(res) if res.error_message.as_deref() == Some("Out of gas error")
+        ),
+        "{:?}",
+        exec_result
+    );
+
+    let state_root_hash = *test
+        .fixture
+        .get_block_by_height(block_height)
+        .state_root_hash();
+    let bob_addr = get_entity_addr_from_account_hash(
+        &mut test.fixture,
+        state_root_hash,
+        BOB_PUBLIC_KEY.to_account_hash(),
+    );
+
+    // Named key should not exist since the execution was reverted because it was out of gas.
+    assert!(
+        get_entity_named_key(&mut test.fixture, state_root_hash, bob_addr, "new_key").is_none()
+    );
 }

--- a/smart_contracts/contracts/test/endless-loop-with-effects/Cargo.toml
+++ b/smart_contracts/contracts/test/endless-loop-with-effects/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "endless-loop-with-effects"
+version = "0.1.0"
+authors = ["Alex Sardan <alexandru@casperlabs.io>"]
+edition = "2021"
+
+[[bin]]
+name = "endless_loop_with_effects"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/endless-loop-with-effects/src/main.rs
+++ b/smart_contracts/contracts/test/endless-loop-with-effects/src/main.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use casper_contract::contract_api::{account, runtime, storage};
+use casper_types::Key;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let mut data: u32 = 1;
+    let uref = storage::new_uref(data);
+    runtime::put_key("new_key", Key::from(uref));
+    loop {
+        let _ = account::get_main_purse();
+        data += 1;
+        storage::write(uref, data);
+    }
+}

--- a/smart_contracts/contracts/test/endless-loop/src/main.rs
+++ b/smart_contracts/contracts/test/endless-loop/src/main.rs
@@ -1,19 +1,18 @@
 #![no_std]
 #![no_main]
 
+#[macro_use]
 extern crate alloc;
 
-use casper_contract::contract_api::{account, runtime, storage};
-use casper_types::Key;
+use casper_contract::contract_api::{account, storage};
+use casper_types::bytesrepr::Bytes;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let mut data: u32 = 1;
-    let uref = storage::new_uref(data);
-    runtime::put_key("new_key", Key::from(uref));
+    let uref = storage::new_uref(());
     loop {
         let _ = account::get_main_purse();
-        data += 1;
+        let data: Bytes = vec![0u8; 4096].into();
         storage::write(uref, data);
     }
 }

--- a/smart_contracts/contracts/test/endless-loop/src/main.rs
+++ b/smart_contracts/contracts/test/endless-loop/src/main.rs
@@ -1,18 +1,19 @@
 #![no_std]
 #![no_main]
 
-#[macro_use]
 extern crate alloc;
 
-use casper_contract::contract_api::{account, storage};
-use casper_types::bytesrepr::Bytes;
+use casper_contract::contract_api::{account, runtime, storage};
+use casper_types::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let uref = storage::new_uref(());
+    let mut data: u32 = 1;
+    let uref = storage::new_uref(data);
+    runtime::put_key("new_key", Key::from(uref));
     loop {
         let _ = account::get_main_purse();
-        let data: Bytes = vec![0u8; 4096].into();
+        data += 1;
         storage::write(uref, data);
     }
 }


### PR DESCRIPTION
Drop effects if WASM module execution caused a revert and also add a test for this.
