### PR TITLE
Fix unbonding failing if accounts weren't migrated

### DIFF
--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -824,7 +824,8 @@ fn should_forcibly_undelegate_after_setting_validator_limits() {
     builder.forced_undelegate(None, DEFAULT_PROTOCOL_VERSION, DEFAULT_BLOCK_TIME);
 
     let bids = builder.get_bids();
-    assert_eq!(bids.len(), 1);
+    // The undelegation itself doesn't remove bids, only process_unbond does.
+    assert_eq!(bids.len(), 3);
 
     assert!(builder.get_validator_weights(new_era + 1).is_none());
 
@@ -839,7 +840,10 @@ fn should_forcibly_undelegate_after_setting_validator_limits() {
 
     assert_eq!(
         *validator_weights.get(&NON_FOUNDER_VALIDATOR_1_PK).unwrap(),
-        U512::from(ADD_BID_AMOUNT_1 + 1_000)
+        // The validator has now bid ADD_BID_AMOUNT_1 + 1_000.
+        // Delegator 1's delegation has been decreased to the maximum of DELEGATE_AMOUNT_1 - 1_000.
+        // Delegator 2's delegation was below minimum, so it has been completely unbonded.
+        U512::from(ADD_BID_AMOUNT_1 + 1_000 + DELEGATE_AMOUNT_1 - 1_000)
     );
 
     let unbonding_purses: UnbondingPurses = builder.get_unbonds();

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -399,9 +399,14 @@ pub trait Auction:
             let minimum_delegation_amount = U512::from(validator_bid.minimum_delegation_amount());
             let maximum_delegation_amount = U512::from(validator_bid.maximum_delegation_amount());
 
-            let mut delegators = read_delegator_bids(self, validator_public_key)?;
-            for delegator in delegators.iter_mut() {
+            let delegators = read_delegator_bids(self, validator_public_key)?;
+            for mut delegator in delegators {
                 let staked_amount = delegator.staked_amount();
+                if staked_amount.is_zero() {
+                    // A delegator who has unbonded - nothing to do here, this will be removed when
+                    // unbonding is processed.
+                    continue;
+                }
                 if staked_amount < minimum_delegation_amount
                     || staked_amount > maximum_delegation_amount
                 {
@@ -419,20 +424,29 @@ pub trait Auction:
                         amount,
                         None,
                     )?;
-                    match delegator.decrease_stake(amount, era_end_timestamp_millis) {
-                        Ok(_) => (),
-                        // Work around the case when the locked amounts table has yet to be
-                        // initialized (likely pre-90 day mark).
-                        Err(Error::DelegatorFundsLocked) => continue,
-                        Err(err) => return Err(err),
-                    }
+                    let updated_stake =
+                        match delegator.decrease_stake(amount, era_end_timestamp_millis) {
+                            Ok(updated_stake) => updated_stake,
+                            // Work around the case when the locked amounts table has yet to be
+                            // initialized (likely pre-90 day mark).
+                            Err(Error::DelegatorFundsLocked) => continue,
+                            Err(err) => return Err(err),
+                        };
                     let delegator_bid_addr = BidAddr::new_from_public_keys(
                         validator_public_key,
                         Some(&delegator_public_key),
                     );
 
-                    debug!("pruning delegator bid {}", delegator_bid_addr);
-                    self.prune_bid(delegator_bid_addr)
+                    debug!(
+                        "forced undelegation for {} reducing {} by {} to {}",
+                        delegator_bid_addr, staked_amount, amount, updated_stake
+                    );
+
+                    // Keep the bid for now - it will get pruned when the unbonds are processed.
+                    self.write_bid(
+                        delegator_bid_addr.into(),
+                        BidKind::Delegator(Box::new(delegator)),
+                    )?;
                 }
             }
         }


### PR DESCRIPTION
If the network is set to a lazy migration of accounts instead of a one-time migration at upgrade, unbonds are failing because they attempt to read accounts in the migrated format, while they are still stored in the old format. This PR adds a lazy migration step when unbonds are processed.

The PR also brings forced unbonds (due to delegated amounts being outside the min/max boundaries set by the validator) to behave more in line with regular unbonds, ie. the delegators' bids aren't being removed immediately, they are only pruned when the unbonds are actually processed.

Closes #4801 