### PR TITLE
Reject transactions for which there’s no chance for the chain to reach the required gas price

### DIFF
--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -247,6 +247,11 @@ function start_upgrade_scenario_15() {
     nctl-exec-upgrade-scenario-15
 }
 
+function start_upgrade_scenario_16() {
+    log "... Starting Upgrade Scenario 16"
+    nctl-exec-upgrade-scenario-16
+}
+
 # ----------------------------------------------------------------
 # ENTRY POINT
 # ----------------------------------------------------------------

--- a/ci/nctl_upgrade.sh
+++ b/ci/nctl_upgrade.sh
@@ -242,6 +242,11 @@ function start_upgrade_scenario_14() {
     nctl-exec-upgrade-scenario-14
 }
 
+function start_upgrade_scenario_15() {
+    log "... Starting Upgrade Scenario 15"
+    nctl-exec-upgrade-scenario-15
+}
+
 # ----------------------------------------------------------------
 # ENTRY POINT
 # ----------------------------------------------------------------

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -94,6 +94,7 @@ function run_nightly_upgrade_test() {
     run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=12"'
     run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=13"'
     run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=14"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=15 skip_setup=true"'
 }
 
 function run_soundness_test() {

--- a/ci/nightly-test.sh
+++ b/ci/nightly-test.sh
@@ -95,6 +95,7 @@ function run_nightly_upgrade_test() {
     run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=13"'
     run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=14"'
     run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=15 skip_setup=true"'
+    run_test_and_count 'bash -c "./ci/nctl_upgrade.sh test_id=16 skip_setup=true"'
 }
 
 function run_soundness_test() {

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.  The format
 * Add `BinaryPort` interface along with the relevant config entries.
 * Added chainspec settings `finders_fee`, `finality_signature_proportion` and `signature_rewards_max_delay` to control behavior of the new seigniorage model.
 * Add `ttl_leeway_for_upgrade_point_check` parameter to the `[transaction_acceptor]` section of the node config.
+* Add `max_ttl_leeway_for_upgrade_point_check` to the chainspec.
 
 ### Changed
 * All SSE events are emitted via the `<IP:Port>/events` endpoint. None of the previous ones (`/events/main`, `/events/deploys`, and `/events/sigs`) is available any longer.

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.  The format
 ### Added
 * Add `BinaryPort` interface along with the relevant config entries.
 * Added chainspec settings `finders_fee`, `finality_signature_proportion` and `signature_rewards_max_delay` to control behavior of the new seigniorage model.
+* Add `ttl_leeway_for_upgrade_point_check` parameter to the `[transaction_acceptor]` section of the node config.
 
 ### Changed
 * All SSE events are emitted via the `<IP:Port>/events` endpoint. None of the previous ones (`/events/main`, `/events/deploys`, and `/events/sigs`) is available any longer.

--- a/node/src/components.rs
+++ b/node/src/components.rs
@@ -67,6 +67,7 @@ pub(crate) mod sync_leaper;
 pub(crate) mod transaction_acceptor;
 pub(crate) mod upgrade_watcher;
 
+use casper_types::EraId;
 use datasize::DataSize;
 use serde::Deserialize;
 use std::fmt::{Debug, Display};
@@ -201,4 +202,28 @@ pub(crate) trait ValidatorBoundComponent<REv>: Component<REv> {
         effect_builder: EffectBuilder<REv>,
         rng: &mut NodeRng,
     ) -> Effects<Self::Event>;
+}
+
+#[derive(Clone, Copy, Ord, Eq, PartialOrd, PartialEq, DataSize, Debug)]
+pub(crate) struct EraPrice {
+    era_id: EraId,
+    gas_price: u8,
+}
+
+impl EraPrice {
+    pub(crate) fn new(era_id: EraId, gas_price: u8) -> Self {
+        Self { era_id, gas_price }
+    }
+
+    pub(crate) fn gas_price(&self) -> u8 {
+        self.gas_price
+    }
+
+    pub(crate) fn maybe_gas_price_for_era_id(&self, era_id: EraId) -> Option<u8> {
+        if self.era_id == era_id {
+            return Some(self.gas_price);
+        }
+
+        None
+    }
 }

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1428,7 +1428,7 @@ async fn execute_finalized_block<REv>(
     .await;
 
     let executable_block =
-        ExecutableBlock::from_finalized_block_and_transactions(finalized_block, transactions);
+        ExecutableBlock::from_finalized_block_and_transactions(finalized_block, transactions, None);
     effect_builder
         .enqueue_block_for_execution(executable_block, MetaBlockState::new())
         .await

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -49,7 +49,7 @@ use casper_types::{
 
 use crate::{
     components::{fetcher::FetchResponse, Component, ComponentState},
-    contract_runtime::{types::EraPrice, utils::handle_protocol_upgrade},
+    contract_runtime::utils::handle_protocol_upgrade,
     effect::{
         announcements::{
             ContractRuntimeAnnouncement, FatalAnnouncement, MetaBlockAnnouncement,
@@ -81,6 +81,8 @@ pub(crate) use types::{
     StepOutcome,
 };
 use utils::{exec_or_requeue, run_intensive_task};
+
+use super::EraPrice;
 
 const COMPONENT_NAME: &str = "contract_runtime";
 

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -540,12 +540,15 @@ impl ContractRuntime {
                     );
 
                     info!("Enqueuing block for execution post state refresh");
+                    let next_era_gas_price = block_header.next_era_gas_price();
+                    debug!(next_era_gas_price, "immediate switch block");
 
                     effect_builder
                         .enqueue_block_for_execution(
                             ExecutableBlock::from_finalized_block_and_transactions(
                                 finalized_block,
                                 vec![],
+                                next_era_gas_price,
                             ),
                             MetaBlockState::new_not_to_be_gossiped(),
                         )

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -177,7 +177,7 @@ impl ContractRuntime {
 
         let new_len = self
             .exec_queue
-            .remove_older_then(execution_pre_state.next_block_height());
+            .remove_older_than(execution_pre_state.next_block_height());
         self.metrics.exec_queue_size.set(new_len);
         debug!(next_block_height, "ContractRuntime: set initial state");
     }

--- a/node/src/components/contract_runtime/exec_queue.rs
+++ b/node/src/components/contract_runtime/exec_queue.rs
@@ -35,7 +35,7 @@ impl ExecQueue {
     }
 
     /// Remove every entry older than the given height, and return the new len.
-    pub fn remove_older_then(&mut self, height: u64) -> i64 {
+    pub fn remove_older_than(&mut self, height: u64) -> i64 {
         let mut locked_queue = self.0
             .lock()
             .expect(

--- a/node/src/components/contract_runtime/tests.rs
+++ b/node/src/components/contract_runtime/tests.rs
@@ -245,6 +245,7 @@ async fn should_not_set_shared_pre_state_to_lower_block_height() {
             PublicKey::System,
         ),
         vec![],
+        None,
     );
 
     runner
@@ -265,6 +266,7 @@ async fn should_not_set_shared_pre_state_to_lower_block_height() {
             PublicKey::System,
         ),
         vec![],
+        None,
     );
     runner
         .process_injected_effects(execute_block(block_1))
@@ -351,6 +353,7 @@ async fn should_not_set_shared_pre_state_to_lower_block_height() {
             PublicKey::System,
         ),
         txns,
+        None,
     );
     runner
         .process_injected_effects(execute_block(block_2))

--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -450,27 +450,3 @@ impl ExecutionPreState {
         self.parent_seed
     }
 }
-
-#[derive(Clone, Copy, Ord, Eq, PartialOrd, PartialEq, DataSize, Debug)]
-pub(crate) struct EraPrice {
-    era_id: EraId,
-    gas_price: u8,
-}
-
-impl EraPrice {
-    pub(crate) fn new(era_id: EraId, gas_price: u8) -> Self {
-        Self { era_id, gas_price }
-    }
-
-    pub(crate) fn gas_price(&self) -> u8 {
-        self.gas_price
-    }
-
-    pub(crate) fn maybe_gas_price_for_era_id(&self, era_id: EraId) -> Option<u8> {
-        if self.era_id == era_id {
-            return Some(self.gas_price);
-        }
-
-        None
-    }
-}

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -1174,7 +1174,7 @@ impl<REv: ReactorEventT> Component<REv> for TransactionAcceptor {
                 event_metadata,
                 is_new,
             } => self.handle_stored_finalized_approvals(effect_builder, event_metadata, is_new),
-            Event::UpdateCurrentGasPrice { era, price } => {
+            Event::UpdateEraGasPrice { era, price } => {
                 debug!(%era, %price, "received current gas price");
                 self.current_gas_price = Some(EraPrice::new(era, price));
                 Effects::new()

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -25,9 +25,7 @@ use casper_types::{
 use crate::{
     components::Component,
     effect::{
-        announcements::{
-            ContractRuntimeAnnouncement, FatalAnnouncement, TransactionAcceptorAnnouncement,
-        },
+        announcements::{FatalAnnouncement, TransactionAcceptorAnnouncement},
         requests::{ContractRuntimeRequest, StorageRequest},
         EffectBuilder, EffectExt, Effects, Responder,
     },
@@ -1030,13 +1028,9 @@ impl<REv: ReactorEventT> Component<REv> for TransactionAcceptor {
                 event_metadata,
                 is_new,
             } => self.handle_stored_finalized_approvals(effect_builder, event_metadata, is_new),
-            Event::ContractRuntimeAnnouncement(ann) => {
-                if let ContractRuntimeAnnouncement::NextEraGasPrice {
-                    next_era_gas_price, ..
-                } = ann
-                {
-                    self.current_gas_price = Some(next_era_gas_price);
-                }
+            Event::UpdateCurrentGasPrice(current_gas_price) => {
+                debug!(%current_gas_price, "received current gas price");
+                self.current_gas_price = Some(current_gas_price);
                 Effects::new()
             }
         }

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -111,7 +111,8 @@ impl TransactionAcceptor {
         current_gas_price: u8,
     ) -> (bool, u8) {
         let price_changes_within_ttl = tx_ttl.as_secs() / era_duration.as_secs();
-        let minimum_reachable_gas_price = current_gas_price - price_changes_within_ttl as u8;
+        let minimum_reachable_gas_price =
+            current_gas_price.saturating_sub(price_changes_within_ttl as u8);
 
         (
             tx_gas_tolerance >= minimum_reachable_gas_price,

--- a/node/src/components/transaction_acceptor/config.rs
+++ b/node/src/components/transaction_acceptor/config.rs
@@ -24,6 +24,9 @@ pub struct Config {
     /// (due to the fact that era duration may vary and that we can't determine how much time in
     /// the current era has passed) we allow short leeway when comparing timestamps to minimize the
     /// chances of the transaction being rejected erroneously.
+    ///
+    /// The maximum value to which `ttl_leeway_for_upgrade_point_check` can be set is defined by
+    /// the chainspec setting `transactions.max_ttl_leeway_for_upgrade_point_check`.
     pub ttl_leeway_for_upgrade_point_check: TimeDiff,
 }
 

--- a/node/src/components/transaction_acceptor/config.rs
+++ b/node/src/components/transaction_acceptor/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use casper_types::TimeDiff;
 
 const DEFAULT_TIMESTAMP_LEEWAY: &str = "2sec";
+const UPGRADE_TTL_LEEWAY_FOR_UPGRADE_POINT_CHECK: &str = "2hours";
 
 /// Configuration options for accepting transactions.
 #[derive(Copy, Clone, Serialize, Deserialize, Debug, DataSize)]
@@ -18,12 +19,22 @@ pub struct Config {
     /// The maximum value to which `timestamp_leeway` can be set is defined by the chainspec
     /// setting `transactions.max_timestamp_leeway`.
     pub timestamp_leeway: TimeDiff,
+    /// The gas price tolerance checks are disabled if the transaction TTL extends beyond the
+    /// planned upgrade activation point. Since it's not possible to do the calculations precisely
+    /// (due to the fact that era duration may vary and that we can't determine how much time in
+    /// the current era has passed) we allow short leeway when comparing timestamps to minimize the
+    /// chances of the transaction being rejected erroneously.
+    pub ttl_leeway_for_upgrade_point_check: TimeDiff,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
             timestamp_leeway: TimeDiff::from_str(DEFAULT_TIMESTAMP_LEEWAY).unwrap(),
+            ttl_leeway_for_upgrade_point_check: TimeDiff::from_str(
+                UPGRADE_TTL_LEEWAY_FOR_UPGRADE_POINT_CHECK,
+            )
+            .unwrap(),
         }
     }
 }

--- a/node/src/components/transaction_acceptor/event.rs
+++ b/node/src/components/transaction_acceptor/event.rs
@@ -100,7 +100,7 @@ pub(crate) enum Event {
         maybe_entry_point: Option<EntryPoint>,
     },
     /// Updates the current era gas price
-    UpdateCurrentGasPrice { era: EraId, price: u8 },
+    UpdateEraGasPrice { era: EraId, price: u8 },
     /// The result of getting next upgrade information from the upgrade watcher component.
     GetNextUpgradeResult {
         event_metadata: Box<EventMetadata>,
@@ -213,7 +213,7 @@ impl Display for Event {
                     block_header.state_root_hash(),
                 )
             }
-            Event::UpdateCurrentGasPrice { era, price } => {
+            Event::UpdateEraGasPrice { era, price } => {
                 write!(
                     formatter,
                     "current gas price set to {} for era {}",

--- a/node/src/components/transaction_acceptor/event.rs
+++ b/node/src/components/transaction_acceptor/event.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
+use derive_more::From;
 use serde::Serialize;
 
 use casper_types::{
@@ -8,7 +9,7 @@ use casper_types::{
 };
 
 use super::{Error, Source};
-use crate::effect::Responder;
+use crate::effect::{announcements::ContractRuntimeAnnouncement, Responder};
 
 /// A utility struct to hold duplicated information across events.
 #[derive(Debug, Serialize)]
@@ -35,7 +36,7 @@ impl EventMetadata {
 }
 
 /// `TransactionAcceptor` events.
-#[derive(Debug, Serialize)]
+#[derive(Debug, From, Serialize)]
 pub(crate) enum Event {
     /// The initiating event to accept a new `Transaction`.
     Accept {
@@ -99,6 +100,8 @@ pub(crate) enum Event {
         entry_point_name: String,
         maybe_entry_point: Option<EntryPoint>,
     },
+    #[from]
+    ContractRuntimeAnnouncement(ContractRuntimeAnnouncement),
 }
 
 impl Display for Event {
@@ -205,6 +208,9 @@ impl Display for Event {
                     event_metadata.transaction.hash(),
                     block_header.state_root_hash(),
                 )
+            }
+            Event::ContractRuntimeAnnouncement(ann) => {
+                write!(formatter, "contract runtime announcement: {}", ann)
             }
         }
     }

--- a/node/src/components/transaction_acceptor/event.rs
+++ b/node/src/components/transaction_acceptor/event.rs
@@ -3,8 +3,8 @@ use std::fmt::{self, Display, Formatter};
 use serde::Serialize;
 
 use casper_types::{
-    AddressableEntity, AddressableEntityHash, BlockHeader, EntityVersion, EntryPoint, NextUpgrade,
-    Package, PackageHash, Timestamp, Transaction, U512,
+    AddressableEntity, AddressableEntityHash, BlockHeader, EntityVersion, EntryPoint, EraId,
+    NextUpgrade, Package, PackageHash, Timestamp, Transaction, U512,
 };
 
 use super::{Error, Source};
@@ -100,7 +100,7 @@ pub(crate) enum Event {
         maybe_entry_point: Option<EntryPoint>,
     },
     /// Updates the current era gas price
-    UpdateCurrentGasPrice(u8),
+    UpdateCurrentGasPrice { era: EraId, price: u8 },
     /// The result of getting next upgrade information from the upgrade watcher component.
     GetNextUpgradeResult {
         event_metadata: Box<EventMetadata>,
@@ -213,8 +213,12 @@ impl Display for Event {
                     block_header.state_root_hash(),
                 )
             }
-            Event::UpdateCurrentGasPrice(current_gas_price) => {
-                write!(formatter, "current gas price set to {}", current_gas_price)
+            Event::UpdateCurrentGasPrice { era, price } => {
+                write!(
+                    formatter,
+                    "current gas price set to {} for era {}",
+                    price, era
+                )
             }
             Event::GetNextUpgradeResult {
                 maybe_next_upgrade, ..

--- a/node/src/components/transaction_acceptor/event.rs
+++ b/node/src/components/transaction_acceptor/event.rs
@@ -1,6 +1,5 @@
 use std::fmt::{self, Display, Formatter};
 
-use derive_more::From;
 use serde::Serialize;
 
 use casper_types::{
@@ -9,7 +8,7 @@ use casper_types::{
 };
 
 use super::{Error, Source};
-use crate::effect::{announcements::ContractRuntimeAnnouncement, Responder};
+use crate::effect::Responder;
 
 /// A utility struct to hold duplicated information across events.
 #[derive(Debug, Serialize)]
@@ -36,7 +35,7 @@ impl EventMetadata {
 }
 
 /// `TransactionAcceptor` events.
-#[derive(Debug, From, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) enum Event {
     /// The initiating event to accept a new `Transaction`.
     Accept {
@@ -100,8 +99,8 @@ pub(crate) enum Event {
         entry_point_name: String,
         maybe_entry_point: Option<EntryPoint>,
     },
-    #[from]
-    ContractRuntimeAnnouncement(ContractRuntimeAnnouncement),
+    /// Updates the current era gas price
+    UpdateCurrentGasPrice(u8),
 }
 
 impl Display for Event {
@@ -209,8 +208,8 @@ impl Display for Event {
                     block_header.state_root_hash(),
                 )
             }
-            Event::ContractRuntimeAnnouncement(ann) => {
-                write!(formatter, "contract runtime announcement: {}", ann)
+            Event::UpdateCurrentGasPrice(current_gas_price) => {
+                write!(formatter, "current gas price set to {}", current_gas_price)
             }
         }
     }

--- a/node/src/components/transaction_acceptor/event.rs
+++ b/node/src/components/transaction_acceptor/event.rs
@@ -3,8 +3,8 @@ use std::fmt::{self, Display, Formatter};
 use serde::Serialize;
 
 use casper_types::{
-    AddressableEntity, AddressableEntityHash, BlockHeader, EntityVersion, EntryPoint, Package,
-    PackageHash, Timestamp, Transaction, U512,
+    AddressableEntity, AddressableEntityHash, BlockHeader, EntityVersion, EntryPoint, NextUpgrade,
+    Package, PackageHash, Timestamp, Transaction, U512,
 };
 
 use super::{Error, Source};
@@ -101,6 +101,11 @@ pub(crate) enum Event {
     },
     /// Updates the current era gas price
     UpdateCurrentGasPrice(u8),
+    /// The result of getting next upgrade information from the upgrade watcher component.
+    GetNextUpgradeResult {
+        event_metadata: Box<EventMetadata>,
+        maybe_next_upgrade: Option<NextUpgrade>,
+    },
 }
 
 impl Display for Event {
@@ -210,6 +215,15 @@ impl Display for Event {
             }
             Event::UpdateCurrentGasPrice(current_gas_price) => {
                 write!(formatter, "current gas price set to {}", current_gas_price)
+            }
+            Event::GetNextUpgradeResult {
+                maybe_next_upgrade, ..
+            } => {
+                write!(
+                    formatter,
+                    "get next upgrade result: {:?}",
+                    maybe_next_upgrade
+                )
             }
         }
     }

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -2635,15 +2635,16 @@ fn detects_unreachable_gas_price() {
 fn detects_distance_between_txn_expiry_and_upgrade_point() {
     let rng = &mut TestRng::new();
 
-    const ONE_HOUR: u32 = 60 * 60;
-    const TWO_HOURS: u32 = ONE_HOUR * 2;
+    const ONE_HOUR: u64 = 60 * 60;
+    const TWO_HOURS: u64 = ONE_HOUR * 2;
 
-    const ERA_DURATION_SECS: u64 = ONE_HOUR as u64;
+    const ERA_DURATION_SECS: u64 = ONE_HOUR;
+    const LEEWAY: u64 = TWO_HOURS;
 
     let txn = Transaction::from(
         TransactionV1Builder::new_random(rng)
             .with_timestamp(Timestamp::now())
-            .with_ttl(TimeDiff::from_seconds(TWO_HOURS)) // 2 eras
+            .with_ttl(TimeDiff::from_seconds(TWO_HOURS as u32)) // 2 eras
             .with_chain_name("casper-example")
             .build()
             .expect("must create fixed mode transaction"),
@@ -2658,6 +2659,7 @@ fn detects_distance_between_txn_expiry_and_upgrade_point() {
         current_era,
         upgrade_era,
         ERA_DURATION_SECS,
+        LEEWAY,
         &txn,
     );
     assert!(!result);
@@ -2671,6 +2673,7 @@ fn detects_distance_between_txn_expiry_and_upgrade_point() {
         current_era,
         upgrade_era,
         ERA_DURATION_SECS,
+        LEEWAY,
         &txn,
     );
     assert!(result);
@@ -2684,6 +2687,7 @@ fn detects_distance_between_txn_expiry_and_upgrade_point() {
         current_era,
         upgrade_era,
         ERA_DURATION_SECS,
+        LEEWAY,
         &txn,
     );
     assert!(result);

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -2561,38 +2561,19 @@ fn detects_unreachable_gas_price() {
     const UNREACHABLE_LOW: u8 = 4;
 
     for gas_price_tolerance in 0..=20 {
-        let (reachable, minimum_possible) = TransactionAcceptor::is_gas_price_tolerance_reachable(
+        let outcome = TransactionAcceptor::is_gas_price_tolerance_reachable(
             TX_TTL,
             gas_price_tolerance,
             ERA_DURATION,
             CURRENT_GAS_PRICE,
         );
         if gas_price_tolerance <= UNREACHABLE_LOW {
-            assert!(!reachable);
+            assert!(matches!(
+                outcome,
+                GasPriceToleranceCheckOutcome::Unreachable { lowest_possible_gas_price_within_ttl }
+             if lowest_possible_gas_price_within_ttl == UNREACHABLE_LOW + 1));
         } else {
-            assert!(reachable);
+            assert!(matches!(outcome, GasPriceToleranceCheckOutcome::Reachable));
         }
-        assert!(minimum_possible == UNREACHABLE_LOW + 1);
     }
-}
-
-#[test]
-fn minimum_reachable_gas_price_should_not_overflow() {
-    const ONE_MIN: Duration = Duration::from_secs(60);
-    const TWO_HOURS: Duration = Duration::from_secs(60 * 60 * 2);
-
-    const ERA_DURATION: Duration = ONE_MIN;
-    const CURRENT_GAS_PRICE: u8 = 10;
-    const GAS_PRICE_TOLERANCE: u8 = 5;
-
-    const TX_TTL: Duration = TWO_HOURS;
-
-    let (_, minimum_reachable_gas_price) = TransactionAcceptor::is_gas_price_tolerance_reachable(
-        TX_TTL,
-        GAS_PRICE_TOLERANCE,
-        ERA_DURATION,
-        CURRENT_GAS_PRICE,
-    );
-
-    assert_eq!(minimum_reachable_gas_price, 0);
 }

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -2525,7 +2525,6 @@ async fn should_reject_deploy_with_too_low_gas_price_tolerance() {
 async fn should_reject_transaction_v1_with_unreachable_gas_price_tolerance() {
     let test_scenario = TestScenario::UnreachableGasPriceToleranceForTransactionV1;
     let result = run_transaction_acceptor_with_gas_price(test_scenario, 20).await;
-    dbg!(&result);
     assert!(matches!(
         result,
         Err(super::Error::InvalidTransaction(InvalidTransaction::V1(

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -1037,7 +1037,7 @@ impl reactor::Reactor for Reactor {
                     self.transaction_acceptor.handle_event(
                         effect_builder,
                         rng,
-                        transaction_acceptor::Event::UpdateCurrentGasPrice {
+                        transaction_acceptor::Event::UpdateEraGasPrice {
                             era: era_id,
                             price: next_era_gas_price,
                         },
@@ -1244,7 +1244,7 @@ async fn run_transaction_acceptor_without_timeout(
     if let Some(EraPrice { era_id, gas_price }) = era_gas_price {
         runner
             .process_injected_effects(|effect_builder: EffectBuilder<Event>| {
-                let event = transaction_acceptor::Event::UpdateCurrentGasPrice {
+                let event = transaction_acceptor::Event::UpdateEraGasPrice {
                     era: era_id,
                     price: gas_price,
                 };

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -1056,7 +1056,8 @@ impl reactor::Reactor for Reactor {
                     .handle_event(effect_builder, rng, event),
             ),
             Event::UpgradeWatcherAnnouncement(ann) => {
-                // TODO[RC]: Add tests with the next upgrade equal to Some()
+                // There is a `detects_distance_between_txn_expiry_and_upgrade_point()` test that
+                // covers various distances to the upgrade point.
                 assert!(ann.0.is_none());
                 Effects::new()
             }

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -2576,3 +2576,24 @@ fn detects_unreachable_gas_price() {
         assert!(minimum_possible == UNREACHABLE_LOW + 1);
     }
 }
+
+#[test]
+fn minimum_reachable_gas_price_should_not_overflow() {
+    const ONE_MIN: Duration = Duration::from_secs(60);
+    const TWO_HOURS: Duration = Duration::from_secs(60 * 60 * 2);
+
+    const ERA_DURATION: Duration = ONE_MIN;
+    const CURRENT_GAS_PRICE: u8 = 10;
+    const GAS_PRICE_TOLERANCE: u8 = 5;
+
+    const TX_TTL: Duration = TWO_HOURS;
+
+    let (_, minimum_reachable_gas_price) = TransactionAcceptor::is_gas_price_tolerance_reachable(
+        TX_TTL,
+        GAS_PRICE_TOLERANCE,
+        ERA_DURATION,
+        CURRENT_GAS_PRICE,
+    );
+
+    assert_eq!(minimum_reachable_gas_price, 0);
+}

--- a/node/src/components/transaction_buffer.rs
+++ b/node/src/components/transaction_buffer.rs
@@ -237,7 +237,7 @@ impl TransactionBuffer {
         if self.prices.get(&era_id).is_none() {
             info!("Empty prices field, requesting gas price from contract runtime");
             return effect_builder
-                .get_current_gas_price(era_id)
+                .get_gas_price(era_id)
                 .event(move |maybe_gas_price| {
                     Event::GetGasPriceResult(
                         maybe_gas_price,

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -1583,7 +1583,7 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
-    pub(crate) async fn get_current_gas_price(self, era_id: EraId) -> Option<u8>
+    pub(crate) async fn get_gas_price(self, era_id: EraId) -> Option<u8>
     where
         REv: From<ContractRuntimeRequest>,
     {

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -925,7 +925,10 @@ impl reactor::Reactor for MainReactor {
                     transaction_buffer::Event::UpdateEraGasPrice(era_id, next_era_gas_price),
                 );
                 let transaction_acceptor_event = MainEvent::TransactionAcceptor(
-                    transaction_acceptor::Event::UpdateCurrentGasPrice(next_era_gas_price),
+                    transaction_acceptor::Event::UpdateCurrentGasPrice {
+                        era: era_id,
+                        price: next_era_gas_price,
+                    },
                 );
                 effects.extend(self.dispatch_event(effect_builder, rng, transaction_buffer_event));
                 effects.extend(self.dispatch_event(

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -921,10 +921,18 @@ impl reactor::Reactor for MainReactor {
                     ContractRuntimeRequest::UpdateRuntimePrice(era_id, next_era_gas_price),
                 );
                 let mut effects = self.dispatch_event(effect_builder, rng, event);
-                let reactor_event = MainEvent::TransactionBuffer(
+                let transaction_buffer_event = MainEvent::TransactionBuffer(
                     transaction_buffer::Event::UpdateEraGasPrice(era_id, next_era_gas_price),
                 );
-                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
+                let transaction_acceptor_event = MainEvent::TransactionAcceptor(
+                    transaction_acceptor::Event::UpdateCurrentGasPrice(next_era_gas_price),
+                );
+                effects.extend(self.dispatch_event(effect_builder, rng, transaction_buffer_event));
+                effects.extend(self.dispatch_event(
+                    effect_builder,
+                    rng,
+                    transaction_acceptor_event,
+                ));
                 effects
             }
 

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -924,13 +924,13 @@ impl reactor::Reactor for MainReactor {
                 let transaction_buffer_event = MainEvent::TransactionBuffer(
                     transaction_buffer::Event::UpdateEraGasPrice(era_id, next_era_gas_price),
                 );
+                effects.extend(self.dispatch_event(effect_builder, rng, transaction_buffer_event));
                 let transaction_acceptor_event = MainEvent::TransactionAcceptor(
-                    transaction_acceptor::Event::UpdateCurrentGasPrice {
+                    transaction_acceptor::Event::UpdateEraGasPrice {
                         era: era_id,
                         price: next_era_gas_price,
                     },
                 );
-                effects.extend(self.dispatch_event(effect_builder, rng, transaction_buffer_event));
                 effects.extend(self.dispatch_event(
                     effect_builder,
                     rng,

--- a/node/src/reactor/main_reactor/config.rs
+++ b/node/src/reactor/main_reactor/config.rs
@@ -66,10 +66,26 @@ impl Config {
                 configured_timestamp_leeway = %self.transaction_acceptor.timestamp_leeway,
                 max_timestamp_leeway = %chainspec.transaction_config.max_timestamp_leeway,
                 "setting value for 'transaction_acceptor.timestamp_leeway' to maximum permitted by \
-                chainspec 'transaction_config.max_timestamp_leeway'",
+                chainspec 'transactions.max_timestamp_leeway'",
             );
             self.transaction_acceptor.timestamp_leeway =
                 chainspec.transaction_config.max_timestamp_leeway;
+        }
+
+        if self.transaction_acceptor.ttl_leeway_for_upgrade_point_check
+            > chainspec
+                .transaction_config
+                .max_ttl_leeway_for_upgrade_point_check
+        {
+            error!(
+                configured_ttl_leeway_for_upgrade_point_check = %self.transaction_acceptor.ttl_leeway_for_upgrade_point_check,
+                max_ttl_leeway_for_upgrade_point_check = %chainspec.transaction_config.max_ttl_leeway_for_upgrade_point_check,
+                "setting value for 'transaction_acceptor.ttl_leeway_for_upgrade_point_check' to maximum permitted by \
+                chainspec 'transactions.max_ttl_leeway_for_upgrade_point_check'",
+            );
+            self.transaction_acceptor.ttl_leeway_for_upgrade_point_check = chainspec
+                .transaction_config
+                .max_ttl_leeway_for_upgrade_point_check;
         }
     }
 }

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -387,6 +387,7 @@ impl MainReactor {
                 ExecutableBlock::from_finalized_block_and_transactions(
                     genesis_switch_block,
                     vec![],
+                    None,
                 ),
                 MetaBlockState::new_not_to_be_gossiped(),
             )

--- a/node/src/types/block/executable_block.rs
+++ b/node/src/types/block/executable_block.rs
@@ -57,6 +57,7 @@ impl ExecutableBlock {
     pub fn from_finalized_block_and_transactions(
         finalized_block: FinalizedBlock,
         transactions: Vec<Transaction>,
+        next_era_gas_price: Option<u8>,
     ) -> Self {
         Self {
             rewarded_signatures: finalized_block.rewarded_signatures,
@@ -69,7 +70,7 @@ impl ExecutableBlock {
             transactions,
             transaction_map: finalized_block.transactions,
             rewards: None,
-            next_era_gas_price: None,
+            next_era_gas_price,
         }
     }
 

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -175,6 +175,8 @@ block_gas_limit = 3_300_000_000_000
 native_transfer_minimum_motes = 2_500_000_000
 # The maximum value to which `transaction_acceptor.timestamp_leeway` can be set in the config.toml file.
 max_timestamp_leeway = '5 seconds'
+# The maximum value to which `transaction_acceptor.ttl_leeway_for_upgrade_point_check` can be set in the config.toml file.
+max_ttl_leeway_for_upgrade_point_check = '12 hours'
 
 [transactions.v1]
 # The configuration settings for the lanes of transactions including both native and Wasm based interactions.

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -579,6 +579,9 @@ timestamp_leeway = '2 seconds'
 # fact that era duration may vary and that we can't determine how much time in the current era
 # has passed) we allow short leeway when comparing timestamps to minimize the chances of the
 # transaction being rejected erroneously.
+#
+# The maximum value to which `ttl_leeway_for_upgrade_point_check` can be set is defined by the
+# chainspec setting `transaction.max_ttl_leeway_for_upgrade_point_check`.
 ttl_leeway_for_upgrade_point_check = '2 hours'
 
 

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -574,6 +574,13 @@ enable_manual_sync = true
 # `transaction.max_timestamp_leeway`.
 timestamp_leeway = '2 seconds'
 
+# The gas price tolerance checks are disabled if the transaction TTL extends beyond the planned
+# upgrade activation point. Since it's not possible to do the calculations precisely (due to the
+# fact that era duration may vary and that we can't determine how much time in the current era
+# has passed) we allow short leeway when comparing timestamps to minimize the chances of the
+# transaction being rejected erroneously.
+ttl_leeway_for_upgrade_point_check = '2 hours'
+
 
 # ===========================================
 # Configuration options for the transaction buffer

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -185,6 +185,8 @@ block_gas_limit = 3_300_000_000_000
 native_transfer_minimum_motes = 2_500_000_000
 # The maximum value to which `transaction_acceptor.timestamp_leeway` can be set in the config.toml file.
 max_timestamp_leeway = '5 seconds'
+# The maximum value to which `transaction_acceptor.ttl_leeway_for_upgrade_point_check` can be set in the config.toml file.
+max_ttl_leeway_for_upgrade_point_check = '12 hours'
 
 [transactions.v1]
 # The configuration settings for the lanes of transactions including both native and Wasm based interactions.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -572,6 +572,12 @@ max_global_state_size = 2_089_072_132_096
 # `transaction.max_timestamp_leeway`.
 timestamp_leeway = '2 seconds'
 
+# The gas price tolerance checks are disabled if the transaction TTL extends beyond the planned
+# upgrade activation point. Since it's not possible to do the calculations precisely (due to the
+# fact that era duration may vary and that we can't determine how much time in the current era
+# has passed) we allow short leeway when comparing timestamps to minimize the chances of the
+# transaction being rejected erroneously.
+ttl_leeway_for_upgrade_point_check = '2 hours'
 
 # ===========================================
 # Configuration options for the transaction buffer

--- a/types/src/block/block_header.rs
+++ b/types/src/block/block_header.rs
@@ -174,6 +174,14 @@ impl BlockHeader {
         }
     }
 
+    /// Returns the gas price for the upcoming era (if this is a switch block).
+    pub fn next_era_gas_price(&self) -> Option<u8> {
+        match self {
+            BlockHeader::V1(_) => None,
+            BlockHeader::V2(v2) => v2.next_era_gas_price(),
+        }
+    }
+
     /// Returns `true` if this block is the Genesis block, i.e. has height 0 and era 0.
     pub fn is_genesis(&self) -> bool {
         match self {

--- a/types/src/block/block_header/block_header_v2.rs
+++ b/types/src/block/block_header/block_header_v2.rs
@@ -182,6 +182,13 @@ impl BlockHeaderV2 {
             .map(|era_end| era_end.next_era_validator_weights())
     }
 
+    /// Returns the gas price for the upcoming era (if this is a switch block).
+    pub fn next_era_gas_price(&self) -> Option<u8> {
+        self.era_end
+            .as_ref()
+            .map(|era_end| era_end.next_era_gas_price())
+    }
+
     /// Returns `true` if this block is the Genesis block, i.e. has height 0 and era 0.
     pub fn is_genesis(&self) -> bool {
         self.era_id().is_genesis() && self.height() == 0

--- a/types/src/chainspec/transaction_config.rs
+++ b/types/src/chainspec/transaction_config.rs
@@ -46,6 +46,9 @@ pub struct TransactionConfig {
     /// Maximum value to which `transaction_acceptor.timestamp_leeway` can be set in the
     /// config.toml file.
     pub max_timestamp_leeway: TimeDiff,
+    /// The maximum value to which `transaction_acceptor.ttl_leeway_for_upgrade_point_check` can be
+    /// set in the config.toml file.
+    pub max_ttl_leeway_for_upgrade_point_check: TimeDiff,
     /// Configuration values specific to Deploy transactions.
     #[serde(rename = "deploy")]
     pub deploy_config: DeployConfig,
@@ -65,6 +68,8 @@ impl TransactionConfig {
         let native_transfer_minimum_motes =
             rng.gen_range(DEFAULT_MIN_TRANSFER_MOTES..1_000_000_000_000_000);
         let max_timestamp_leeway = TimeDiff::from_seconds(rng.gen_range(0..6));
+        let max_ttl_leeway_for_upgrade_point_check =
+            TimeDiff::from_seconds(rng.gen_range(60 * 60 * 2..60 * 60 * 8));
         let deploy_config = DeployConfig::random(rng);
         let transaction_v1_config = TransactionV1Config::random(rng);
 
@@ -77,6 +82,7 @@ impl TransactionConfig {
             max_timestamp_leeway,
             deploy_config,
             transaction_v1_config,
+            max_ttl_leeway_for_upgrade_point_check,
         }
     }
 }
@@ -93,6 +99,7 @@ impl Default for TransactionConfig {
             max_timestamp_leeway: TimeDiff::from_seconds(5),
             deploy_config: DeployConfig::default(),
             transaction_v1_config: TransactionV1Config::default(),
+            max_ttl_leeway_for_upgrade_point_check: TimeDiff::from_seconds(60 * 60 * 2),
         }
     }
 }
@@ -105,6 +112,8 @@ impl ToBytes for TransactionConfig {
         self.block_gas_limit.write_bytes(writer)?;
         self.native_transfer_minimum_motes.write_bytes(writer)?;
         self.max_timestamp_leeway.write_bytes(writer)?;
+        self.max_ttl_leeway_for_upgrade_point_check
+            .write_bytes(writer)?;
         self.deploy_config.write_bytes(writer)?;
         self.transaction_v1_config.write_bytes(writer)
     }
@@ -122,6 +131,9 @@ impl ToBytes for TransactionConfig {
             + self.block_gas_limit.serialized_length()
             + self.native_transfer_minimum_motes.serialized_length()
             + self.max_timestamp_leeway.serialized_length()
+            + self
+                .max_ttl_leeway_for_upgrade_point_check
+                .serialized_length()
             + self.deploy_config.serialized_length()
             + self.transaction_v1_config.serialized_length()
     }
@@ -135,6 +147,7 @@ impl FromBytes for TransactionConfig {
         let (block_gas_limit, remainder) = u64::from_bytes(remainder)?;
         let (native_transfer_minimum_motes, remainder) = u64::from_bytes(remainder)?;
         let (max_timestamp_leeway, remainder) = TimeDiff::from_bytes(remainder)?;
+        let (max_ttl_leeway_for_upgrade_point_check, remainder) = TimeDiff::from_bytes(remainder)?;
         let (deploy_config, remainder) = DeployConfig::from_bytes(remainder)?;
         let (transaction_v1_config, remainder) = TransactionV1Config::from_bytes(remainder)?;
 
@@ -147,6 +160,7 @@ impl FromBytes for TransactionConfig {
             max_timestamp_leeway,
             deploy_config,
             transaction_v1_config,
+            max_ttl_leeway_for_upgrade_point_check,
         };
         Ok((config, remainder))
     }

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -393,6 +393,15 @@ impl Transaction {
         }
     }
 
+    /// Returns the gas price tolerance.
+    #[cfg(any(feature = "std", test))]
+    pub fn gas_price_tolerance(&self) -> Result<u8, InvalidDeploy> {
+        match self {
+            Transaction::Deploy(deploy) => deploy.gas_price_tolerance(),
+            Transaction::V1(tx) => Ok(tx.header().gas_price_tolerance()),
+        }
+    }
+
     // This method is not intended to be used by third party crates.
     #[doc(hidden)]
     #[cfg(feature = "json-schema")]

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -2259,36 +2259,6 @@ mod tests {
     }
 
     #[test]
-    fn not_acceptable_due_to_too_low_gas_price_tolerance() {
-        const GAS_PRICE_TOLERANCE: u8 = 0;
-
-        let mut rng = TestRng::new();
-        let chain_name = "net-1";
-        let mut chainspec = Chainspec::default();
-        chainspec.with_chain_name(chain_name.to_string());
-
-        let config = chainspec.transaction_config.clone();
-        let deploy = create_deploy(
-            &mut rng,
-            config.max_ttl,
-            config.deploy_config.max_dependencies as usize,
-            chain_name,
-            GAS_PRICE_TOLERANCE as u64,
-        );
-
-        let current_timestamp = deploy.header().timestamp();
-        assert!(matches!(
-            deploy.is_config_compliant(
-                &chainspec,
-                TimeDiff::default(),
-                current_timestamp
-            ),
-            Err(InvalidDeploy::GasPriceToleranceTooLow { min_gas_price_tolerance, provided_gas_price_tolerance })
-                if min_gas_price_tolerance == chainspec.vacancy_config.min_gas_price && provided_gas_price_tolerance == GAS_PRICE_TOLERANCE
-        ))
-    }
-
-    #[test]
     fn not_acceptable_due_to_insufficient_transfer_amount() {
         const GAS_PRICE_TOLERANCE: u8 = u8::MAX;
 

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -585,6 +585,44 @@ impl Deploy {
         )
     }
 
+    /// Returns a random `Deploy` but using the specified `timestamp`, `ttl` and `gas_price`.
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
+    pub fn random_with_timestamp_and_ttl_and_gas_price(
+        rng: &mut TestRng,
+        timestamp: Timestamp,
+        ttl: TimeDiff,
+        gas_price: u64,
+    ) -> Self {
+        let dependencies = vec![];
+        let chain_name = String::from("casper-example");
+
+        // We need "amount" in order to be able to get correct info via `deploy_info()`.
+        let payment_args = runtime_args! {
+            "amount" => U512::from(DEFAULT_MAX_PAYMENT_MOTES),
+        };
+        let payment = ExecutableDeployItem::StoredContractByName {
+            name: String::from("casper-example"),
+            entry_point: String::from("example-entry-point"),
+            args: payment_args,
+        };
+
+        let session = rng.gen();
+
+        let secret_key = SecretKey::random(rng);
+
+        Deploy::new(
+            timestamp,
+            ttl,
+            gas_price,
+            dependencies,
+            chain_name,
+            payment,
+            session,
+            &secret_key,
+            None,
+        )
+    }
+
     /// Turns `self` into an invalid `Deploy` by clearing the `chain_name`, invalidating the deploy
     /// hash.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -424,15 +424,6 @@ impl Deploy {
             });
         }
 
-        let min_gas_price = chainspec.vacancy_config.min_gas_price;
-        let gas_price_tolerance = self.gas_price_tolerance()?;
-        if gas_price_tolerance < min_gas_price {
-            return Err(InvalidDeploy::GasPriceToleranceTooLow {
-                min_gas_price_tolerance: min_gas_price,
-                provided_gas_price_tolerance: gas_price_tolerance,
-            });
-        }
-
         header.is_valid(config, timestamp_leeway, at, &self.hash)?;
 
         let max_associated_keys = chainspec.core_config.max_associated_keys;

--- a/types/src/transaction/deploy/error.rs
+++ b/types/src/transaction/deploy/error.rs
@@ -132,6 +132,16 @@ pub enum InvalidDeploy {
         /// The provided gas price tolerance.
         provided_gas_price_tolerance: u8,
     },
+
+    /// Unreachable gas price tolerance.
+    GasPriceToleranceUnreachable {
+        /// Current gas price.
+        current_gas_price: u8,
+        /// Acceptable gas price.
+        provided_gas_price_tolerance: u8,
+        /// Lowest possible gas price within TTL.
+        lowest_possible_gas_price_within_ttl: u8,
+    },
 }
 
 impl Display for InvalidDeploy {
@@ -254,6 +264,13 @@ impl Display for InvalidDeploy {
                 "received a deploy with gas price tolerance {} but this chain will only go as low as {}",
                 provided_gas_price_tolerance, min_gas_price_tolerance
             ),
+            InvalidDeploy::GasPriceToleranceUnreachable { current_gas_price, provided_gas_price_tolerance, lowest_possible_gas_price_within_ttl } =>                 write!(
+                formatter,
+                "received a deploy with gas price tolerance {provided_gas_price_tolerance} but current gas \
+                price is {current_gas_price} and it can only reach {lowest_possible_gas_price_within_ttl} within \
+                the transaction TTL",
+            )
+,
         }
     }
 }
@@ -288,7 +305,8 @@ impl StdError for InvalidDeploy {
             | InvalidDeploy::ExcessiveApprovals { .. }
             | InvalidDeploy::UnableToCalculateGasLimit
             | InvalidDeploy::UnableToCalculateGasCost
-            | InvalidDeploy::GasPriceToleranceTooLow { .. } => None,
+            | InvalidDeploy::GasPriceToleranceTooLow { .. }
+            | InvalidDeploy::GasPriceToleranceUnreachable { .. } => None,
         }
     }
 }

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -415,15 +415,6 @@ impl TransactionV1 {
             }
         }
 
-        let min_gas_price = chainspec.vacancy_config.min_gas_price;
-        let gas_price_tolerance = self.header.gas_price_tolerance();
-        if gas_price_tolerance < min_gas_price {
-            return Err(InvalidTransactionV1::GasPriceToleranceTooLow {
-                min_gas_price_tolerance: min_gas_price,
-                provided_gas_price_tolerance: gas_price_tolerance,
-            });
-        }
-
         header.is_valid(&transaction_config, timestamp_leeway, at, &self.hash)?;
 
         let max_associated_keys = chainspec.core_config.max_associated_keys;

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -163,6 +163,15 @@ pub enum InvalidTransaction {
         /// The provided gas price tolerance.
         provided_gas_price_tolerance: u8,
     },
+    /// Unreachable gas price tolerance.
+    GasPriceToleranceUnreachable {
+        /// Current gas price.
+        current_gas_price: u8,
+        /// Acceptable gas price.
+        provided_gas_price_tolerance: u8,
+        /// Lowest possible gas price within TTL.
+        lowest_possible_gas_price_within_ttl: u8,
+    },
 }
 
 impl Display for InvalidTransaction {
@@ -311,6 +320,18 @@ impl Display for InvalidTransaction {
                     provided_gas_price_tolerance, min_gas_price_tolerance
                 )
             }
+            InvalidTransaction::GasPriceToleranceUnreachable {
+                current_gas_price,
+                provided_gas_price_tolerance,
+                lowest_possible_gas_price_within_ttl,
+            } => {
+                write!(
+                    formatter,
+                    "received a transaction with gas price tolerance {provided_gas_price_tolerance} but current gas \
+                    price is {current_gas_price} and it can only reach {lowest_possible_gas_price_within_ttl} within \
+                    the transaction TTL",
+                )
+            }
         }
     }
 }
@@ -349,6 +370,7 @@ impl StdError for InvalidTransaction {
             | InvalidTransaction::UnableToCalculateGasCost
             | InvalidTransaction::InvalidPricingMode { .. }
             | InvalidTransaction::GasPriceToleranceTooLow { .. }
+            | InvalidTransaction::GasPriceToleranceUnreachable { .. }
             | InvalidTransaction::InvalidTransactionKind(_) => None,
         }
     }


### PR DESCRIPTION
This PR adds another check to the transaction acceptor.

It makes the acceptor reject transactions with gas price tolerance set to a value that is not achievable by the chain within the given TTL.

Calculation is based on the assumptions that chain gas price can only go up and down by 1 every each era.

Additionally, this PR also fixes the problem with the gas price being reset after the network upgrade. With the fix, the gas price is preserved across the upgrades, which is covered by a new NCTL upgrade test in the [corresponding PR](https://github.com/casper-network/casper-nctl/pull/14).