### PR TITLE
Add an error code for purse not found for balance requests

### DIFF
--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -277,6 +277,9 @@ pub enum ErrorCode {
     /// Received V1 Transaction for spec exec.
     #[error("received v1 transaction for speculative execution")]
     ReceivedV1Transaction = 86,
+    /// Purse was not found for given identifier.
+    #[error("purse was not found for given identifier")]
+    PurseNotFound = 87,
 }
 
 impl TryFrom<u16> for ErrorCode {
@@ -371,6 +374,7 @@ impl TryFrom<u16> for ErrorCode {
             84 => Ok(ErrorCode::InvalidTransactionInvalidTransactionKind),
             85 => Ok(ErrorCode::GasPriceToleranceTooLow),
             86 => Ok(ErrorCode::ReceivedV1Transaction),
+            87 => Ok(ErrorCode::PurseNotFound),
             _ => Err(UnknownErrorCode),
         }
     }

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -27,6 +27,7 @@ use casper_storage::{
     },
     global_state::trie::TrieRaw,
     system::auction,
+    tracking_copy::TrackingCopyError,
     KeyPrefix as StorageKeyPrefix,
 };
 use casper_types::{
@@ -671,7 +672,11 @@ where
             };
             BinaryResponse::from_value(response, protocol_version)
         }
-        BalanceResult::Failure(_) => {
+        BalanceResult::Failure(TrackingCopyError::KeyNotFound(_)) => {
+            BinaryResponse::new_error(ErrorCode::PurseNotFound, protocol_version)
+        }
+        BalanceResult::Failure(error) => {
+            debug!(%error, "failed when querying for a balance");
             BinaryResponse::new_error(ErrorCode::FailedQuery, protocol_version)
         }
     }

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -902,7 +902,7 @@ fn get_balance(state_root_hash: Digest, account_hash: AccountHash) -> TestCase {
 
 fn get_balance_account_not_found(state_root_hash: Digest) -> TestCase {
     TestCase {
-        name: "get_balance_not_found",
+        name: "get_balance_account_not_found",
         request: BinaryRequest::Get(GetRequest::State(Box::new(GlobalStateRequest::Balance {
             state_identifier: Some(GlobalStateIdentifier::StateRootHash(state_root_hash)),
             purse_identifier: PurseIdentifier::Account(AccountHash([9; 32])),
@@ -913,7 +913,7 @@ fn get_balance_account_not_found(state_root_hash: Digest) -> TestCase {
 
 fn get_balance_purse_uref_not_found(state_root_hash: Digest) -> TestCase {
     TestCase {
-        name: "get_balance_not_found",
+        name: "get_balance_purse_uref_not_found",
         request: BinaryRequest::Get(GetRequest::State(Box::new(GlobalStateRequest::Balance {
             state_identifier: Some(GlobalStateIdentifier::StateRootHash(state_root_hash)),
             purse_identifier: PurseIdentifier::Purse(URef::new([9; 32], Default::default())),

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -362,6 +362,8 @@ async fn binary_port_component_handles_all_requests() {
         try_accept_transaction_invalid(&mut rng),
         try_accept_transaction(&secret_signing_key),
         get_balance(state_root_hash, test_account_hash),
+        get_balance_account_not_found(state_root_hash),
+        get_balance_purse_uref_not_found(state_root_hash),
         get_named_keys_by_prefix(state_root_hash, test_entity_addr),
         get_reward(
             Some(EraIdentifier::Era(ERA_ONE)),
@@ -895,6 +897,28 @@ fn get_balance(state_root_hash: Digest, account_hash: AccountHash) -> TestCase {
                 |res| res.available_balance == U512::one(),
             )
         }),
+    }
+}
+
+fn get_balance_account_not_found(state_root_hash: Digest) -> TestCase {
+    TestCase {
+        name: "get_balance_not_found",
+        request: BinaryRequest::Get(GetRequest::State(Box::new(GlobalStateRequest::Balance {
+            state_identifier: Some(GlobalStateIdentifier::StateRootHash(state_root_hash)),
+            purse_identifier: PurseIdentifier::Account(AccountHash([9; 32])),
+        }))),
+        asserter: Box::new(|response| response.error_code() == ErrorCode::PurseNotFound as u16),
+    }
+}
+
+fn get_balance_purse_uref_not_found(state_root_hash: Digest) -> TestCase {
+    TestCase {
+        name: "get_balance_not_found",
+        request: BinaryRequest::Get(GetRequest::State(Box::new(GlobalStateRequest::Balance {
+            state_identifier: Some(GlobalStateIdentifier::StateRootHash(state_root_hash)),
+            purse_identifier: PurseIdentifier::Purse(URef::new([9; 32], Default::default())),
+        }))),
+        asserter: Box::new(|response| response.error_code() == ErrorCode::PurseNotFound as u16),
     }
 }
 


### PR DESCRIPTION
We currently return a generic query error (we did the same in 1.5), but bitvavo have asked for a dedicated error for this