### PR TITLE
Bump rust-toolchain to 1.77.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,15 +1444,15 @@ checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5133,9 +5133,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -5180,9 +5180,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",

--- a/binary_port/src/binary_request.rs
+++ b/binary_port/src/binary_request.rs
@@ -243,7 +243,7 @@ impl TryFrom<u8> for BinaryRequestTag {
             0 => Ok(BinaryRequestTag::Get),
             1 => Ok(BinaryRequestTag::TryAcceptTransaction),
             2 => Ok(BinaryRequestTag::TrySpeculativeExec),
-            _ => Err(InvalidBinaryRequestTag(value)),
+            _ => Err(InvalidBinaryRequestTag),
         }
     }
 }
@@ -255,7 +255,7 @@ impl From<BinaryRequestTag> for u8 {
 }
 
 /// Error raised when trying to convert an invalid u8 into a `BinaryRequestTag`.
-pub struct InvalidBinaryRequestTag(u8);
+pub struct InvalidBinaryRequestTag;
 
 #[cfg(test)]
 mod tests {

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -809,7 +809,7 @@ where
         self.context.access_rights_extend(&urefs);
         {
             let transfers = self.context.transfers_mut();
-            *transfers = mint_runtime.context.transfers().to_owned();
+            mint_runtime.context.transfers().clone_into(transfers);
         }
         Ok(ret)
     }
@@ -888,7 +888,7 @@ where
         self.context.access_rights_extend(&urefs);
         {
             let transfers = self.context.transfers_mut();
-            *transfers = runtime.context.transfers().to_owned();
+            runtime.context.transfers().clone_into(transfers);
         }
         Ok(ret)
     }
@@ -1138,7 +1138,7 @@ where
         self.context.access_rights_extend(&urefs);
         {
             let transfers = self.context.transfers_mut();
-            *transfers = runtime.context.transfers().to_owned();
+            runtime.context.transfers().clone_into(transfers);
         }
 
         Ok(ret)
@@ -1622,7 +1622,7 @@ where
         self.context
             .set_emit_message_cost(runtime.context.emit_message_cost());
         let transfers = self.context.transfers_mut();
-        *transfers = runtime.context.transfers().to_owned();
+        runtime.context.transfers().clone_into(transfers);
 
         return match result {
             Ok(_) => {

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -1274,7 +1274,7 @@ where
                     "Contract".to_string(),
                     other.type_name(),
                 ))),
-                None => Err(Into::into(TrackingCopyError::KeyNotFound(key))),
+                None => Err(TrackingCopyError::KeyNotFound(key).into()),
             },
         }
     }

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -1274,7 +1274,7 @@ where
                     "Contract".to_string(),
                     other.type_name(),
                 ))),
-                None => Err(TrackingCopyError::KeyNotFound(key)).map_err(Into::into),
+                None => Err(Into::into(TrackingCopyError::KeyNotFound(key))),
             },
         }
     }

--- a/execution_engine_testing/tests/Cargo.toml
+++ b/execution_engine_testing/tests/Cargo.toml
@@ -9,7 +9,7 @@ base16 = "0.2.1"
 casper-engine-test-support = { path = "../test_support" }
 casper-execution-engine = { path = "../../execution_engine", features = ["test-support"] }
 casper-storage = { path = "../../storage" }
-casper-types = { path = "../../types", default_features = false, features = ["datasize", "json-schema"] }
+casper-types = { path = "../../types", default-features = false, features = ["datasize", "json-schema"] }
 casper-wasm = "0.46.0"
 clap = "2"
 fs_extra = "1.2.0"

