### PR TITLE
trie store: fix extension node split when inserting key of variable len

### DIFF
--- a/storage/src/global_state/trie_store/operations/mod.rs
+++ b/storage/src/global_state/trie_store/operations/mod.rs
@@ -363,6 +363,14 @@ where
                 }
             }
             LazilyDeserializedTrie::Extension { affix, pointer } => {
+                if path.len() < depth + affix.len() {
+                    // We might be trying to store a key that is shorter than the keys that are
+                    // already stored. In this case, we would need to split this extension.
+                    return Ok(TrieScanRaw::new(
+                        LazilyDeserializedTrie::Extension { affix, pointer },
+                        acc,
+                    ));
+                }
                 let sub_path = &path[depth..depth + affix.len()];
                 if sub_path != affix.as_slice() {
                     return Ok(TrieScanRaw::new(


### PR DESCRIPTION
When using keys that are different lengths it may be possible that while traversing the MPT store to insert a shorter key than the ones already stored we encounter an extension node that has an affix which would create a sub path that is larger than the new key length.
The old code did not take this into account as the expectation was that all keys in a particular subtrie would have the same length. In Condor this assumption is no longer true so when we encounter such situation, we need to split the extension node accordingly.