### PR TITLE
Return the switch block hash with rewards response

### DIFF
--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -957,6 +957,7 @@ where
                         reward,
                         header.era_id(),
                         *seigniorage_recipient.delegation_rate(),
+                        header.block_hash(),
                     );
                     BinaryResponse::from_value(response, protocol_version)
                 }


### PR DESCRIPTION
Adds a new field to enable users to retrieve the block at which rewards were distributed