### PR TITLE
Migration version bug fix

### DIFF
--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -986,6 +986,16 @@ fn call_and_migrate_purse_holder_contract(migration_scenario: MigrationScenario)
         .map(PackageHash::new)
         .unwrap();
 
+    // There is only one version present, post migration there should also
+    // be only one.
+    let version_count = builder
+        .get_package(package_hash)
+        .expect("must have package")
+        .versions()
+        .version_count();
+
+    assert_eq!(version_count, 1usize);
+
     let execute_request = match migration_scenario {
         MigrationScenario::ByPackageName(maybe_contract_version) => {
             ExecuteRequestBuilder::versioned_contract_call_by_name(
@@ -1057,6 +1067,15 @@ fn call_and_migrate_purse_holder_contract(migration_scenario: MigrationScenario)
     if let MigrationScenario::ByUpgrader = migration_scenario {
         let expect_associated_keys = AssociatedKeys::new(*DEFAULT_ACCOUNT_ADDR, Weight::new(1));
         assert_eq!(actual_associated_keys, &expect_associated_keys);
+        // Post migration by upgrade there should be previous + 1 versions
+        // present in the package. (previous = 1)
+        let version_count = builder
+            .get_package(package_hash)
+            .expect("must have package")
+            .versions()
+            .version_count();
+
+        assert_eq!(version_count, 2usize);
     } else {
         assert_eq!(actual_associated_keys, &AssociatedKeys::default());
     }

--- a/storage/src/tracking_copy/ext_entity.rs
+++ b/storage/src/tracking_copy/ext_entity.rs
@@ -667,8 +667,6 @@ where
             self.prune(Key::Hash(contract_hash.value()));
             // Prune the legacy Wasm record.
             self.prune(Key::Hash(contract_wasm_hash.value()));
-
-            package.insert_entity_version(protocol_version.value().major, entity_hash);
         }
 
         let access_key_value = CLValue::from_t(access_uref).map_err(Self::Error::CLValue)?;

--- a/storage/src/tracking_copy/ext_entity.rs
+++ b/storage/src/tracking_copy/ext_entity.rs
@@ -592,7 +592,7 @@ where
         let access_uref = legacy_package.access_key();
         let mut generator = AddressGenerator::new(access_uref.addr().as_ref(), Phase::System);
 
-        let mut package: Package = legacy_package.into();
+        let package: Package = legacy_package.into();
 
         for (_, contract_hash) in legacy_versions.into_iter() {
             let legacy_contract = match self.read(&Key::Hash(contract_hash.value()))? {

--- a/types/src/package.rs
+++ b/types/src/package.rs
@@ -216,6 +216,11 @@ impl EntityVersions {
             None
         }
     }
+
+    /// The number of versions present in the package.
+    pub fn version_count(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl ToBytes for EntityVersions {


### PR DESCRIPTION
CHANGELOG:

- Removed a redundant insertion of entity versions during the migration of legacy contracts
- Added a check in tests to ensure that versions are correctly carried forward 