--- a/execution_engine_testing/tests/src/test/check_transfer_success.rs
+++ b/execution_engine_testing/tests/src/test/check_transfer_success.rs
@@ -1,4 +1,3 @@
-use core::convert::TryFrom;
 use std::path::PathBuf;
 
 use casper_engine_test_support::{
@@ -39,7 +38,7 @@ fn test_check_transfer_success_with_source_only() {
     );
 
     // Doing a transfer from main purse to create new purse and store URef under NEW_PURSE_NAME.
-    let transfer_amount = U512::try_from(FIRST_TRANSFER_AMOUNT).expect("U512 from u64");
+    let transfer_amount = U512::from(FIRST_TRANSFER_AMOUNT);
     let path = PathBuf::from(TRANSFER_WASM);
     let session_args = runtime_args! {
         ARG_DESTINATION => NEW_PURSE_NAME,
@@ -100,9 +99,9 @@ fn test_check_transfer_success_with_source_only_errors() {
     );
 
     // Doing a transfer from main purse to create new purse and store Uref under NEW_PURSE_NAME.
-    let transfer_amount = U512::try_from(FIRST_TRANSFER_AMOUNT).expect("U512 from u64");
+    let transfer_amount = U512::from(FIRST_TRANSFER_AMOUNT);
     // Setup mismatch between transfer_amount performed and given to trigger assertion.
-    let wrong_transfer_amount = transfer_amount - U512::try_from(100u64).expect("U512 from 64");
+    let wrong_transfer_amount = transfer_amount - U512::from(100u64);
 
     let path = PathBuf::from(TRANSFER_WASM);
     let session_args = runtime_args! {
@@ -160,7 +159,7 @@ fn test_check_transfer_success_with_source_and_target() {
         DEFAULT_CHAINSPEC_REGISTRY.clone(),
     );
 
-    let transfer_amount = U512::try_from(SECOND_TRANSFER_AMOUNT).expect("U512 from u64");
+    let transfer_amount = U512::from(SECOND_TRANSFER_AMOUNT);
     // Doing a transfer from main purse to create new purse and store URef under NEW_PURSE_NAME.
     let path = PathBuf::from(TRANSFER_WASM);
     let session_args = runtime_args! {

--- a/execution_engine_testing/tests/src/test/contract_messages.rs
+++ b/execution_engine_testing/tests/src/test/contract_messages.rs
@@ -960,7 +960,7 @@ fn should_produce_per_block_message_ordering() {
                 .get_last_exec_result()
                 .unwrap()
                 .messages()
-                .get(0)
+                .first()
                 .unwrap()
                 .block_index(),
             expected_index

--- a/execution_engine_testing/tests/src/test/regression/ee_1120.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_1120.rs
@@ -311,9 +311,9 @@ fn should_run_ee_1120_slash_delegators() {
 
     let unbond_purses_after: UnbondingPurses = builder.get_unbonds();
     assert_ne!(unbond_purses_before, unbond_purses_after);
-    assert!(unbond_purses_after.get(&VALIDATOR_1_ADDR).is_none());
-    assert!(unbond_purses_after.get(&DELEGATOR_1_ADDR).is_some());
-    assert!(unbond_purses_after.get(&VALIDATOR_2_ADDR).is_some());
+    assert!(!unbond_purses_after.contains_key(&VALIDATOR_1_ADDR));
+    assert!(unbond_purses_after.contains_key(&DELEGATOR_1_ADDR));
+    assert!(unbond_purses_after.contains_key(&VALIDATOR_2_ADDR));
 
     // slash validator 1 to clear remaining bids and unbonding purses
     let slash_request_2 = ExecuteRequestBuilder::contract_call_by_hash(

--- a/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction_bidding.rs
@@ -171,7 +171,7 @@ fn should_run_successful_bond_and_unbond_and_slashing() {
     builder.exec(exec_request_5).expect_success().commit();
 
     let unbond_purses: UnbondingPurses = builder.get_unbonds();
-    assert!(unbond_purses.get(&*DEFAULT_ACCOUNT_ADDR).is_none());
+    assert!(!unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR));
 
     let bids = builder.get_bids();
     assert!(bids.validator_bid(&DEFAULT_ACCOUNT_PUBLIC_KEY).is_none());
@@ -460,7 +460,7 @@ fn should_run_successful_bond_and_unbond_with_release() {
     );
 
     let unbond_purses: UnbondingPurses = builder.get_unbonds();
-    assert!(unbond_purses.get(&*DEFAULT_ACCOUNT_ADDR).is_none());
+    assert!(!unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR));
 
     let bids = builder.get_bids();
     assert!(!bids.is_empty());
@@ -650,7 +650,7 @@ fn should_run_successful_unbond_funds_after_changing_unbonding_delay() {
     );
 
     let unbond_purses: UnbondingPurses = builder.get_unbonds();
-    assert!(unbond_purses.get(&*DEFAULT_ACCOUNT_ADDR).is_none());
+    assert!(!unbond_purses.contains_key(&*DEFAULT_ACCOUNT_ADDR));
 
     let bids = builder.get_bids();
     assert!(!bids.is_empty());

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -155,6 +155,7 @@ pub(crate) trait InitializedComponent<REv>: Component<REv> {
         self.state() == &ComponentState::Uninitialized
     }
 
+    #[allow(dead_code)]
     fn is_initialized(&self) -> bool {
         self.state() == &ComponentState::Initialized
     }

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -155,11 +155,6 @@ pub(crate) trait InitializedComponent<REv>: Component<REv> {
         self.state() == &ComponentState::Uninitialized
     }
 
-    #[allow(dead_code)]
-    fn is_initialized(&self) -> bool {
-        self.state() == &ComponentState::Initialized
-    }
-
     fn is_fatal(&self) -> bool {
         matches!(self.state(), ComponentState::Fatal(_))
     }

--- a/node/src/components/block_accumulator/tests.rs
+++ b/node/src/components/block_accumulator/tests.rs
@@ -2126,7 +2126,7 @@ async fn block_accumulator_doesnt_purge_with_delayed_block_execution() {
     // block can be delayed. Since we would purge an acceptor if the purge interval has passed,
     // we want to simulate a situation in which the purge interval was exceeded in order to test
     // the special case that if an acceptor that had sufficient finality, it is not purged.
-    tokio::time::sleep(
+    time::sleep(
         Duration::from(runner.reactor().block_accumulator.purge_interval) + Duration::from_secs(1),
     )
     .await;

--- a/node/src/components/block_synchronizer/execution_results_acquisition.rs
+++ b/node/src/components/block_synchronizer/execution_results_acquisition.rs
@@ -87,7 +87,7 @@ pub(crate) enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Error::BlockHashMismatch { expected, actual } => {
                 write!(

--- a/node/src/components/block_synchronizer/global_state_synchronizer.rs
+++ b/node/src/components/block_synchronizer/global_state_synchronizer.rs
@@ -118,7 +118,7 @@ pub(crate) enum Event {
         result: PutTrieResult,
     },
     #[from]
-    TrieAccumulatorEvent(TrieAccumulatorEvent),
+    TrieAccumulator(TrieAccumulatorEvent),
 }
 
 #[derive(Debug, DataSize)]
@@ -651,8 +651,8 @@ where
                 raw: trie_raw,
                 result: put_trie_result,
             } => self.handle_put_trie_result(trie_raw.hash(), put_trie_result, effect_builder),
-            Event::TrieAccumulatorEvent(event) => reactor::wrap_effects(
-                Event::TrieAccumulatorEvent,
+            Event::TrieAccumulator(event) => reactor::wrap_effects(
+                Event::TrieAccumulator,
                 self.trie_accumulator
                     .handle_event(effect_builder, rng, event),
             ),

--- a/node/src/components/block_synchronizer/signature_acquisition.rs
+++ b/node/src/components/block_synchronizer/signature_acquisition.rs
@@ -205,7 +205,7 @@ mod tests {
         );
 
         // Signature for the validator #0 weighting 1:
-        let (public_0, secret_0) = validators.get(0).unwrap();
+        let (public_0, secret_0) = validators.first().unwrap();
         let finality_signature = FinalitySignatureV2::create(
             block_hash,
             block_height,
@@ -427,7 +427,7 @@ mod tests {
         );
 
         // Set the validator #0 weighting 1 as pending:
-        let (public_0, secret_0) = validators.get(0).unwrap();
+        let (public_0, secret_0) = validators.first().unwrap();
         signature_acquisition.register_pending(public_0.clone());
         assert_iter_equal!(signature_acquisition.have_signatures(), []);
         assert_iter_equal!(signature_acquisition.not_vacant(), [public_0]);

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -42,21 +42,21 @@ const STRICT_FINALITY_REQUIRED_VERSION: ProtocolVersion = ProtocolVersion::from_
 /// Event for the mock reactor.
 #[derive(Debug, From)]
 enum MockReactorEvent {
-    MarkBlockCompletedRequest(MarkBlockCompletedRequest),
+    MarkBlockCompletedRequest(#[allow(dead_code)] MarkBlockCompletedRequest),
     BlockFetcherRequest(FetcherRequest<Block>),
     BlockHeaderFetcherRequest(FetcherRequest<BlockHeader>),
     LegacyDeployFetcherRequest(FetcherRequest<LegacyDeploy>),
     TransactionFetcherRequest(FetcherRequest<Transaction>),
     FinalitySignatureFetcherRequest(FetcherRequest<FinalitySignature>),
-    TrieOrChunkFetcherRequest(FetcherRequest<TrieOrChunk>),
+    TrieOrChunkFetcherRequest(#[allow(dead_code)] FetcherRequest<TrieOrChunk>),
     BlockExecutionResultsOrChunkFetcherRequest(FetcherRequest<BlockExecutionResultsOrChunk>),
-    SyncLeapFetcherRequest(FetcherRequest<SyncLeap>),
+    SyncLeapFetcherRequest(#[allow(dead_code)] FetcherRequest<SyncLeap>),
     ApprovalsHashesFetcherRequest(FetcherRequest<ApprovalsHashes>),
     NetworkInfoRequest(NetworkInfoRequest),
     BlockAccumulatorRequest(BlockAccumulatorRequest),
-    PeerBehaviorAnnouncement(PeerBehaviorAnnouncement),
+    PeerBehaviorAnnouncement(#[allow(dead_code)] PeerBehaviorAnnouncement),
     StorageRequest(StorageRequest),
-    TrieAccumulatorRequest(TrieAccumulatorRequest),
+    TrieAccumulatorRequest(#[allow(dead_code)] TrieAccumulatorRequest),
     ContractRuntimeRequest(ContractRuntimeRequest),
     SyncGlobalStateRequest(SyncGlobalStateRequest),
     MakeBlockExecutableRequest(MakeBlockExecutableRequest),
@@ -275,7 +275,7 @@ impl BlockSynchronizer {
             Arc::new(Chainspec::random(rng)),
             MAX_SIMULTANEOUS_PEERS,
             validator_matrix,
-            &prometheus::Registry::new(),
+            &Registry::new(),
         )
         .expect("Failed to create BlockSynchronizer");
 
@@ -2445,7 +2445,7 @@ async fn historical_sync_skips_exec_results_and_deploys_if_block_empty() {
         Event::GlobalStateSynced {
             block_hash: *block.hash(),
             result: Ok(GlobalStateSynchronizerResponse::new(
-                super::global_state_synchronizer::RootHash::new(*block.state_root_hash()),
+                global_state_synchronizer::RootHash::new(*block.state_root_hash()),
                 vec![],
             )),
         },
@@ -2552,7 +2552,7 @@ async fn historical_sync_no_legacy_block() {
         Event::GlobalStateSynced {
             block_hash: *block.hash(),
             result: Ok(GlobalStateSynchronizerResponse::new(
-                super::global_state_synchronizer::RootHash::new(*block.state_root_hash()),
+                global_state_synchronizer::RootHash::new(*block.state_root_hash()),
                 vec![],
             )),
         },
@@ -2780,7 +2780,7 @@ async fn historical_sync_legacy_block_strict_finality() {
         Event::GlobalStateSynced {
             block_hash: *block.hash(),
             result: Ok(GlobalStateSynchronizerResponse::new(
-                super::global_state_synchronizer::RootHash::new(*block.state_root_hash()),
+                global_state_synchronizer::RootHash::new(*block.state_root_hash()),
                 vec![],
             )),
         },
@@ -2982,7 +2982,7 @@ async fn historical_sync_legacy_block_weak_finality() {
         Event::GlobalStateSynced {
             block_hash: *block.hash(),
             result: Ok(GlobalStateSynchronizerResponse::new(
-                super::global_state_synchronizer::RootHash::new(*block.state_root_hash()),
+                global_state_synchronizer::RootHash::new(*block.state_root_hash()),
                 vec![],
             )),
         },
@@ -3195,7 +3195,7 @@ async fn historical_sync_legacy_block_any_finality() {
         Event::GlobalStateSynced {
             block_hash: *block.hash(),
             result: Ok(GlobalStateSynchronizerResponse::new(
-                super::global_state_synchronizer::RootHash::new(*block.state_root_hash()),
+                global_state_synchronizer::RootHash::new(*block.state_root_hash()),
                 vec![],
             )),
         },
@@ -3865,7 +3865,7 @@ async fn historical_sync_latch_should_not_decrement_for_old_deploy_fetch_respons
         Event::GlobalStateSynced {
             block_hash: *block.hash(),
             result: Ok(GlobalStateSynchronizerResponse::new(
-                super::global_state_synchronizer::RootHash::new(*block.state_root_hash()),
+                global_state_synchronizer::RootHash::new(*block.state_root_hash()),
                 vec![],
             )),
         },
@@ -4136,7 +4136,7 @@ async fn historical_sync_latch_should_not_decrement_for_old_execution_results() 
         Event::GlobalStateSynced {
             block_hash: *block.hash(),
             result: Ok(GlobalStateSynchronizerResponse::new(
-                super::global_state_synchronizer::RootHash::new(*block.state_root_hash()),
+                global_state_synchronizer::RootHash::new(*block.state_root_hash()),
                 vec![],
             )),
         },

--- a/node/src/components/block_synchronizer/trie_accumulator/tests.rs
+++ b/node/src/components/block_synchronizer/trie_accumulator/tests.rs
@@ -12,7 +12,7 @@ use futures::channel::oneshot;
 #[derive(Debug)]
 enum ReactorEvent {
     FetcherRequest(FetcherRequest<TrieOrChunk>),
-    PeerBehaviorAnnouncement(PeerBehaviorAnnouncement),
+    PeerBehaviorAnnouncement(#[allow(dead_code)] PeerBehaviorAnnouncement),
 }
 
 impl From<PeerBehaviorAnnouncement> for ReactorEvent {

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -38,7 +38,7 @@ enum ReactorEvent {
     #[from]
     Storage(StorageRequest),
     #[from]
-    FatalAnnouncement(FatalAnnouncement),
+    FatalAnnouncement(#[allow(dead_code)] FatalAnnouncement),
 }
 
 impl From<BlockValidationRequest> for ReactorEvent {
@@ -148,34 +148,13 @@ pub(super) fn new_proposed_block_with_cited_signatures(
     let block_context = BlockContext::new(timestamp, vec![]);
     let transactions = {
         let mut ret = BTreeMap::new();
-        ret.insert(
-            MINT_LANE_ID,
-            transfer
-                .into_iter()
-                .map(|(txn_hash, approvals)| (txn_hash, approvals))
-                .collect(),
-        );
-        ret.insert(
-            AUCTION_LANE_ID,
-            staking
-                .into_iter()
-                .map(|(txn_hash, approvals)| (txn_hash, approvals))
-                .collect(),
-        );
+        ret.insert(MINT_LANE_ID, transfer.into_iter().collect());
+        ret.insert(AUCTION_LANE_ID, staking.into_iter().collect());
         ret.insert(
             INSTALL_UPGRADE_LANE_ID,
-            install_upgrade
-                .into_iter()
-                .map(|(txn_hash, approvals)| (txn_hash, approvals))
-                .collect(),
+            install_upgrade.into_iter().collect(),
         );
-        ret.insert(
-            LARGE_LANE_ID,
-            standard
-                .into_iter()
-                .map(|(txn_hash, approvals)| (txn_hash, approvals))
-                .collect(),
-        );
+        ret.insert(LARGE_LANE_ID, standard.into_iter().collect());
         ret
     };
     let block_payload = BlockPayload::new(transactions, vec![], cited_signatures, true);

--- a/node/src/components/consensus.rs
+++ b/node/src/components/consensus.rs
@@ -183,7 +183,7 @@ pub(crate) enum Event {
 }
 
 impl Debug for ConsensusMessage {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ConsensusMessage::Protocol { era_id, payload: _ } => {
                 write!(f, "Protocol {{ era_id: {:?}, .. }}", era_id)
@@ -218,7 +218,7 @@ impl Display for ConsensusMessage {
 }
 
 impl Debug for ConsensusRequestMessage {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "ConsensusRequestMessage {{ era_id: {:?}, .. }}",

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -142,7 +142,7 @@ impl EraSupervisor {
         registry: &Registry,
     ) -> Result<Self, Error> {
         let unit_files_folder = storage_dir.join("unit_files");
-        std::fs::create_dir_all(&unit_files_folder)?;
+        fs::create_dir_all(&unit_files_folder)?;
         info!(our_id = %validator_matrix.public_signing_key(), "EraSupervisor pubkey",);
         let metrics = Metrics::new(registry)?;
 

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -71,7 +71,7 @@ enum HighwayMessage {
 }
 
 impl Debug for HighwayMessage {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             HighwayMessage::Timer(t) => f.debug_tuple("Timer").field(&t.millis()).finish(),
             HighwayMessage::RequestBlock(bc) => f
@@ -153,7 +153,7 @@ pub(crate) enum TestRunError {
 }
 
 impl Display for TestRunError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             TestRunError::NoMessages => write!(
                 f,
@@ -1024,7 +1024,7 @@ impl Debug for HashWrapper {
 }
 
 impl Display for HashWrapper {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(self, f)
     }
 }
@@ -1139,8 +1139,8 @@ mod test_harness {
                 (
                     v.finalized_values().cloned().collect::<Vec<_>>(),
                     v.messages_produced()
+                        .filter(|&hwm| hwm.is_new_unit())
                         .cloned()
-                        .filter(|hwm| hwm.is_new_unit())
                         .count(),
                 )
             })

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -48,7 +48,7 @@ where
         highway_testing::TEST_ENDORSEMENT_EVIDENCE_LIMIT,
     );
     let weights = weights.into_iter().map(|w| w.into()).collect::<Vec<_>>();
-    state::State::new(weights, params, vec![], vec![])
+    State::new(weights, params, vec![], vec![])
 }
 
 const INSTANCE_ID_DATA: &[u8; 1] = &[123u8; 1];

--- a/node/src/components/consensus/protocols/zug/des_testing.rs
+++ b/node/src/components/consensus/protocols/zug/des_testing.rs
@@ -166,7 +166,7 @@ pub(crate) enum TestRunError {
 }
 
 impl Display for TestRunError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             TestRunError::NoMessages => write!(
                 f,
@@ -999,7 +999,7 @@ impl Debug for HashWrapper {
 }
 
 impl Display for HashWrapper {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(self, f)
     }
 }
@@ -1112,8 +1112,8 @@ mod test_harness {
                 (
                     v.finalized_values().cloned().collect::<Vec<_>>(),
                     v.messages_produced()
+                        .filter(|&zm| zm.is_signed_gossip_message() || zm.is_proposal())
                         .cloned()
-                        .filter(|zm| zm.is_signed_gossip_message() || zm.is_proposal())
                         .count(),
                 )
             })

--- a/node/src/components/consensus/protocols/zug/wal.rs
+++ b/node/src/components/consensus/protocols/zug/wal.rs
@@ -115,7 +115,7 @@ impl<C: Context> ReadWal<C> {
     pub(crate) fn new(wal_path: &PathBuf) -> Result<Self, ReadWalError> {
         let file = OpenOptions::new()
             .create(true)
-            .truncate(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(wal_path)

--- a/node/src/components/consensus/protocols/zug/wal.rs
+++ b/node/src/components/consensus/protocols/zug/wal.rs
@@ -115,6 +115,7 @@ impl<C: Context> ReadWal<C> {
     pub(crate) fn new(wal_path: &PathBuf) -> Result<Self, ReadWalError> {
         let file = OpenOptions::new()
             .create(true)
+            .truncate(true)
             .read(true)
             .write(true)
             .open(wal_path)

--- a/node/src/components/contract_runtime/exec_queue.rs
+++ b/node/src/components/contract_runtime/exec_queue.rs
@@ -44,7 +44,7 @@ impl ExecQueue {
 
         *locked_queue = locked_queue.split_off(&height);
 
-        core::convert::TryInto::try_into(locked_queue.len()).unwrap_or(i64::MIN)
+        TryInto::try_into(locked_queue.len()).unwrap_or(i64::MIN)
     }
 }
 

--- a/node/src/components/contract_runtime/utils.rs
+++ b/node/src/components/contract_runtime/utils.rs
@@ -243,12 +243,7 @@ pub(super) async fn exec_or_requeue<REv>(
         None
     };
 
-    let BlockAndExecutionArtifacts {
-        block,
-        approvals_hashes,
-        execution_artifacts,
-        step_outcome: maybe_step_outcome,
-    } = match run_intensive_task(move || {
+    let task = move || {
         debug!("ContractRuntime: execute_finalized_block");
         execute_finalized_block(
             data_access_layer.as_ref(),
@@ -262,9 +257,13 @@ pub(super) async fn exec_or_requeue<REv>(
             maybe_next_era_gas_price,
             last_switch_block_hash,
         )
-    })
-    .await
-    {
+    };
+    let BlockAndExecutionArtifacts {
+        block,
+        approvals_hashes,
+        execution_artifacts,
+        step_outcome: maybe_step_outcome,
+    } = match run_intensive_task(task).await {
         Ok(ret) => ret,
         Err(error) => {
             error!(%error, "failed to execute block");

--- a/node/src/components/diagnostics_port/tasks.rs
+++ b/node/src/components/diagnostics_port/tasks.rs
@@ -395,7 +395,7 @@ impl Session {
         let tempdir = tempfile::tempdir().map_err(ObtainDumpError::CreateTempDir)?;
         let tempfile_path = tempdir.path().join("queue-dump");
 
-        let tempfile = fs::File::create(&tempfile_path).map_err(ObtainDumpError::CreateTempFile)?;
+        let tempfile = File::create(&tempfile_path).map_err(ObtainDumpError::CreateTempFile)?;
 
         effect_builder
             .diagnostics_port_dump_queue(self.create_queue_dump_format(tempfile))
@@ -403,7 +403,7 @@ impl Session {
 
         // We can now reopen the file and return it.
         let reopened_tempfile =
-            fs::File::open(tempfile_path).map_err(ObtainDumpError::ReopenTempFile)?;
+            File::open(tempfile_path).map_err(ObtainDumpError::ReopenTempFile)?;
         Ok(reopened_tempfile)
     }
 

--- a/node/src/components/gossiper/gossip_table.rs
+++ b/node/src/components/gossiper/gossip_table.rs
@@ -673,14 +673,14 @@ mod tests {
 
         // Check same complete data from other source causes `Noop` to be returned since we still
         // have all gossip requests in flight.  Check it updates holders.
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[0]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[0]));
         let action = gossip_table.new_complete_data(&data_id, Some(node_ids[0]), GossipTarget::All);
         assert_eq!(GossipAction::Noop, action);
         check_holders(&node_ids[..1], &gossip_table, &data_id);
 
         // Check receiving a gossip response, causes `ShouldGossip` to be returned and holders
         // updated.
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[1]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[1]));
         let action = gossip_table.already_infected(&data_id, node_ids[1]);
         let expected = GossipAction::ShouldGossip(ShouldGossip {
             count: 1,
@@ -691,7 +691,7 @@ mod tests {
         assert_eq!(expected, action);
         check_holders(&node_ids[..2], &gossip_table, &data_id);
 
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[2]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[2]));
         let action = gossip_table.new_complete_data(&data_id, Some(node_ids[2]), GossipTarget::All);
         assert_eq!(GossipAction::Noop, action);
         check_holders(&node_ids[..3], &gossip_table, &data_id);
@@ -700,7 +700,7 @@ mod tests {
         // causes `Noop` to be returned and holders cleared.
         let limit = 3 + EXPECTED_DEFAULT_INFECTION_TARGET;
         for node_id in &node_ids[3..limit] {
-            gossip_table.register_infection_attempt(&data_id, std::iter::once(node_id));
+            gossip_table.register_infection_attempt(&data_id, iter::once(node_id));
             let _ = gossip_table.we_infected(&data_id, *node_id);
         }
         let action = gossip_table.new_complete_data(&data_id, None, GossipTarget::All);
@@ -739,7 +739,7 @@ mod tests {
         let _ = gossip_table.new_complete_data(&data_id, None, GossipTarget::All);
         let limit = EXPECTED_DEFAULT_INFECTION_TARGET - 1;
         for node_id in node_ids.iter().take(limit) {
-            gossip_table.register_infection_attempt(&data_id, std::iter::once(node_id));
+            gossip_table.register_infection_attempt(&data_id, iter::once(node_id));
             let action = gossip_table.we_infected(&data_id, *node_id);
             assert_eq!(GossipAction::Noop, action);
             assert!(!gossip_table.finished.contains(&data_id));
@@ -747,7 +747,7 @@ mod tests {
 
         // Check recording an infection from an already-recorded infectee doesn't cause us to stop
         // gossiping.
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[limit - 1]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[limit - 1]));
         let action = gossip_table.we_infected(&data_id, node_ids[limit - 1]);
         let expected = GossipAction::ShouldGossip(ShouldGossip {
             count: 1,
@@ -759,7 +759,7 @@ mod tests {
         assert!(!gossip_table.finished.contains(&data_id));
 
         // Check third new infection does cause us to stop gossiping.
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[limit]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[limit]));
         let action = gossip_table.we_infected(&data_id, node_ids[limit]);
         assert_eq!(GossipAction::AnnounceFinished, action);
         assert!(gossip_table.finished.contains(&data_id));
@@ -818,7 +818,7 @@ mod tests {
         let limit = EXPECTED_DEFAULT_ATTEMPTED_TO_INFECT_LIMIT - 1;
         for node_id in node_ids.iter().take(limit) {
             let _ = gossip_table.new_complete_data(&data_id, Some(*node_id), GossipTarget::All);
-            gossip_table.register_infection_attempt(&data_id, std::iter::once(node_id));
+            gossip_table.register_infection_attempt(&data_id, iter::once(node_id));
             assert!(!gossip_table.finished.contains(&data_id));
         }
 
@@ -826,7 +826,7 @@ mod tests {
         // `finished` collection.
         gossip_table.register_infection_attempt(
             &data_id,
-            std::iter::once(&node_ids[EXPECTED_DEFAULT_ATTEMPTED_TO_INFECT_LIMIT]),
+            iter::once(&node_ids[EXPECTED_DEFAULT_ATTEMPTED_TO_INFECT_LIMIT]),
         );
         let action = gossip_table.check_timeout(
             &data_id,
@@ -875,7 +875,7 @@ mod tests {
         let _ = gossip_table.new_complete_data(&data_id, None, GossipTarget::All);
         let limit = EXPECTED_DEFAULT_ATTEMPTED_TO_INFECT_LIMIT - 1;
         for (index, node_id) in node_ids.iter().enumerate().take(limit) {
-            gossip_table.register_infection_attempt(&data_id, std::iter::once(node_id));
+            gossip_table.register_infection_attempt(&data_id, iter::once(node_id));
             let action = gossip_table.already_infected(&data_id, *node_id);
             let expected = GossipAction::ShouldGossip(ShouldGossip {
                 count: 1,
@@ -888,7 +888,7 @@ mod tests {
 
         // Check recording a non-infection from an already-recorded holder doesn't cause us to stop
         // gossiping.
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[0]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[0]));
         let action = gossip_table.already_infected(&data_id, node_ids[0]);
         let expected = GossipAction::ShouldGossip(ShouldGossip {
             count: 1,
@@ -899,7 +899,7 @@ mod tests {
         assert_eq!(expected, action);
 
         // Check 15th non-infection does cause us to stop gossiping.
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[limit]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[limit]));
         let action = gossip_table.we_infected(&data_id, node_ids[limit]);
         assert_eq!(GossipAction::AnnounceFinished, action);
     }
@@ -917,19 +917,19 @@ mod tests {
         let _ = gossip_table.new_complete_data(&data_id, None, GossipTarget::All);
         let infection_limit = EXPECTED_DEFAULT_INFECTION_TARGET - 1;
         for node_id in &node_ids[0..infection_limit] {
-            gossip_table.register_infection_attempt(&data_id, std::iter::once(node_id));
+            gossip_table.register_infection_attempt(&data_id, iter::once(node_id));
             let _ = gossip_table.we_infected(&data_id, *node_id);
         }
 
         let attempted_to_infect = EXPECTED_DEFAULT_ATTEMPTED_TO_INFECT_LIMIT - 2;
         for node_id in &node_ids[infection_limit..attempted_to_infect] {
-            gossip_table.register_infection_attempt(&data_id, std::iter::once(node_id));
+            gossip_table.register_infection_attempt(&data_id, iter::once(node_id));
             let _ = gossip_table.already_infected(&data_id, *node_id);
         }
 
         // Check adding 12th non-infection doesn't cause us to stop gossiping.
         gossip_table
-            .register_infection_attempt(&data_id, std::iter::once(&node_ids[attempted_to_infect]));
+            .register_infection_attempt(&data_id, iter::once(&node_ids[attempted_to_infect]));
         let action = gossip_table.already_infected(&data_id, node_ids[attempted_to_infect]);
         let expected = GossipAction::ShouldGossip(ShouldGossip {
             count: 1,
@@ -958,11 +958,11 @@ mod tests {
 
         // check_timeout for node 0 should return Noop, and for node 1 it should represent a timed
         // out response and return ShouldGossip.
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[0]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[0]));
         let action = gossip_table.check_timeout(&data_id, node_ids[0]);
         assert_eq!(GossipAction::Noop, action);
 
-        gossip_table.register_infection_attempt(&data_id, std::iter::once(&node_ids[1]));
+        gossip_table.register_infection_attempt(&data_id, iter::once(&node_ids[1]));
         let action = gossip_table.check_timeout(&data_id, node_ids[1]);
         let expected = GossipAction::ShouldGossip(ShouldGossip {
             count: 1,

--- a/node/src/components/storage/object_pool.rs
+++ b/node/src/components/storage/object_pool.rs
@@ -101,10 +101,10 @@ where
     }
 
     /// Retrieves an object from the pool, if present.
-    pub(super) fn get<Q: ?Sized>(&self, id: &Q) -> Option<Arc<[u8]>>
+    pub(super) fn get<Q>(&self, id: &Q) -> Option<Arc<[u8]>>
     where
         I: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.items.get(id).and_then(Weak::upgrade)
     }

--- a/node/src/components/storage/tests.rs
+++ b/node/src/components/storage/tests.rs
@@ -2278,7 +2278,7 @@ fn check_force_resync_with_marker_file() {
     );
     drop(storage);
     // Remove the marker file.
-    std::fs::remove_file(&force_resync_file_path).unwrap();
+    fs::remove_file(&force_resync_file_path).unwrap();
     assert!(!force_resync_file_path.exists());
 
     // Reinitialize storage with force resync enabled.

--- a/node/src/components/sync_leaper/leap_activity.rs
+++ b/node/src/components/sync_leaper/leap_activity.rs
@@ -216,7 +216,7 @@ mod tests {
         let (actual_sync_leap, actual_peers) = leap_activity.best_response().unwrap();
 
         assert!(!actual_peers.is_empty());
-        assert_eq!(actual_peers.get(0).unwrap(), &peer_1.0);
+        assert_eq!(actual_peers.first().unwrap(), &peer_1.0);
         assert_eq!(actual_sync_leap, sync_leap);
 
         // Adding peers in other states does not change the result.
@@ -232,7 +232,7 @@ mod tests {
         let (actual_sync_leap, actual_peers) = leap_activity.best_response().unwrap();
 
         assert_eq!(actual_peers.len(), 1);
-        assert_eq!(actual_peers.get(0).unwrap(), &peer_1.0);
+        assert_eq!(actual_peers.first().unwrap(), &peer_1.0);
         assert_eq!(actual_sync_leap, sync_leap);
     }
 
@@ -276,7 +276,7 @@ mod tests {
 
         // Expect only a single peer with the best sync leap.
         assert_eq!(actual_peers.len(), 1);
-        assert_eq!(actual_peers.get(0).unwrap(), &peer_1_best_node_id);
+        assert_eq!(actual_peers.first().unwrap(), &peer_1_best_node_id);
         assert_eq!(actual_sync_leap, best_sync_leap);
 
         // Add two more peers with even better response.

--- a/node/src/components/transaction_buffer/tests.rs
+++ b/node/src/components/transaction_buffer/tests.rs
@@ -368,7 +368,7 @@ fn get_appendable_block_when_transfers_are_of_one_category() {
     get_appendable_block(
         &mut rng,
         &mut transaction_buffer,
-        std::iter::repeat_with(|| MINT_LANE_ID),
+        iter::repeat_with(|| MINT_LANE_ID),
         transaction_config
             .transaction_v1_config
             .get_max_transaction_count(MINT_LANE_ID) as usize
@@ -439,7 +439,7 @@ fn get_appendable_block_when_standards_are_of_one_category() {
     get_appendable_block(
         &mut rng,
         &mut transaction_buffer,
-        std::iter::repeat_with(|| large_lane_id),
+        iter::repeat_with(|| large_lane_id),
         transaction_config
             .transaction_v1_config
             .get_max_transaction_count(large_lane_id) as usize
@@ -828,12 +828,12 @@ fn register_transactions_and_blocks() {
     // try to register held transactions again.
     let mut held_transactions = valid_transactions
         .iter()
-        .cloned()
-        .filter(|transaction| {
+        .filter(|&transaction| {
             appendable_block
                 .transaction_hashes()
                 .contains(&transaction.hash())
         })
+        .cloned()
         .peekable();
     assert!(held_transactions.peek().is_some());
     held_transactions.for_each(|transaction| transaction_buffer.register_transaction(transaction));
@@ -847,7 +847,7 @@ fn register_transactions_and_blocks() {
     // test if transactions held for proposed blocks which did not get finalized in time
     // are eligible again
     let count = rng.gen_range(1..11);
-    let txns: Vec<_> = std::iter::repeat_with(|| Transaction::Deploy(Deploy::random(&mut rng)))
+    let txns: Vec<_> = iter::repeat_with(|| Transaction::Deploy(Deploy::random(&mut rng)))
         .take(count)
         .collect();
     let block = FinalizedBlock::random_with_specifics(
@@ -871,7 +871,7 @@ fn register_transactions_and_blocks() {
 #[derive(Debug)]
 enum ReactorEvent {
     TransactionBufferAnnouncement(TransactionBufferAnnouncement),
-    Event(Event),
+    Event(#[allow(dead_code)] Event),
 }
 
 impl From<TransactionBufferAnnouncement> for ReactorEvent {
@@ -1401,7 +1401,7 @@ fn register_random_deploys_unique_hashes(
     num_deploys: usize,
     rng: &mut TestRng,
 ) {
-    let deploys = std::iter::repeat_with(|| {
+    let deploys = iter::repeat_with(|| {
         let name = format!("{}", rng.gen::<u64>());
         let call = format!("{}", rng.gen::<u64>());
         Deploy::random_contract_by_name(
@@ -1424,7 +1424,7 @@ fn register_random_deploys_same_hash(
     num_deploys: usize,
     rng: &mut TestRng,
 ) {
-    let deploys = std::iter::repeat_with(|| {
+    let deploys = iter::repeat_with(|| {
         let name = "test".to_owned();
         let call = "test".to_owned();
         Deploy::random_contract_by_name(

--- a/node/src/components/upgrade_watcher.rs
+++ b/node/src/components/upgrade_watcher.rs
@@ -329,7 +329,7 @@ struct UpgradePoint {
 
 impl UpgradePoint {
     /// Parses a chainspec file at the given path as an `UpgradePoint`.
-    fn from_chainspec_path<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Result<Self, Error> {
+    fn from_chainspec_path<P: AsRef<Path> + fmt::Debug>(path: P) -> Result<Self, Error> {
         let bytes = file_utils::read_file(path.as_ref().join(CHAINSPEC_FILENAME))
             .map_err(Error::LoadUpgradePoint)?;
         Ok(toml::from_str(std::str::from_utf8(&bytes).unwrap())?)
@@ -349,8 +349,7 @@ fn next_installed_version(
     dir: &Path,
     current_version: ProtocolVersion,
 ) -> Result<ProtocolVersion, Error> {
-    let max_version =
-        ProtocolVersion::from_parts(u32::max_value(), u32::max_value(), u32::max_value());
+    let max_version = ProtocolVersion::from_parts(u32::MAX, u32::MAX, u32::MAX);
 
     let mut next_version = max_version;
     let mut read_version = false;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -145,10 +145,7 @@ mod tests {
         let (version, sha) = prefix.split_once('-').unwrap_or((prefix, ""));
 
         assert_eq!(version, env!("CARGO_PKG_VERSION"));
-        assert_eq!(
-            sha,
-            std::env::var("NODE_GIT_SHA").unwrap_or_default().as_str()
-        );
+        assert_eq!(sha, env::var("NODE_GIT_SHA").unwrap_or_default().as_str());
         if env!("NODE_BUILD_PROFILE") == "release" {
             assert_eq!(profile, "");
         } else {
@@ -163,10 +160,7 @@ mod tests {
         let (version, sha) = prefix.split_once('-').unwrap_or((prefix, ""));
 
         assert_eq!(version, env!("CARGO_PKG_VERSION"));
-        assert_eq!(
-            sha,
-            std::env::var("NODE_GIT_SHA").unwrap_or_default().as_str()
-        );
+        assert_eq!(sha, env::var("NODE_GIT_SHA").unwrap_or_default().as_str());
         if env!("NODE_BUILD_PROFILE") == "release" {
             assert_eq!(profile, "");
         } else {

--- a/node/src/logging.rs
+++ b/node/src/logging.rs
@@ -311,12 +311,12 @@ pub fn display_global_env_filter() -> anyhow::Result<String> {
 }
 
 /// Type alias for the formatting function used.
-pub type FormatDebugFn = fn(&mut Writer, &Field, &dyn std::fmt::Debug) -> fmt::Result;
+pub type FormatDebugFn = fn(&mut Writer, &Field, &dyn fmt::Debug) -> fmt::Result;
 
 fn format_into_debug_writer(
     writer: &mut Writer,
     field: &Field,
-    value: &dyn std::fmt::Debug,
+    value: &dyn fmt::Debug,
 ) -> fmt::Result {
     match field.name() {
         LOG_FIELD_MESSAGE => write!(writer, "{:?}", value),
@@ -346,7 +346,7 @@ pub fn init_with_config(config: &LoggingConfig) -> anyhow::Result<()> {
         // Setup a new tracing-subscriber writing to `stdout` for logging.
         LoggingFormat::Text => {
             let builder = tracing_subscriber::fmt()
-                .with_writer(io::stdout as fn() -> std::io::Stdout)
+                .with_writer(io::stdout as fn() -> io::Stdout)
                 .with_env_filter(filter)
                 .fmt_fields(formatter)
                 .event_format(FmtEvent::new(config.color, config.abbreviate_modules))
@@ -360,7 +360,7 @@ pub fn init_with_config(config: &LoggingConfig) -> anyhow::Result<()> {
         // JSON logging writes to `stdout` as well but uses the JSON format.
         LoggingFormat::Json => {
             let builder = tracing_subscriber::fmt()
-                .with_writer(io::stdout as fn() -> std::io::Stdout)
+                .with_writer(io::stdout as fn() -> io::Stdout)
                 .with_env_filter(filter)
                 .json()
                 .with_filter_reloading();

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -117,7 +117,7 @@ impl MainReactor {
                 match self
                     .storage
                     .read_highest_switch_block_headers(1)
-                    .map(|headers| headers.get(0).cloned())
+                    .map(|headers| headers.first().cloned())
                 {
                     Ok(Some(_)) => {
                         // no trusted hash, no local block, no error, must be waiting for genesis

--- a/node/src/reactor/main_reactor/event.rs
+++ b/node/src/reactor/main_reactor/event.rs
@@ -562,7 +562,7 @@ impl From<SyncGlobalStateRequest> for MainEvent {
 impl From<TrieAccumulatorRequest> for MainEvent {
     fn from(request: TrieAccumulatorRequest) -> Self {
         MainEvent::BlockSynchronizer(block_synchronizer::Event::GlobalStateSynchronizer(
-            block_synchronizer::GlobalStateSynchronizerEvent::TrieAccumulatorEvent(request.into()),
+            GlobalStateSynchronizerEvent::TrieAccumulator(request.into()),
         ))
     }
 }

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -364,7 +364,7 @@ pub(crate) enum UnitTestEvent {
     FatalAnnouncement(FatalAnnouncement),
     /// A network request made by the component under test.
     #[from]
-    NetworkRequest(NetworkRequest<Message>),
+    NetworkRequest(#[allow(dead_code)] NetworkRequest<Message>),
 }
 
 impl ReactorEvent for UnitTestEvent {

--- a/node/src/tls.rs
+++ b/node/src/tls.rs
@@ -710,7 +710,7 @@ fn generate_private_key() -> SslResult<PKey<Private>> {
     // TODO: Please verify this for accuracy!
 
     let ec_group = ec::EcGroup::from_curve_name(SIGNATURE_CURVE)?;
-    let ec_key = ec::EcKey::generate(ec_group.as_ref())?;
+    let ec_key = EcKey::generate(ec_group.as_ref())?;
 
     PKey::from_ec_key(ec_key)
 }

--- a/node/src/types/exit_code.rs
+++ b/node/src/types/exit_code.rs
@@ -11,6 +11,7 @@ const SIGNAL_OFFSET: u8 = 128;
 /// Note that a panic will result in the Rust process producing an exit code of 101.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, DataSize)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum ExitCode {
     /// The process should exit with success.  The launcher should proceed to run the next
     /// installed version of `casper-node`.
@@ -18,11 +19,6 @@ pub enum ExitCode {
     /// The process should exit with `101`, equivalent to panicking.  The launcher should not
     /// restart the node.
     Abort = 101,
-    /// The process should exit with `102`.  It used to be an indication to the launcher
-    /// that it should proceed to run the previous installed version of `casper-node`.
-    /// It is no longer used, but we keep it here to avoid it being reassigned to other features.
-    #[doc(hidden)]
-    DowngradeVersion = 102,
     /// The process should exit with `103`.  The user requested a node shut down without restart.
     CleanExitDontRestart = 103,
     /// The exit code Rust uses by default when interrupted via an `INT` signal.

--- a/node/src/types/exit_code.rs
+++ b/node/src/types/exit_code.rs
@@ -19,6 +19,11 @@ pub enum ExitCode {
     /// The process should exit with `101`, equivalent to panicking.  The launcher should not
     /// restart the node.
     Abort = 101,
+    /// The process should exit with `102`.  It used to be an indication to the launcher
+    /// that it should proceed to run the previous installed version of `casper-node`.
+    /// It is no longer used, but we keep it here to avoid it being reassigned to other features.
+    #[doc(hidden)]
+    DowngradeVersion = 102,
     /// The process should exit with `103`.  The user requested a node shut down without restart.
     CleanExitDontRestart = 103,
     /// The exit code Rust uses by default when interrupted via an `INT` signal.

--- a/node/src/types/sync_leap.rs
+++ b/node/src/types/sync_leap.rs
@@ -84,7 +84,7 @@ impl SyncLeapIdentifier {
 }
 
 impl Display for SyncLeapIdentifier {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{} trusted_ancestor_only: {}",

--- a/node/src/utils/specimen.rs
+++ b/node/src/utils/specimen.rs
@@ -60,7 +60,7 @@ impl Cache {
     /// Retrieves a potentially memoized instance.
     pub(crate) fn get<T: Any>(&mut self) -> Option<&T> {
         self.get_all::<T>()
-            .get(0)
+            .first()
             .map(|box_any| box_any.downcast_ref::<T>().expect("cache corrupted"))
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.77.2"

--- a/storage/src/block_store/lmdb/lmdb_ext.rs
+++ b/storage/src/block_store/lmdb/lmdb_ext.rs
@@ -13,7 +13,9 @@
 use std::{any::TypeId, collections::BTreeSet};
 
 use lmdb::{Database, RwTransaction, Transaction, WriteFlags};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
+#[cfg(test)]
+use serde::Serialize;
 use thiserror::Error;
 use tracing::warn;
 
@@ -121,6 +123,7 @@ pub(super) trait WriteTransactionExt {
     /// Returns `true` if the value has actually been written, `false` if the key already existed.
     ///
     /// Setting `overwrite` to true will cause the value to always be written instead.
+    #[cfg(test)]
     fn put_value<K: AsRef<[u8]>, V: 'static + Serialize>(
         &mut self,
         db: Database,
@@ -206,6 +209,7 @@ where
 /// function to provide compatibility with the legacy version of the `UnbondingPurse` struct.
 /// See [`serialize_unbonding_purse`] for more details.
 // TODO: Get rid of the 'static bound.
+#[cfg(test)]
 pub(crate) fn serialize_internal<V: 'static + Serialize>(
     value: &V,
 ) -> Result<Vec<u8>, LmdbExtError> {
@@ -232,6 +236,7 @@ pub(crate) fn deserialize_internal<V: 'static + DeserializeOwned>(
 }
 
 impl WriteTransactionExt for RwTransaction<'_> {
+    #[cfg(test)]
     fn put_value<K: AsRef<[u8]>, V: 'static + Serialize>(
         &mut self,
         db: Database,
@@ -343,6 +348,7 @@ pub(super) fn deserialize_unbonding_purse<T: DeserializeOwned + 'static>(
 }
 
 /// Serializes into a buffer.
+#[cfg(test)]
 #[inline(always)]
 pub(super) fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, LmdbExtError> {
     bincode::serialize(value).map_err(|err| LmdbExtError::Other(Box::new(err)))
@@ -352,6 +358,7 @@ pub(super) fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, LmdbExtError
 /// To provide backward compatibility with the previous version of the `UnbondingPurse`,
 /// the serialized bytes are prefixed with the "magic bytes", which will be used by the
 /// deserialization routine to detect the version of the `UnbondingPurse` struct.
+#[cfg(test)]
 #[inline(always)]
 pub(super) fn serialize_unbonding_purse<T: Serialize>(value: &T) -> Result<Vec<u8>, LmdbExtError> {
     let mut serialized = UNBONDING_PURSE_V2_MAGIC_BYTES.to_vec();

--- a/storage/src/data_access_layer/genesis.rs
+++ b/storage/src/data_access_layer/genesis.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -53,6 +54,7 @@ impl GenesisRequest {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
 impl Distribution<GenesisRequest> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> GenesisRequest {
         let input: [u8; 32] = rng.gen();

--- a/storage/src/global_state/trie_store/operations/tests/prune.rs
+++ b/storage/src/global_state/trie_store/operations/tests/prune.rs
@@ -344,8 +344,8 @@ mod full_tries {
         let pairs_to_insert_less_pruned: Vec<(K, V)> = pairs_to_insert
             .iter()
             .rev()
+            .filter(|&(key, _value)| !keys_to_prune.contains(key))
             .cloned()
-            .filter(|(key, _value)| !keys_to_prune.contains(key))
             .collect();
 
         let mut actual_root = *root;

--- a/storage/src/system/handle_payment/handle_payment_native.rs
+++ b/storage/src/system/handle_payment/handle_payment_native.rs
@@ -20,8 +20,6 @@ use casper_types::{
 use std::collections::BTreeSet;
 use tracing::error;
 
-pub use casper_types::system::handle_payment::Error as HandlePaymentError;
-
 impl<S> MintProvider for RuntimeNative<S>
 where
     S: StateReader<Key, StoredValue, Error = GlobalStateError>,

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -226,7 +226,7 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
 
     /// Gets value from `key` in the cache.
     pub fn get(&mut self, key: &Key) -> Option<&StoredValue> {
-        if self.prunes_cached.get(key).is_some() {
+        if self.prunes_cached.contains(key) {
             // the item is marked for pruning and therefore
             // is no longer accessible.
             return None;

--- a/types/src/account/error.rs
+++ b/types/src/account/error.rs
@@ -38,6 +38,3 @@ impl Display for FromStrError {
         }
     }
 }
-/// Associated error type of `TryFrom<&[u8]>` for [`AccountHash`](super::AccountHash).
-#[derive(Debug)]
-pub struct TryFromSliceForAccountHashError(());

--- a/types/src/block/rewarded_signatures.rs
+++ b/types/src/block/rewarded_signatures.rs
@@ -322,6 +322,18 @@ fn chunks_8(bits: impl Iterator<Item = u8>) -> impl Iterator<Item = impl Iterato
     Chunks(bits)
 }
 
+#[cfg(any(feature = "testing", test))]
+impl SingleBlockRewardedSignatures {
+    /// Returns random data.
+    pub fn random(rng: &mut crate::testing::TestRng, n_validators: usize) -> Self {
+        let mut bytes = vec![0; (n_validators + 7) / 8];
+
+        rand::RngCore::fill_bytes(rng, bytes.as_mut());
+
+        SingleBlockRewardedSignatures(bytes)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{chunks_8, SingleBlockRewardedSignatures};
@@ -458,17 +470,5 @@ mod tests {
         assert_eq!(v(chunks.next()), Some(vec![10, 11, 12, 13, 14, 15, 16, 17]));
         assert_eq!(v(chunks.next()), Some(vec![18, 19, 20, 21, 22, 23, 24, 25]));
         assert_eq!(v(chunks.next()), Some(vec![26]));
-    }
-}
-
-#[cfg(any(feature = "testing", test))]
-impl SingleBlockRewardedSignatures {
-    /// Returns random data.
-    pub fn random(rng: &mut crate::testing::TestRng, n_validators: usize) -> Self {
-        let mut bytes = vec![0; (n_validators + 7) / 8];
-
-        rand::RngCore::fill_bytes(rng, bytes.as_mut());
-
-        SingleBlockRewardedSignatures(bytes)
     }
 }

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -101,10 +101,10 @@ pub fn unchecked_allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Vec<u8> {
 }
 
 /// Returns a `Vec<u8>` initialized with sufficient capacity to hold `to_be_serialized` after
-/// serialization, or an error if the capacity would exceed `u32::max_value()`.
+/// serialization, or an error if the capacity would exceed `u32::MAX`.
 pub fn allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Result<Vec<u8>, Error> {
     let serialized_length = to_be_serialized.serialized_length();
-    if serialized_length > u32::max_value() as usize {
+    if serialized_length > u32::MAX as usize {
         return Err(Error::OutOfMemory);
     }
     Ok(Vec::with_capacity(serialized_length))
@@ -1684,7 +1684,7 @@ mod proptests {
             bytesrepr::test_serialization_roundtrip(&t);
         }
         #[test]
-        fn test_ratio_u64(t in (any::<u64>(), 1..u64::max_value())) {
+        fn test_ratio_u64(t in (any::<u64>(), 1..u64::MAX)) {
             bytesrepr::test_serialization_roundtrip(&t);
         }
     }

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -44,15 +44,14 @@ pub use activation_point::ActivationPoint;
 pub use chainspec_raw_bytes::ChainspecRawBytes;
 #[cfg(any(feature = "testing", test))]
 pub use core_config::DEFAULT_FEE_HANDLING;
+#[cfg(any(feature = "testing", test))]
+pub use core_config::DEFAULT_GAS_HOLD_BALANCE_HANDLING;
 #[cfg(any(feature = "std", test))]
 pub use core_config::DEFAULT_REFUND_HANDLING;
 pub use core_config::{
-    ConsensusProtocolName, CoreConfig, LegacyRequiredFinality, DEFAULT_GAS_HOLD_BALANCE_HANDLING,
-    DEFAULT_GAS_HOLD_INTERVAL,
+    ConsensusProtocolName, CoreConfig, LegacyRequiredFinality, DEFAULT_GAS_HOLD_INTERVAL,
 };
 pub use fee_handling::FeeHandling;
-#[cfg(any(feature = "testing", test))]
-pub use genesis_config::DEFAULT_AUCTION_DELAY;
 #[cfg(any(feature = "std", test))]
 pub use genesis_config::{GenesisConfig, GenesisConfigBuilder};
 pub use global_state_update::{GlobalStateUpdate, GlobalStateUpdateConfig, GlobalStateUpdateError};

--- a/types/src/chainspec/accounts_config/genesis.rs
+++ b/types/src/chainspec/accounts_config/genesis.rs
@@ -306,11 +306,9 @@ impl GenesisAccount {
             | GenesisAccount::Delegator { .. } => {
                 // This value represents a delegation rate in invalid state that system is supposed
                 // to reject if used.
-                DelegationRate::max_value()
+                DelegationRate::MAX
             }
-            GenesisAccount::Administrator(AdministratorAccount { .. }) => {
-                DelegationRate::max_value()
-            }
+            GenesisAccount::Administrator(AdministratorAccount { .. }) => DelegationRate::MAX,
         }
     }
 

--- a/types/src/chainspec/transaction_config.rs
+++ b/types/src/chainspec/transaction_config.rs
@@ -17,8 +17,10 @@ use crate::{
 pub use deploy_config::DeployConfig;
 #[cfg(any(feature = "testing", test))]
 pub use deploy_config::DEFAULT_MAX_PAYMENT_MOTES;
+pub use transaction_v1_config::TransactionV1Config;
+#[cfg(any(feature = "testing", test))]
 pub use transaction_v1_config::{
-    TransactionV1Config, DEFAULT_INSTALL_UPGRADE_GAS_LIMIT, DEFAULT_LARGE_TRANSACTION_GAS_LIMIT,
+    DEFAULT_INSTALL_UPGRADE_GAS_LIMIT, DEFAULT_LARGE_TRANSACTION_GAS_LIMIT,
 };
 
 /// The default minimum number of motes that can be transferred.

--- a/types/src/chainspec/transaction_config/transaction_v1_config.rs
+++ b/types/src/chainspec/transaction_config/transaction_v1_config.rs
@@ -6,10 +6,11 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(any(feature = "testing", test))]
 use crate::testing::TestRng;
+#[cfg(any(feature = "testing", test))]
+use crate::INSTALL_UPGRADE_LANE_ID;
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes},
     transaction::TransactionCategory,
-    INSTALL_UPGRADE_LANE_ID,
 };
 
 /// Default gas limit of install / upgrade contracts

--- a/types/src/chainspec/vm_config.rs
+++ b/types/src/chainspec/vm_config.rs
@@ -10,15 +10,20 @@ mod storage_costs;
 mod system_config;
 mod wasm_config;
 
-pub use auction_costs::{AuctionCosts, DEFAULT_ADD_BID_COST, DEFAULT_DELEGATE_COST};
+pub use auction_costs::AuctionCosts;
+#[cfg(any(feature = "testing", test))]
+pub use auction_costs::{DEFAULT_ADD_BID_COST, DEFAULT_DELEGATE_COST};
 pub use chainspec_registry::ChainspecRegistry;
 pub use handle_payment_costs::HandlePaymentCosts;
+#[cfg(any(feature = "testing", test))]
+pub use host_function_costs::DEFAULT_NEW_DICTIONARY_COST;
 pub use host_function_costs::{
-    Cost as HostFunctionCost, HostFunction, HostFunctionCosts,
-    DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, DEFAULT_NEW_DICTIONARY_COST,
+    Cost as HostFunctionCost, HostFunction, HostFunctionCosts, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY,
 };
 pub use message_limits::MessageLimits;
-pub use mint_costs::{MintCosts, DEFAULT_TRANSFER_COST};
+pub use mint_costs::MintCosts;
+#[cfg(any(feature = "testing", test))]
+pub use mint_costs::DEFAULT_TRANSFER_COST;
 pub use opcode_costs::{BrTableCost, ControlFlowCosts, OpcodeCosts};
 #[cfg(any(feature = "testing", test))]
 pub use opcode_costs::{
@@ -37,4 +42,6 @@ pub use opcode_costs::{
 pub use standard_payment_costs::StandardPaymentCosts;
 pub use storage_costs::StorageCosts;
 pub use system_config::SystemConfig;
-pub use wasm_config::{WasmConfig, DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY};
+pub use wasm_config::WasmConfig;
+#[cfg(any(feature = "testing", test))]
+pub use wasm_config::{DEFAULT_MAX_STACK_HEIGHT, DEFAULT_WASM_MAX_MEMORY};

--- a/types/src/crypto/error.rs
+++ b/types/src/crypto/error.rs
@@ -152,8 +152,10 @@ mod serde_helpers {
     #[derive(Serialize)]
     #[serde(remote = "base64::DecodeError")]
     pub(super) enum Base64DecodeError {
+        #[allow(dead_code)]
         InvalidByte(usize, u8),
         InvalidLength,
+        #[allow(dead_code)]
         InvalidLastSymbol(usize, u8),
     }
 }

--- a/types/src/era_id.rs
+++ b/types/src/era_id.rs
@@ -33,7 +33,7 @@ pub struct EraId(u64);
 
 impl EraId {
     /// Maximum possible value an [`EraId`] can hold.
-    pub const MAX: EraId = EraId(u64::max_value());
+    pub const MAX: EraId = EraId(u64::MAX);
 
     /// Creates new [`EraId`] instance.
     pub const fn new(value: u64) -> EraId {
@@ -232,7 +232,7 @@ mod tests {
 
         let window: Vec<EraId> = current_era.iter_inclusive(auction_delay).collect();
         assert_eq!(window.len(), auction_delay as usize + 1);
-        assert_eq!(window.get(0), Some(&current_era));
+        assert_eq!(window.first(), Some(&current_era));
         assert_eq!(
             window.iter().next_back(),
             Some(&(current_era + auction_delay))

--- a/types/src/file_utils.rs
+++ b/types/src/file_utils.rs
@@ -67,6 +67,7 @@ pub(crate) fn write_private_file<P: AsRef<Path>, B: AsRef<[u8]>>(
     fs::OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .mode(0o600)
         .open(path)
         .and_then(|mut file| file.write_all(data.as_ref()))

--- a/types/src/testing.rs
+++ b/types/src/testing.rs
@@ -14,7 +14,7 @@ use rand::{
 use rand_pcg::Pcg64Mcg;
 
 thread_local! {
-    static THIS_THREAD_HAS_RNG: RefCell<bool> = RefCell::new(false);
+    static THIS_THREAD_HAS_RNG: RefCell<bool> = const { RefCell::new(false) };
 }
 
 const CL_TEST_SEED: &str = "CL_TEST_SEED";

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -40,8 +40,10 @@ use crate::{
     crypto, Digest, DisplayIter, RuntimeArgs, SecretKey, TimeDiff, Timestamp, TransactionRuntime,
 };
 
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
+use crate::TransactionConfig;
 #[cfg(any(feature = "std", test))]
-use crate::{Gas, Motes, TransactionConfig, U512};
+use crate::{Gas, Motes, U512};
 pub use errors_v1::{
     DecodeFromJsonErrorV1 as TransactionV1DecodeFromJsonError, ErrorV1 as TransactionV1Error,
     ExcessiveSizeErrorV1 as TransactionV1ExcessiveSizeError,
@@ -276,7 +278,7 @@ impl TransactionV1 {
 
     /// Returns `true` if the serialized size of the transaction is not greater than
     /// `max_transaction_size`.
-    #[cfg(any(feature = "std", test))]
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
     fn is_valid_size(
         &self,
         max_transaction_size: u32,

--- a/types/src/transaction/transaction_v1/transaction_v1_body.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_body.rs
@@ -12,22 +12,22 @@ use rand::{Rng, RngCore};
 use schemars::JsonSchema;
 #[cfg(any(feature = "std", test))]
 use serde::{Deserialize, Serialize};
-#[cfg(any(feature = "std", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 use tracing::debug;
 
 use super::super::{RuntimeArgs, TransactionEntryPoint, TransactionScheduling, TransactionTarget};
 
 use super::TransactionCategory;
-#[cfg(any(feature = "std", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 use super::TransactionConfig;
 #[cfg(doc)]
 use super::TransactionV1;
 use crate::bytesrepr::{self, FromBytes, ToBytes};
 
-#[cfg(any(feature = "std", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::InvalidTransactionV1;
 
-#[cfg(any(feature = "std", test))]
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::TransactionV1ExcessiveSizeError;
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::{
@@ -131,7 +131,7 @@ impl TransactionV1Body {
         (self.args, self.target, self.entry_point, self.scheduling)
     }
 
-    #[cfg(any(feature = "std", test))]
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub(super) fn is_valid(&self, config: &TransactionConfig) -> Result<(), InvalidTransactionV1> {
         let kind = self.transaction_category;
         if !config.transaction_v1_config.is_supported(kind) {

--- a/types/src/transaction/transaction_v1/transaction_v1_body/arg_handling.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_body/arg_handling.rs
@@ -2,12 +2,12 @@ use core::marker::PhantomData;
 
 use tracing::debug;
 
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
+use crate::{account::AccountHash, system::auction::ARG_VALIDATOR, CLType};
 use crate::{
-    account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
-    system::auction::ARG_VALIDATOR,
-    CLType, CLTyped, CLValue, CLValueError, InvalidTransactionV1, PublicKey, RuntimeArgs,
-    TransferTarget, URef, U512,
+    CLTyped, CLValue, CLValueError, InvalidTransactionV1, PublicKey, RuntimeArgs, TransferTarget,
+    URef, U512,
 };
 
 const TRANSFER_ARG_AMOUNT: RequiredArg<U512> = RequiredArg::new("amount");
@@ -39,6 +39,7 @@ const REDELEGATE_ARG_VALIDATOR: RequiredArg<PublicKey> = RequiredArg::new("valid
 const REDELEGATE_ARG_AMOUNT: RequiredArg<U512> = RequiredArg::new("amount");
 const REDELEGATE_ARG_NEW_VALIDATOR: RequiredArg<PublicKey> = RequiredArg::new("new_validator");
 
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 const ACTIVATE_BID_ARG_VALIDATOR: RequiredArg<PublicKey> = RequiredArg::new(ARG_VALIDATOR);
 
 const CHANGE_BID_PUBLIC_KEY_ARG_PUBLIC_KEY: RequiredArg<PublicKey> = RequiredArg::new("public_key");
@@ -92,6 +93,7 @@ impl<T> OptionalArg<T> {
         }
     }
 
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
     fn get(&self, args: &RuntimeArgs) -> Result<Option<T>, InvalidTransactionV1>
     where
         T: CLTyped + FromBytes,
@@ -162,6 +164,7 @@ pub(in crate::transaction::transaction_v1) fn new_transfer_args<
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in a transfer transaction.
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub(in crate::transaction::transaction_v1) fn has_valid_transfer_args(
     args: &RuntimeArgs,
     native_transfer_minimum_motes: u64,
@@ -235,6 +238,7 @@ pub(in crate::transaction::transaction_v1) fn new_add_bid_args<A: Into<U512>>(
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in an add_bid transaction.
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub(in crate::transaction::transaction_v1) fn has_valid_add_bid_args(
     args: &RuntimeArgs,
 ) -> Result<(), InvalidTransactionV1> {
@@ -256,6 +260,7 @@ pub(in crate::transaction::transaction_v1) fn new_withdraw_bid_args<A: Into<U512
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in an withdraw_bid transaction.
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub(in crate::transaction::transaction_v1) fn has_valid_withdraw_bid_args(
     args: &RuntimeArgs,
 ) -> Result<(), InvalidTransactionV1> {
@@ -278,6 +283,7 @@ pub(in crate::transaction::transaction_v1) fn new_delegate_args<A: Into<U512>>(
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in a delegate transaction.
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub(in crate::transaction::transaction_v1) fn has_valid_delegate_args(
     args: &RuntimeArgs,
 ) -> Result<(), InvalidTransactionV1> {
@@ -301,6 +307,7 @@ pub(in crate::transaction::transaction_v1) fn new_undelegate_args<A: Into<U512>>
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in an undelegate transaction.
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub(in crate::transaction::transaction_v1) fn has_valid_undelegate_args(
     args: &RuntimeArgs,
 ) -> Result<(), InvalidTransactionV1> {
@@ -326,6 +333,7 @@ pub(in crate::transaction::transaction_v1) fn new_redelegate_args<A: Into<U512>>
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in a redelegate transaction.
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub(in crate::transaction::transaction_v1) fn has_valid_redelegate_args(
     args: &RuntimeArgs,
 ) -> Result<(), InvalidTransactionV1> {
@@ -337,6 +345,7 @@ pub(in crate::transaction::transaction_v1) fn has_valid_redelegate_args(
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in an activate bid transaction.
+#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub(in crate::transaction::transaction_v1) fn has_valid_activate_bid_args(
     args: &RuntimeArgs,
 ) -> Result<(), InvalidTransactionV1> {
@@ -345,7 +354,8 @@ pub(in crate::transaction::transaction_v1) fn has_valid_activate_bid_args(
 }
 
 /// Checks the given `RuntimeArgs` are suitable for use in a change bid public key transaction.
-pub(in crate::transaction::transaction_v1) fn has_valid_change_bid_public_key_args(
+#[allow(dead_code)]
+pub(super) fn has_valid_change_bid_public_key_args(
     args: &RuntimeArgs,
 ) -> Result<(), InvalidTransactionV1> {
     let _public_key = CHANGE_BID_PUBLIC_KEY_ARG_PUBLIC_KEY.get(args)?;


### PR DESCRIPTION
Update rust-toolchain to 1.77.2. In an attempt to shrink down #4806 which requires 1.74.0 stable, I tried to upgrade as high as I could and we're just two versions behind (1.79 is currently stable). I tried to go to the current stable, but the amount of extra warnings (tons of `field x is never read` etc.) made me uncomfortable pursuing this further.

Once merged it should slightly decrease the size of #4806 PR.