### PR TITLE
Fix issue with multiple balance holds in the same block.

### DIFF
--- a/storage/src/data_access_layer/balance_hold.rs
+++ b/storage/src/data_access_layer/balance_hold.rs
@@ -6,7 +6,7 @@ use casper_types::{
     account::AccountHash,
     execution::Effects,
     system::mint::{BalanceHoldAddr, BalanceHoldAddrTag},
-    Digest, ProtocolVersion, U512,
+    Digest, ProtocolVersion, StoredValue, U512,
 };
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
@@ -159,7 +159,8 @@ pub enum BalanceHoldError {
     TrackingCopy(TrackingCopyError),
     Balance(BalanceFailure),
     InsufficientBalance { remaining_balance: U512 },
-    UnexpectedWildcardVariant, // programmer error
+    UnexpectedWildcardVariant, // programmer error,
+    UnexpectedHoldValue(StoredValue),
 }
 
 impl From<BalanceFailure> for BalanceHoldError {
@@ -190,6 +191,9 @@ impl Display for BalanceHoldError {
                 )
             }
             BalanceHoldError::Balance(be) => Display::fmt(be, f),
+            BalanceHoldError::UnexpectedHoldValue(value) => {
+                write!(f, "Found an unexpected hold value in storage: {:?}", value,)
+            }
         }
     }
 }


### PR DESCRIPTION
When multiple transactions from the same initiator are included in the same block, balance holds created for gas should accumulate for all the transactions in that block.
We were previously overwriting the gas hold record in global state with the hold for the last transaction executed in the block for the corresponding purse.
We now add the hold amount to the record if it exists or create a new record with the hold if it doesn't.

Fixes: https://github.com/casper-network/casper-node/issues/4803
Adresses: https://github.com/casper-network/condor-info/issues/52