### PR TITLE
Introducing calltable serialization to `TransactionV1` structures subtree.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,8 +186,8 @@ checksum = "a941c39708478e8eea39243b5983f1c42d2717b3620ee91f4a52115fd02ac43f"
 dependencies = [
  "itertools 0.9.0",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -239,9 +239,9 @@ version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -984,8 +984,8 @@ checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -996,9 +996,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1462,7 +1462,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.32",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -1489,9 +1489,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1519,8 +1519,8 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613e4ee15899913285b7612004bbd490abd605be7b11d35afada5902fb6b91d5"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -1564,10 +1564,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "rustc_version",
- "syn 2.0.32",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1748,8 +1748,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "079044df30bb07de7d846d41a184c4b00e66ebdac93ee459253474f3a47e50ae"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -2007,8 +2007,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -2020,9 +2020,9 @@ checksum = "e4f76552f53cefc9a7f64987c3701b99d982f7690606fd67de1d09712fbf52f1"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2279,9 +2279,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2763,9 +2763,9 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3912,8 +3912,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -4038,9 +4038,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4194,9 +4194,9 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4300,8 +4300,8 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30490e0852e58402b8fae0d39897b08a24f493023a4d6cf56b2e30f31ed57548"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "regex",
  "syn 1.0.109",
 ]
@@ -4396,8 +4396,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
  "version_check",
 ]
@@ -4408,8 +4408,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "version_check",
 ]
 
@@ -4424,9 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -4478,8 +4478,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa06db3abc95f048e0afa371db5569b24912bb98a8e2e2e89c75c5b43bc2aa8"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -4576,11 +4576,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.86",
 ]
 
 [[package]]
@@ -5119,8 +5119,8 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "serde_derive_internals",
  "syn 1.0.109",
 ]
@@ -5232,9 +5232,9 @@ version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5243,8 +5243,8 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -5266,9 +5266,9 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5512,8 +5512,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -5539,8 +5539,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -5552,10 +5552,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "rustversion",
- "syn 2.0.32",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5604,19 +5604,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "unicode-ident",
 ]
 
@@ -5734,9 +5734,9 @@ version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d7b1fadccbbc7e19ea64708629f9d8dccd007c260d66485f20a6d41bc1cf4b3"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5827,9 +5827,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6022,9 +6022,9 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6442,7 +6442,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d0801cec07737d88cb900e6419f6f68733867f90b3faaa837e84692e101bf0"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.86",
  "pulldown-cmark",
  "regex",
  "semver",
@@ -6522,8 +6522,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -6593,9 +6593,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -6617,7 +6617,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.32",
+ "quote 1.0.36",
  "wasm-bindgen-macro-support",
 ]
 
@@ -6627,9 +6627,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6947,9 +6947,9 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.32",
- "syn 2.0.32",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/execution_engine_testing/tests/src/test/explorer/faucet.rs
+++ b/execution_engine_testing/tests/src/test/explorer/faucet.rs
@@ -660,10 +660,11 @@ fn faucet_costs() {
     // This test will fail if execution costs vary.  The expected costs should not be updated
     // without understanding why the cost has changed.  If the costs do change, it should be
     // reflected in the "Costs by Entry Point" section of the faucet crate's README.md.
-    const EXPECTED_FAUCET_INSTALL_COST: u64 = 160_907_378_504;
+    const EXPECTED_FAUCET_INSTALL_COST: u64 = 160_995_706_637;
+
     const EXPECTED_FAUCET_SET_VARIABLES_COST: u64 = 135_355_310;
-    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_884_533_347;
-    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_623_236_926;
+    const EXPECTED_FAUCET_CALL_BY_INSTALLER_COST: u64 = 2_884_534_947;
+    const EXPECTED_FAUCET_CALL_BY_USER_COST: u64 = 2_623_238_526;
 
     let installer_account = AccountHash::new([1u8; 32]);
     let user_account: AccountHash = AccountHash::new([2u8; 32]);

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -1562,9 +1562,15 @@
         "approvals",
         "body",
         "hash",
-        "header"
+        "header",
+        "serialization_version"
       ],
       "properties": {
+        "serialization_version": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
         "hash": {
           "$ref": "#/definitions/TransactionV1Hash"
         },

--- a/types/src/bytesrepr.rs
+++ b/types/src/bytesrepr.rs
@@ -104,10 +104,16 @@ pub fn unchecked_allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Vec<u8> {
 /// serialization, or an error if the capacity would exceed `u32::MAX`.
 pub fn allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Result<Vec<u8>, Error> {
     let serialized_length = to_be_serialized.serialized_length();
-    if serialized_length > u32::MAX as usize {
+    allocate_buffer_for_size(serialized_length)
+}
+
+/// Returns a `Vec<u8>` initialized with sufficient capacity to hold `expected_size` bytes,
+/// or an error if the capacity would exceed `u32::max_value()`.
+pub fn allocate_buffer_for_size(expected_size: usize) -> Result<Vec<u8>, Error> {
+    if expected_size > u32::max_value() as usize {
         return Err(Error::OutOfMemory);
     }
-    Ok(Vec::with_capacity(serialized_length))
+    Ok(Vec::with_capacity(expected_size))
 }
 
 /// Serialization and deserialization errors.

--- a/types/src/crypto/asymmetric_key/gens.rs
+++ b/types/src/crypto/asymmetric_key/gens.rs
@@ -42,3 +42,17 @@ pub fn public_key_arb_no_system() -> impl Strategy<Value = PublicKey> {
         })
     ]
 }
+
+/// Returns a strategy for creating random [`SecretKey`] instances but NOT system variant.
+pub fn secret_key_arb_no_system() -> impl Strategy<Value = SecretKey> {
+    prop_oneof![
+        collection::vec(<u8>::arbitrary(), SecretKey::ED25519_LENGTH).prop_map(|bytes| {
+            let byte_array: [u8; SecretKey::ED25519_LENGTH] = bytes.try_into().unwrap();
+            SecretKey::ed25519_from_bytes(byte_array).unwrap()
+        }),
+        collection::vec(<u8>::arbitrary(), SecretKey::SECP256K1_LENGTH).prop_map(|bytes| {
+            let bytes_array: [u8; SecretKey::SECP256K1_LENGTH] = bytes.try_into().unwrap();
+            SecretKey::secp256k1_from_bytes(bytes_array).unwrap()
+        })
+    ]
+}

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     block::BlockGlobalAddr,
     byte_code::ByteCodeKind,
+    bytesrepr::Bytes,
     contract_messages::{MessageChecksum, MessageTopicSummary, TopicNameHash},
     contracts::{
         Contract, ContractHash, ContractPackage, ContractPackageStatus, ContractVersionKey,
@@ -53,8 +54,10 @@ use crate::{
     },
     AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, ByteCode, CLType, CLValue,
     Digest, EntityAddr, EntityKind, EntryPoint, EntryPointAccess, EntryPointPayment,
-    EntryPointType, EntryPoints, EraId, Group, Key, NamedArg, Package, Parameter, Phase,
-    ProtocolVersion, SemVer, StoredValue, TransactionRuntime, URef, U128, U256, U512,
+    EntryPointType, EntryPoints, EraId, Group, InitiatorAddr, Key, NamedArg, Package, Parameter,
+    Phase, PricingMode, ProtocolVersion, RuntimeArgs, SemVer, StoredValue, Timestamp,
+    TransactionCategory, TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntime,
+    TransactionScheduling, TransactionTarget, TransactionV1Body, URef, U128, U256, U512,
 };
 
 pub fn u8_slice_32() -> impl Strategy<Value = [u8; 32]> {
@@ -522,6 +525,10 @@ pub fn entity_kind_arb() -> impl Strategy<Value = EntityKind> {
     ]
 }
 
+pub fn addressable_entity_hash_arb() -> impl Strategy<Value = AddressableEntityHash> {
+    u8_slice_32().prop_map(AddressableEntityHash::new)
+}
+
 pub fn addressable_entity_arb() -> impl Strategy<Value = AddressableEntity> {
     (
         protocol_version_arb(),
@@ -910,4 +917,138 @@ pub fn trie_merkle_proof_arb() -> impl Strategy<Value = TrieMerkleProof<Key, Sto
         vec(trie_merkle_proof_step_arb(), STEPS_SIZE),
     )
         .prop_map(|(key, value, proof_steps)| TrieMerkleProof::new(key, value, proof_steps.into()))
+}
+
+pub fn transaction_category_arb() -> impl Strategy<Value = TransactionCategory> {
+    prop_oneof![
+        Just(TransactionCategory::Mint),
+        Just(TransactionCategory::Auction),
+        Just(TransactionCategory::InstallUpgrade),
+        Just(TransactionCategory::Large),
+        Just(TransactionCategory::Medium),
+        Just(TransactionCategory::Small),
+    ]
+}
+
+pub fn transaction_scheduling_arb() -> impl Strategy<Value = TransactionScheduling> {
+    prop_oneof![
+        Just(TransactionScheduling::Standard),
+        era_id_arb().prop_map(TransactionScheduling::FutureEra),
+        any::<u64>().prop_map(
+            |timestamp| TransactionScheduling::FutureTimestamp(Timestamp::from(timestamp))
+        ),
+    ]
+}
+
+pub fn transaction_invocation_target_arb() -> impl Strategy<Value = TransactionInvocationTarget> {
+    prop_oneof![
+        addressable_entity_hash_arb().prop_map(TransactionInvocationTarget::new_invocable_entity),
+        Just(TransactionInvocationTarget::new_invocable_entity_alias(
+            "abcd".to_string()
+        )),
+        Just(TransactionInvocationTarget::new_package_alias(
+            "abcd".to_string(),
+            None
+        )),
+        Just(TransactionInvocationTarget::new_package_alias(
+            "abcd".to_string(),
+            Some(10)
+        )),
+        u8_slice_32()
+            .prop_map(|addr| { TransactionInvocationTarget::new_package(addr.into(), None) }),
+        u8_slice_32()
+            .prop_map(|addr| { TransactionInvocationTarget::new_package(addr.into(), Some(150)) }),
+    ]
+}
+
+pub fn transaction_target_arb() -> impl Strategy<Value = TransactionTarget> {
+    prop_oneof![
+        Just(TransactionTarget::Native),
+        (
+            transaction_invocation_target_arb(),
+            transaction_runtime_arb()
+        )
+            .prop_map(|(target, runtime)| TransactionTarget::new_stored(target, runtime))
+    ]
+}
+pub fn transaction_entry_point_arb() -> impl Strategy<Value = TransactionEntryPoint> {
+    prop_oneof![
+        Just(TransactionEntryPoint::Call),
+        Just(TransactionEntryPoint::Transfer),
+        Just(TransactionEntryPoint::AddBid),
+        Just(TransactionEntryPoint::WithdrawBid),
+        Just(TransactionEntryPoint::Delegate),
+        Just(TransactionEntryPoint::Undelegate),
+        Just(TransactionEntryPoint::Redelegate),
+        Just(TransactionEntryPoint::ActivateBid),
+        Just(TransactionEntryPoint::ChangeBidPublicKey),
+        Just(TransactionEntryPoint::Custom("custom".to_string())),
+        Just(TransactionEntryPoint::AddReservations),
+        Just(TransactionEntryPoint::CancelReservations),
+    ]
+}
+
+pub fn runtime_args_arb() -> impl Strategy<Value = RuntimeArgs> {
+    let mut runtime_args_1 = RuntimeArgs::new();
+    let semi_random_string_pairs = [
+        ("977837db-8dba-48c2-86f1-32f9740631db", "b7b3b3b3-8b3b-48c2-86f1-32f9740631db"),
+        ("5de3eecc-b9c8-477f-bebe-937c3a16df85", "2ffd7939-34e5-4660-af9f-772a83011ce0"),
+        ("036db036-8b7b-4009-a0d4-c9ce", "515f4fe6-06c8-45c5-8554-f07e727a842d036db036-8b7b-4009-a0d4-c9ce036db036-8b7b-4009-a0d4-c9ce"),
+    ];
+    for (key, val_str) in semi_random_string_pairs.iter() {
+        let _ = runtime_args_1.insert(key.to_string(), Bytes::from(val_str.as_bytes()));
+    }
+    prop_oneof![Just(runtime_args_1)]
+}
+
+pub fn v1_transaction_body_arb() -> impl Strategy<Value = TransactionV1Body> {
+    (
+        runtime_args_arb(),
+        transaction_target_arb(),
+        transaction_entry_point_arb(),
+        transaction_category_arb(),
+        transaction_scheduling_arb(),
+    )
+        .prop_map(
+            |(args, target, entry_point, transaction_category, scheduling)| {
+                TransactionV1Body::new(
+                    args,
+                    target,
+                    entry_point,
+                    transaction_category as u8,
+                    scheduling,
+                )
+            },
+        )
+}
+
+pub fn pricing_mode_arb() -> impl Strategy<Value = PricingMode> {
+    prop_oneof![
+        (any::<u64>(), any::<u8>(), any::<bool>()).prop_map(
+            |(payment_amount, gas_price_tolerance, standard_payment)| {
+                PricingMode::Classic {
+                    payment_amount,
+                    gas_price_tolerance,
+                    standard_payment,
+                }
+            }
+        ),
+        any::<u8>().prop_map(|gas_price_tolerance| {
+            PricingMode::Fixed {
+                gas_price_tolerance,
+            }
+        }),
+        u8_slice_32().prop_map(|receipt| {
+            PricingMode::Reserved {
+                receipt: receipt.into(),
+            }
+        }),
+    ]
+}
+
+pub fn initiator_addr_arb() -> impl Strategy<Value = InitiatorAddr> {
+    prop_oneof![
+        public_key_arb_no_system().prop_map(InitiatorAddr::PublicKey),
+        u2_slice_32().prop_map(|hash| InitiatorAddr::AccountHash(AccountHash::new(hash))),
+    ]
 }

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -10,6 +10,7 @@ mod initiator_addr_and_secret_key;
 mod package_identifier;
 mod pricing_mode;
 mod runtime_args;
+mod serialization;
 mod transaction_category;
 mod transaction_entry_point;
 mod transaction_hash;

--- a/types/src/transaction/pricing_mode.rs
+++ b/types/src/transaction/pricing_mode.rs
@@ -9,18 +9,19 @@ use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::serialization::CalltableSerializationEnvelope;
 #[cfg(doc)]
 use super::Transaction;
 #[cfg(any(feature = "testing", test))]
 use crate::testing::TestRng;
 use crate::{
-    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    bytesrepr::{
+        Error::{self, Formatting},
+        FromBytes, ToBytes,
+    },
+    transaction::serialization::CalltableSerializationEnvelopeBuilder,
     Digest,
 };
-
-const CLASSIC_TAG: u8 = 0;
-const FIXED_TAG: u8 = 1;
-const RESERVED_TAG: u8 = 2;
 
 /// The pricing mode of a [`Transaction`].
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
@@ -77,6 +78,133 @@ impl PricingMode {
             _ => unreachable!(),
         }
     }
+
+    fn serialized_field_lengths(&self) -> Vec<usize> {
+        match self {
+            PricingMode::Classic {
+                payment_amount,
+                gas_price_tolerance,
+                standard_payment,
+            } => {
+                vec![
+                    crate::bytesrepr::U8_SERIALIZED_LENGTH,
+                    payment_amount.serialized_length(),
+                    gas_price_tolerance.serialized_length(),
+                    standard_payment.serialized_length(),
+                ]
+            }
+            PricingMode::Fixed {
+                gas_price_tolerance,
+            } => {
+                vec![
+                    crate::bytesrepr::U8_SERIALIZED_LENGTH,
+                    gas_price_tolerance.serialized_length(),
+                ]
+            }
+            PricingMode::Reserved { receipt } => {
+                vec![
+                    crate::bytesrepr::U8_SERIALIZED_LENGTH,
+                    receipt.serialized_length(),
+                ]
+            }
+        }
+    }
+}
+const TAG_FIELD_INDEX: u16 = 0;
+
+const CLASSIC_VARIANT_TAG: u8 = 0;
+const CLASSIC_PAYMENT_AMOUNT_INDEX: u16 = 1;
+const CLASSIC_GAS_PRICE_TOLERANCE_INDEX: u16 = 2;
+const CLASSIC_STANDARD_PAYMENT_INDEX: u16 = 3;
+
+const FIXED_VARIANT_TAG: u8 = 1;
+const FIXED_GAS_PRICE_TOLERANCE_INDEX: u16 = 1;
+
+const RESERVED_VARIANT_TAG: u8 = 2;
+const RESERVED_RECEIPT_INDEX: u16 = 1;
+
+impl ToBytes for PricingMode {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        match self {
+            PricingMode::Classic {
+                payment_amount,
+                gas_price_tolerance,
+                standard_payment,
+            } => CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+                .add_field(TAG_FIELD_INDEX, &CLASSIC_VARIANT_TAG)?
+                .add_field(CLASSIC_PAYMENT_AMOUNT_INDEX, &payment_amount)?
+                .add_field(CLASSIC_GAS_PRICE_TOLERANCE_INDEX, &gas_price_tolerance)?
+                .add_field(CLASSIC_STANDARD_PAYMENT_INDEX, &standard_payment)?
+                .binary_payload_bytes(),
+            PricingMode::Fixed {
+                gas_price_tolerance,
+            } => CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+                .add_field(TAG_FIELD_INDEX, &FIXED_VARIANT_TAG)?
+                .add_field(FIXED_GAS_PRICE_TOLERANCE_INDEX, &gas_price_tolerance)?
+                .binary_payload_bytes(),
+            PricingMode::Reserved { receipt } => {
+                CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+                    .add_field(TAG_FIELD_INDEX, &RESERVED_VARIANT_TAG)?
+                    .add_field(RESERVED_RECEIPT_INDEX, &receipt)?
+                    .binary_payload_bytes()
+            }
+        }
+    }
+    fn serialized_length(&self) -> usize {
+        CalltableSerializationEnvelope::estimate_size(self.serialized_field_lengths())
+    }
+}
+
+impl FromBytes for PricingMode {
+    fn from_bytes(bytes: &[u8]) -> Result<(PricingMode, &[u8]), Error> {
+        let (binary_payload, remainder) = CalltableSerializationEnvelope::from_bytes(4, bytes)?;
+        let window = binary_payload.start_consuming()?.ok_or(Formatting)?;
+        window.verify_index(TAG_FIELD_INDEX)?;
+        let (tag, window) = window.deserialize_and_maybe_next::<u8>()?;
+        let to_ret = match tag {
+            CLASSIC_VARIANT_TAG => {
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(CLASSIC_PAYMENT_AMOUNT_INDEX)?;
+                let (payment_amount, window) = window.deserialize_and_maybe_next::<u64>()?;
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(CLASSIC_GAS_PRICE_TOLERANCE_INDEX)?;
+                let (gas_price_tolerance, window) = window.deserialize_and_maybe_next::<u8>()?;
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(CLASSIC_STANDARD_PAYMENT_INDEX)?;
+                let (standard_payment, window) = window.deserialize_and_maybe_next::<bool>()?;
+                if window.is_some() {
+                    return Err(Formatting);
+                }
+                Ok(PricingMode::Classic {
+                    payment_amount,
+                    gas_price_tolerance,
+                    standard_payment,
+                })
+            }
+            FIXED_VARIANT_TAG => {
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(FIXED_GAS_PRICE_TOLERANCE_INDEX)?;
+                let (gas_price_tolerance, window) = window.deserialize_and_maybe_next::<u8>()?;
+                if window.is_some() {
+                    return Err(Formatting);
+                }
+                Ok(PricingMode::Fixed {
+                    gas_price_tolerance,
+                })
+            }
+            RESERVED_VARIANT_TAG => {
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(RESERVED_RECEIPT_INDEX)?;
+                let (receipt, window) = window.deserialize_and_maybe_next::<Digest>()?;
+                if window.is_some() {
+                    return Err(Formatting);
+                }
+                Ok(PricingMode::Reserved { receipt })
+            }
+            _ => Err(Formatting),
+        };
+        to_ret.map(|endpoint| (endpoint, remainder))
+    }
 }
 
 impl Display for PricingMode {
@@ -101,104 +229,25 @@ impl Display for PricingMode {
     }
 }
 
-impl ToBytes for PricingMode {
-    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        match self {
-            PricingMode::Classic {
-                payment_amount,
-                gas_price_tolerance: gas_price,
-                standard_payment,
-            } => {
-                CLASSIC_TAG.write_bytes(writer)?;
-                payment_amount.write_bytes(writer)?;
-                gas_price.write_bytes(writer)?;
-                standard_payment.write_bytes(writer)
-            }
-            PricingMode::Reserved { receipt } => {
-                RESERVED_TAG.write_bytes(writer)?;
-                receipt.write_bytes(writer)
-            }
-            PricingMode::Fixed {
-                gas_price_tolerance,
-            } => {
-                FIXED_TAG.write_bytes(writer)?;
-                gas_price_tolerance.write_bytes(writer)
-            }
-        }
-    }
-
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        self.write_bytes(&mut buffer)?;
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        U8_SERIALIZED_LENGTH
-            + match self {
-                PricingMode::Classic {
-                    payment_amount,
-                    gas_price_tolerance: gas_price,
-                    standard_payment,
-                } => {
-                    payment_amount.serialized_length()
-                        + gas_price.serialized_length()
-                        + standard_payment.serialized_length()
-                }
-                PricingMode::Reserved { receipt } => receipt.serialized_length(),
-                PricingMode::Fixed {
-                    gas_price_tolerance,
-                } => gas_price_tolerance.serialized_length(),
-            }
-    }
-}
-
-impl FromBytes for PricingMode {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (tag, remainder) = u8::from_bytes(bytes)?;
-
-        match tag {
-            CLASSIC_TAG => {
-                let (payment_amount, remainder) = u64::from_bytes(remainder)?;
-                let (gas_price, remainder) = u8::from_bytes(remainder)?;
-                let (standard_payment, remainder) = bool::from_bytes(remainder)?;
-                Ok((
-                    PricingMode::Classic {
-                        payment_amount,
-                        gas_price_tolerance: gas_price,
-                        standard_payment,
-                    },
-                    remainder,
-                ))
-            }
-            FIXED_TAG => {
-                let (gas_price_tolerance, remainder) = u8::from_bytes(remainder)?;
-                Ok((
-                    PricingMode::Fixed {
-                        gas_price_tolerance,
-                    },
-                    remainder,
-                ))
-            }
-            RESERVED_TAG => {
-                let (receipt, remainder) = Digest::from_bytes(remainder)?;
-                Ok((PricingMode::Reserved { receipt }, remainder))
-            }
-            _ => Err(bytesrepr::Error::Formatting),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::TestRng;
+    use crate::{bytesrepr, testing::TestRng};
 
     #[test]
     fn bytesrepr_roundtrip() {
         let rng = &mut TestRng::new();
         for _ in 0..10 {
             bytesrepr::test_serialization_roundtrip(&PricingMode::random(rng));
+        }
+    }
+
+    use crate::gens::pricing_mode_arb;
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn generative_bytesrepr_roundtrip(val in pricing_mode_arb()) {
+            bytesrepr::test_serialization_roundtrip(&val);
         }
     }
 }

--- a/types/src/transaction/serialization/field.rs
+++ b/types/src/transaction/serialization/field.rs
@@ -1,0 +1,53 @@
+use crate::bytesrepr::{
+    self, Error, FromBytes, ToBytes, U16_SERIALIZED_LENGTH, U32_SERIALIZED_LENGTH,
+};
+use alloc::vec::Vec;
+
+#[derive(Eq, PartialEq, Debug)]
+pub(crate) struct Field {
+    pub index: u16,
+    pub offset: u32,
+}
+
+impl Field {
+    pub(crate) fn new(index: u16, offset: u32) -> Self {
+        Field { index, offset }
+    }
+}
+
+impl ToBytes for Field {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), Error> {
+        self.index.write_bytes(writer)?;
+        self.offset.write_bytes(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        U16_SERIALIZED_LENGTH + U32_SERIALIZED_LENGTH
+    }
+}
+
+impl FromBytes for Field {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let (index, remainder) = u16::from_bytes(bytes)?;
+        let (offset, remainder) = u32::from_bytes(remainder)?;
+        Ok((Field::new(index, offset), remainder))
+    }
+}
+
+impl Field {
+    pub fn serialized_vec_size(number_of_fields: usize) -> usize {
+        let mut size = U32_SERIALIZED_LENGTH; // Overhead of the vec itself
+        size += number_of_fields * Field::serialized_length();
+        size
+    }
+
+    pub fn serialized_length() -> usize {
+        U16_SERIALIZED_LENGTH + U32_SERIALIZED_LENGTH
+    }
+}

--- a/types/src/transaction/serialization/mod.rs
+++ b/types/src/transaction/serialization/mod.rs
@@ -1,0 +1,346 @@
+mod field;
+use alloc::vec::Vec;
+use field::Field;
+
+use crate::bytesrepr::{
+    self, Bytes, Error, FromBytes, ToBytes, U32_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH,
+};
+
+pub struct CalltableSerializationEnvelopeBuilder {
+    fields: Vec<Field>,
+    expected_payload_sizes: Vec<usize>,
+    bytes: Vec<u8>,
+    current_field_index: usize,
+    current_offset: usize,
+}
+
+impl CalltableSerializationEnvelopeBuilder {
+    pub fn new(
+        expected_payload_sizes: Vec<usize>,
+    ) -> Result<CalltableSerializationEnvelopeBuilder, Error> {
+        let number_of_fields = expected_payload_sizes.len();
+        let fields_size = Field::serialized_vec_size(number_of_fields);
+        let bytes_of_payload_size = expected_payload_sizes.iter().sum::<usize>();
+        let payload_and_vec_overhead: usize = U32_SERIALIZED_LENGTH + bytes_of_payload_size; // u32 for the overhead of serializing a vec
+        let mut payload_buffer =
+            bytesrepr::allocate_buffer_for_size(fields_size + payload_and_vec_overhead)?;
+        payload_buffer.extend(vec![0; fields_size]); // Making room for the call table
+        payload_buffer.extend((bytes_of_payload_size as u32).to_bytes()?); // Writing down number of bytes that are in the payload
+        Ok(CalltableSerializationEnvelopeBuilder {
+            fields: Vec::with_capacity(number_of_fields),
+            expected_payload_sizes,
+            bytes: payload_buffer,
+            current_field_index: 0,
+            current_offset: 0,
+        })
+    }
+
+    pub fn add_field<T: ToBytes + ?Sized>(
+        mut self,
+        field_index: u16,
+        value: &T,
+    ) -> Result<Self, Error> {
+        let current_field_index = self.current_field_index;
+        if current_field_index >= self.expected_payload_sizes.len() {
+            //We wrote more fields than expected
+            return Err(Error::NotRepresentable);
+        }
+        let fields = &mut self.fields;
+        if current_field_index > 0 && fields[current_field_index - 1].index >= field_index {
+            //Need to make sure we write fields in ascending order of tab index
+            return Err(Error::NotRepresentable);
+        }
+        let size = self.expected_payload_sizes[current_field_index];
+        let bytes_before = self.bytes.len();
+        value.write_bytes(&mut self.bytes)?;
+        fields.push(Field::new(field_index, self.current_offset as u32));
+        self.current_field_index += 1;
+        self.current_offset += size;
+        let bytes_after = self.bytes.len();
+        let wrote_bytes = bytes_after - bytes_before;
+        if wrote_bytes == 0 {
+            //We don't allow writing empty fields
+            return Err(Error::NotRepresentable);
+        }
+        if wrote_bytes != size {
+            //The written field occupied different amount of bytes than declared
+            return Err(Error::NotRepresentable);
+        }
+        Ok(self)
+    }
+
+    pub fn binary_payload_bytes(mut self) -> Result<Vec<u8>, Error> {
+        if self.current_field_index != self.expected_payload_sizes.len() {
+            //We didn't write all the fields we expected
+            return Err(Error::NotRepresentable);
+        }
+        let write_at_slice = &mut self.bytes[0..];
+        let calltable_bytes = self.fields.to_bytes()?;
+        for (pos, byte) in calltable_bytes.into_iter().enumerate() {
+            write_at_slice[pos] = byte;
+        }
+        Ok(self.bytes)
+    }
+}
+
+pub struct CalltableSerializationEnvelope {
+    fields: Vec<Field>,
+    bytes: Bytes,
+}
+
+impl CalltableSerializationEnvelope {
+    pub fn estimate_size(field_sizes: Vec<usize>) -> usize {
+        let number_of_fields = field_sizes.len();
+        let payload_in_bytes: usize = field_sizes.iter().sum();
+        let mut size = U32_SERIALIZED_LENGTH + U32_SERIALIZED_LENGTH; // Overhead of the fields vec and bytes vec
+        size += number_of_fields * Field::serialized_length();
+        size += payload_in_bytes * U8_SERIALIZED_LENGTH;
+        size
+    }
+
+    pub fn start_consuming(&self) -> Result<Option<CalltableFieldsIterator>, Error> {
+        if self.fields.is_empty() {
+            return Ok(None);
+        }
+        let field = &self.fields[0];
+        let expected_size = if self.fields.len() == 1 {
+            self.bytes.len()
+        } else {
+            self.fields[1].offset as usize
+        };
+        Ok(Some(CalltableFieldsIterator {
+            index_in_fields_vec: 0,
+            expected_size,
+            field,
+            bytes: &self.bytes,
+            parent: self,
+        }))
+    }
+
+    pub fn from_bytes(
+        max_expected_fields: u32,
+        input_bytes: &[u8],
+    ) -> Result<(CalltableSerializationEnvelope, &[u8]), Error> {
+        if input_bytes.len() < U32_SERIALIZED_LENGTH {
+            //The first "thing" in the bytes of the payload should be a `fields` vector. We want to
+            // check the number of entries in that vector to avoid field pumping. If the
+            // payload doesn't have u32 size of bytes in it, then it's malformed.
+            return Err(Error::Formatting);
+        }
+        let (number_of_fields, _) = u32::from_bytes(input_bytes)?;
+        if number_of_fields > max_expected_fields {
+            return Err(Error::Formatting);
+        }
+        let (fields, remainder) = Vec::<Field>::from_bytes(input_bytes)?;
+        let (bytes, remainder) = Bytes::from_bytes(remainder)?;
+        Ok((CalltableSerializationEnvelope { fields, bytes }, remainder))
+    }
+}
+
+pub struct CalltableFieldsIterator<'a> {
+    index_in_fields_vec: usize,
+    expected_size: usize,
+    field: &'a Field,
+    bytes: &'a [u8],
+    parent: &'a CalltableSerializationEnvelope,
+}
+
+impl<'a> CalltableFieldsIterator<'a> {
+    pub fn verify_index(&self, expected_index: u16) -> Result<(), Error> {
+        let field = self.field;
+        if field.index != expected_index {
+            return Err(Error::Formatting);
+        }
+        Ok(())
+    }
+
+    pub fn deserialize_and_maybe_next<T: FromBytes>(
+        &self,
+    ) -> Result<(T, Option<CalltableFieldsIterator>), Error> {
+        let (t, maybe_window) = self.step()?;
+        Ok((t, maybe_window))
+    }
+
+    fn step<T: FromBytes>(&self) -> Result<(T, Option<CalltableFieldsIterator>), Error> {
+        let (t, remainder) = T::from_bytes(self.bytes)?;
+        let parent_fields = &self.parent.fields;
+        let parent_fields_len = parent_fields.len();
+        let is_last_field = self.index_in_fields_vec == parent_fields_len - 1;
+        if remainder.len() + self.expected_size != self.bytes.len() {
+            //The field occupied different amount of bytes than expected
+            return Err(Error::Formatting);
+        }
+        if !is_last_field {
+            let next_field_index = self.index_in_fields_vec + 1;
+            let next_field = &parent_fields[next_field_index]; // We already checked that this index exists
+            let is_next_field_last = next_field_index == parent_fields_len - 1;
+            let expected_size = if is_next_field_last {
+                remainder.len()
+            } else {
+                (parent_fields[next_field_index + 1].offset
+                    - parent_fields[next_field_index].offset) as usize
+            };
+            let next_window = CalltableFieldsIterator {
+                index_in_fields_vec: next_field_index,
+                expected_size,
+                field: next_field,
+                bytes: remainder,
+                parent: self.parent,
+            };
+            Ok((t, Some(next_window)))
+        } else {
+            if !remainder.is_empty() {
+                //The payload of BinaryPayload should contain only the serialized, there should be
+                // no trailing bytes after consuming all the fields.
+                return Err(Error::Formatting);
+            }
+            Ok((t, None))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CalltableSerializationEnvelope, CalltableSerializationEnvelopeBuilder, Field};
+    use crate::bytesrepr::*;
+
+    #[test]
+    fn binary_payload_should_serialize_fields() {
+        let binary_payload = CalltableSerializationEnvelopeBuilder::new(vec![
+            U8_SERIALIZED_LENGTH,
+            U32_SERIALIZED_LENGTH,
+            U16_SERIALIZED_LENGTH,
+        ])
+        .unwrap();
+        let bytes = binary_payload
+            .add_field(0, &(254_u8))
+            .unwrap()
+            .add_field(1, &(u32::MAX))
+            .unwrap()
+            .add_field(2, &(555_u16))
+            .unwrap()
+            .binary_payload_bytes()
+            .unwrap();
+        let (payload, remainder) = CalltableSerializationEnvelope::from_bytes(3, &bytes).unwrap();
+        assert!(remainder.is_empty());
+        assert_eq!(
+            payload.fields,
+            vec![Field::new(0, 0), Field::new(1, 1), Field::new(2, 5)]
+        );
+        let bytes = &payload.bytes;
+        let (first_value, remainder) = u8::from_bytes(bytes).unwrap();
+        let (second_value, remainder) = u32::from_bytes(remainder).unwrap();
+        let (third_value, remainder) = u16::from_bytes(remainder).unwrap();
+        assert!(remainder.is_empty());
+        assert_eq!(first_value, 254);
+        assert_eq!(second_value, u32::MAX);
+        assert_eq!(third_value, 555);
+    }
+
+    #[test]
+    fn binary_payload_should_fail_to_deserialzie_if_more_then_expected_fields() {
+        let binary_payload = CalltableSerializationEnvelopeBuilder::new(vec![
+            U8_SERIALIZED_LENGTH,
+            U32_SERIALIZED_LENGTH,
+            U16_SERIALIZED_LENGTH,
+        ])
+        .unwrap();
+        let bytes = binary_payload
+            .add_field(0, &(254_u8))
+            .unwrap()
+            .add_field(1, &(u32::MAX))
+            .unwrap()
+            .add_field(2, &(555_u16))
+            .unwrap()
+            .binary_payload_bytes()
+            .unwrap();
+        let res = CalltableSerializationEnvelope::from_bytes(2, &bytes);
+        assert!(res.is_err())
+    }
+
+    #[test]
+    fn binary_payload_should_fail_to_serialize_if_field_indexes_not_unique() {
+        let binary_payload = CalltableSerializationEnvelopeBuilder::new(vec![
+            U8_SERIALIZED_LENGTH,
+            U32_SERIALIZED_LENGTH,
+            U16_SERIALIZED_LENGTH,
+        ])
+        .unwrap();
+        let res = binary_payload
+            .add_field(0, &(254_u8))
+            .unwrap()
+            .add_field(0, &(u32::MAX));
+        assert!(res.is_err())
+    }
+
+    #[test]
+    fn binary_payload_should_fail_to_serialize_if_field_indexes_not_sequential() {
+        let binary_payload = CalltableSerializationEnvelopeBuilder::new(vec![
+            U8_SERIALIZED_LENGTH,
+            U32_SERIALIZED_LENGTH,
+            U16_SERIALIZED_LENGTH,
+        ])
+        .unwrap();
+        let res = binary_payload
+            .add_field(1, &(254_u8))
+            .unwrap()
+            .add_field(0, &(u32::MAX));
+        assert!(res.is_err())
+    }
+
+    #[test]
+    fn binary_payload_should_fail_to_serialize_if_proposed_fields_size_is_smaller_than_declaration()
+    {
+        let binary_payload = CalltableSerializationEnvelopeBuilder::new(vec![
+            U8_SERIALIZED_LENGTH,
+            U32_SERIALIZED_LENGTH,
+            U16_SERIALIZED_LENGTH,
+        ])
+        .unwrap();
+        let res = binary_payload
+            .add_field(0, &(254_u8))
+            .unwrap()
+            .add_field(1, &(u16::MAX));
+        assert!(res.is_err())
+    }
+
+    #[test]
+    fn binary_payload_should_fail_to_serialize_if_proposed_fields_size_is_greater_than_declaration()
+    {
+        let binary_payload = CalltableSerializationEnvelopeBuilder::new(vec![
+            U8_SERIALIZED_LENGTH,
+            U16_SERIALIZED_LENGTH,
+        ])
+        .unwrap();
+        let res = binary_payload
+            .add_field(0, &(254_u8))
+            .unwrap()
+            .add_field(1, &(u32::MAX));
+        assert!(res.is_err())
+    }
+
+    #[test]
+    fn binary_payload_should_fail_to_serialize_if_proposed_a_field_with_zero_bytes() {
+        struct FunkyType {}
+        impl ToBytes for FunkyType {
+            fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+                Ok(Vec::new())
+            }
+
+            fn serialized_length(&self) -> usize {
+                0
+            }
+        }
+        let funky_instance = FunkyType {};
+        let binary_payload = CalltableSerializationEnvelopeBuilder::new(vec![
+            U8_SERIALIZED_LENGTH,
+            funky_instance.serialized_length(),
+        ])
+        .unwrap();
+        let res = binary_payload
+            .add_field(0, &(254_u8))
+            .unwrap()
+            .add_field(1, &(funky_instance));
+        assert!(res.is_err())
+    }
+}

--- a/types/src/transaction/transaction_runtime.rs
+++ b/types/src/transaction/transaction_runtime.rs
@@ -1,13 +1,12 @@
 use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
+#[cfg(feature = "datasize")]
+use datasize::DataSize;
 #[cfg(any(feature = "testing", test))]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-
-#[cfg(feature = "datasize")]
-use datasize::DataSize;
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/types/src/transaction/transaction_target.rs
+++ b/types/src/transaction/transaction_target.rs
@@ -1,6 +1,19 @@
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 
+use super::{
+    serialization::CalltableSerializationEnvelope, TransactionInvocationTarget, TransactionRuntime,
+};
+#[cfg(any(feature = "testing", test))]
+use crate::testing::TestRng;
+use crate::{
+    bytesrepr::{
+        Bytes,
+        Error::{self, Formatting},
+        FromBytes, ToBytes,
+    },
+    transaction::serialization::CalltableSerializationEnvelopeBuilder,
+};
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
 #[cfg(any(feature = "testing", test))]
@@ -8,17 +21,6 @@ use rand::{Rng, RngCore};
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-#[cfg(doc)]
-use super::Transaction;
-use super::{TransactionInvocationTarget, TransactionRuntime};
-use crate::bytesrepr::{self, Bytes, FromBytes, ToBytes, U8_SERIALIZED_LENGTH};
-#[cfg(any(feature = "testing", test))]
-use crate::testing::TestRng;
-
-const NATIVE_TAG: u8 = 0;
-const STORED_TAG: u8 = 1;
-const SESSION_TAG: u8 = 2;
 
 /// The execution target of a [`Transaction`].
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -67,22 +69,139 @@ impl TransactionTarget {
         }
     }
 
+    fn serialized_field_lengths(&self) -> Vec<usize> {
+        match self {
+            TransactionTarget::Native => {
+                vec![crate::bytesrepr::U8_SERIALIZED_LENGTH]
+            }
+            TransactionTarget::Stored { id, runtime } => {
+                vec![
+                    crate::bytesrepr::U8_SERIALIZED_LENGTH,
+                    id.serialized_length(),
+                    runtime.serialized_length(),
+                ]
+            }
+            TransactionTarget::Session {
+                module_bytes,
+                runtime,
+            } => {
+                vec![
+                    crate::bytesrepr::U8_SERIALIZED_LENGTH,
+                    module_bytes.serialized_length(),
+                    runtime.serialized_length(),
+                ]
+            }
+        }
+    }
+
     /// Returns a random `TransactionTarget`.
     #[cfg(any(feature = "testing", test))]
     pub fn random(rng: &mut TestRng) -> Self {
         match rng.gen_range(0..3) {
-            NATIVE_TAG => TransactionTarget::Native,
-            STORED_TAG => TransactionTarget::new_stored(
+            0 => TransactionTarget::Native,
+            1 => TransactionTarget::new_stored(
                 TransactionInvocationTarget::random(rng),
                 TransactionRuntime::VmCasperV1,
             ),
-            SESSION_TAG => {
+            2 => {
                 let mut buffer = vec![0u8; rng.gen_range(0..100)];
                 rng.fill_bytes(buffer.as_mut());
                 TransactionTarget::new_session(Bytes::from(buffer), TransactionRuntime::VmCasperV1)
             }
             _ => unreachable!(),
         }
+    }
+}
+
+const TAG_FIELD_INDEX: u16 = 0;
+
+const NATIVE_VARIANT: u8 = 0;
+
+const STORED_VARIANT: u8 = 1;
+const STORED_ID_INDEX: u16 = 1;
+const STORED_RUNTIME_INDEX: u16 = 2;
+
+const SESSION_VARIANT: u8 = 2;
+const SESSION_MODULE_BYTES_INDEX: u16 = 1;
+const SESSION_RUNTIME_INDEX: u16 = 2;
+
+impl ToBytes for TransactionTarget {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        match self {
+            TransactionTarget::Native => {
+                CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+                    .add_field(TAG_FIELD_INDEX, &NATIVE_VARIANT)?
+                    .binary_payload_bytes()
+            }
+            TransactionTarget::Stored { id, runtime } => {
+                CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+                    .add_field(TAG_FIELD_INDEX, &STORED_VARIANT)?
+                    .add_field(STORED_ID_INDEX, &id)?
+                    .add_field(STORED_RUNTIME_INDEX, &runtime)?
+                    .binary_payload_bytes()
+            }
+            TransactionTarget::Session {
+                module_bytes,
+                runtime,
+            } => CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+                .add_field(TAG_FIELD_INDEX, &SESSION_VARIANT)?
+                .add_field(SESSION_MODULE_BYTES_INDEX, &module_bytes)?
+                .add_field(SESSION_RUNTIME_INDEX, &runtime)?
+                .binary_payload_bytes(),
+        }
+    }
+
+    fn serialized_length(&self) -> usize {
+        CalltableSerializationEnvelope::estimate_size(self.serialized_field_lengths())
+    }
+}
+
+impl FromBytes for TransactionTarget {
+    fn from_bytes(bytes: &[u8]) -> Result<(TransactionTarget, &[u8]), Error> {
+        let (binary_payload, remainder) = CalltableSerializationEnvelope::from_bytes(3, bytes)?;
+        let window = binary_payload.start_consuming()?.ok_or(Formatting)?;
+        window.verify_index(TAG_FIELD_INDEX)?;
+        let (tag, window) = window.deserialize_and_maybe_next::<u8>()?;
+        let to_ret = match tag {
+            NATIVE_VARIANT => {
+                if window.is_some() {
+                    return Err(Formatting);
+                }
+                Ok(TransactionTarget::Native)
+            }
+            STORED_VARIANT => {
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(STORED_ID_INDEX)?;
+                let (id, window) =
+                    window.deserialize_and_maybe_next::<TransactionInvocationTarget>()?;
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(STORED_RUNTIME_INDEX)?;
+                let (runtime, window) =
+                    window.deserialize_and_maybe_next::<TransactionRuntime>()?;
+                if window.is_some() {
+                    return Err(Formatting);
+                }
+                Ok(TransactionTarget::Stored { id, runtime })
+            }
+            SESSION_VARIANT => {
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(SESSION_MODULE_BYTES_INDEX)?;
+                let (module_bytes, window) = window.deserialize_and_maybe_next::<Bytes>()?;
+                let window = window.ok_or(Formatting)?;
+                window.verify_index(SESSION_RUNTIME_INDEX)?;
+                let (runtime, window) =
+                    window.deserialize_and_maybe_next::<TransactionRuntime>()?;
+                if window.is_some() {
+                    return Err(Formatting);
+                }
+                Ok(TransactionTarget::Session {
+                    module_bytes,
+                    runtime,
+                })
+            }
+            _ => Err(Formatting),
+        };
+        to_ret.map(|endpoint| (endpoint, remainder))
     }
 }
 
@@ -136,78 +255,23 @@ impl Debug for TransactionTarget {
     }
 }
 
-impl ToBytes for TransactionTarget {
-    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        match self {
-            TransactionTarget::Native => NATIVE_TAG.write_bytes(writer),
-            TransactionTarget::Stored { id, runtime } => {
-                STORED_TAG.write_bytes(writer)?;
-                id.write_bytes(writer)?;
-                runtime.write_bytes(writer)
-            }
-            TransactionTarget::Session {
-                module_bytes,
-                runtime,
-            } => {
-                SESSION_TAG.write_bytes(writer)?;
-                module_bytes.write_bytes(writer)?;
-                runtime.write_bytes(writer)
-            }
-        }
-    }
-
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        self.write_bytes(&mut buffer)?;
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        U8_SERIALIZED_LENGTH
-            + match self {
-                TransactionTarget::Native => 0,
-                TransactionTarget::Stored { id, runtime } => {
-                    id.serialized_length() + runtime.serialized_length()
-                }
-                TransactionTarget::Session {
-                    module_bytes,
-                    runtime,
-                } => module_bytes.serialized_length() + runtime.serialized_length(),
-            }
-    }
-}
-
-impl FromBytes for TransactionTarget {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (tag, remainder) = u8::from_bytes(bytes)?;
-        match tag {
-            NATIVE_TAG => Ok((TransactionTarget::Native, remainder)),
-            STORED_TAG => {
-                let (id, remainder) = TransactionInvocationTarget::from_bytes(remainder)?;
-                let (runtime, remainder) = TransactionRuntime::from_bytes(remainder)?;
-                let target = TransactionTarget::new_stored(id, runtime);
-                Ok((target, remainder))
-            }
-            SESSION_TAG => {
-                let (module_bytes, remainder) = Bytes::from_bytes(remainder)?;
-                let (runtime, remainder) = TransactionRuntime::from_bytes(remainder)?;
-                let target = TransactionTarget::new_session(module_bytes, runtime);
-                Ok((target, remainder))
-            }
-            _ => Err(bytesrepr::Error::Formatting),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    use crate::{bytesrepr, gens::transaction_target_arb};
+    use proptest::prelude::*;
     #[test]
     fn bytesrepr_roundtrip() {
         let rng = &mut TestRng::new();
         for _ in 0..10 {
             bytesrepr::test_serialization_roundtrip(&TransactionTarget::random(rng));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn generative_bytesrepr_roundtrip(val in transaction_target_arb()) {
+            bytesrepr::test_serialization_roundtrip(&val);
         }
     }
 }

--- a/types/src/transaction/transaction_v1/transaction_v1_body.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_body.rs
@@ -4,6 +4,7 @@ pub(super) mod arg_handling;
 use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
 
+use super::super::{RuntimeArgs, TransactionEntryPoint, TransactionScheduling, TransactionTarget};
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
@@ -15,18 +16,13 @@ use serde::{Deserialize, Serialize};
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use tracing::debug;
 
-use super::super::{RuntimeArgs, TransactionEntryPoint, TransactionScheduling, TransactionTarget};
-
 use super::TransactionCategory;
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use super::TransactionConfig;
 #[cfg(doc)]
 use super::TransactionV1;
-use crate::bytesrepr::{self, FromBytes, ToBytes};
-
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
+#[cfg(any(feature = "std", test))]
 use crate::InvalidTransactionV1;
-
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::TransactionV1ExcessiveSizeError;
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
@@ -34,7 +30,12 @@ use crate::{
     bytesrepr::Bytes, testing::TestRng, PublicKey, TransactionInvocationTarget, TransactionRuntime,
     TransferTarget,
 };
-
+use crate::{
+    bytesrepr::{Error, FromBytes, ToBytes},
+    transaction::serialization::{
+        CalltableSerializationEnvelope, CalltableSerializationEnvelopeBuilder,
+    },
+};
 /// The body of a [`TransactionV1`].
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(
@@ -49,11 +50,11 @@ use crate::{
     schemars(description = "Body of a `TransactionV1`.")
 )]
 pub struct TransactionV1Body {
-    pub(super) args: RuntimeArgs,
-    pub(super) target: TransactionTarget,
-    pub(super) entry_point: TransactionEntryPoint,
-    pub(super) transaction_category: u8,
-    pub(super) scheduling: TransactionScheduling,
+    pub(crate) args: RuntimeArgs,
+    pub(crate) target: TransactionTarget,
+    pub(crate) entry_point: TransactionEntryPoint,
+    pub(crate) transaction_category: u8,
+    pub(crate) scheduling: TransactionScheduling,
 }
 
 impl TransactionV1Body {
@@ -266,6 +267,16 @@ impl TransactionV1Body {
         }
     }
 
+    fn serialized_field_lengths(&self) -> Vec<usize> {
+        vec![
+            self.args.serialized_length(),
+            self.target.serialized_length(),
+            self.entry_point.serialized_length(),
+            self.transaction_category.serialized_length(),
+            self.scheduling.serialized_length(),
+        ]
+    }
+
     /// Returns a random `TransactionV1Body`.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn random_of_category(rng: &mut TestRng, category: u8) -> Self {
@@ -466,6 +477,63 @@ impl TransactionV1Body {
     }
 }
 
+const ARGS_INDEX: u16 = 0;
+const TARGET_INDEX: u16 = 1;
+const ENTRY_POINT_INDEX: u16 = 2;
+const TRANSACTION_CATEGORY_INDEX: u16 = 3;
+const SCHEDULING_INDEX: u16 = 4;
+
+impl FromBytes for TransactionV1Body {
+    fn from_bytes(bytes: &[u8]) -> Result<(TransactionV1Body, &[u8]), Error> {
+        let (binary_payload, remainder) =
+            crate::transaction::serialization::CalltableSerializationEnvelope::from_bytes(
+                5, bytes,
+            )?;
+        let window = binary_payload.start_consuming()?;
+        let window = window.ok_or(Error::Formatting)?;
+        window.verify_index(ARGS_INDEX)?;
+        let (args, window) = window.deserialize_and_maybe_next::<RuntimeArgs>()?;
+        let window = window.ok_or(Error::Formatting)?;
+        window.verify_index(TARGET_INDEX)?;
+        let (target, window) = window.deserialize_and_maybe_next::<TransactionTarget>()?;
+        let window = window.ok_or(Error::Formatting)?;
+        window.verify_index(ENTRY_POINT_INDEX)?;
+        let (entry_point, window) = window.deserialize_and_maybe_next::<TransactionEntryPoint>()?;
+        let window = window.ok_or(Error::Formatting)?;
+        window.verify_index(TRANSACTION_CATEGORY_INDEX)?;
+        let (transaction_category, window) = window.deserialize_and_maybe_next::<u8>()?;
+        let window = window.ok_or(Error::Formatting)?;
+        window.verify_index(SCHEDULING_INDEX)?;
+        let (scheduling, window) = window.deserialize_and_maybe_next::<TransactionScheduling>()?;
+        if window.is_some() {
+            return Err(Error::Formatting);
+        }
+        let from_bytes = TransactionV1Body {
+            args,
+            target,
+            entry_point,
+            transaction_category,
+            scheduling,
+        };
+        Ok((from_bytes, remainder))
+    }
+}
+
+impl ToBytes for TransactionV1Body {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+            .add_field(ARGS_INDEX, &self.args)?
+            .add_field(TARGET_INDEX, &self.target)?
+            .add_field(ENTRY_POINT_INDEX, &self.entry_point)?
+            .add_field(TRANSACTION_CATEGORY_INDEX, &self.transaction_category)?
+            .add_field(SCHEDULING_INDEX, &self.scheduling)?
+            .binary_payload_bytes()
+    }
+    fn serialized_length(&self) -> usize {
+        CalltableSerializationEnvelope::estimate_size(self.serialized_field_lengths())
+    }
+}
+
 impl Display for TransactionV1Body {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
@@ -476,46 +544,10 @@ impl Display for TransactionV1Body {
     }
 }
 
-impl ToBytes for TransactionV1Body {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        self.write_bytes(&mut buffer)?;
-        Ok(buffer)
-    }
-
-    fn serialized_length(&self) -> usize {
-        self.args.serialized_length()
-            + self.target.serialized_length()
-            + self.entry_point.serialized_length()
-            + self.transaction_category.serialized_length()
-            + self.scheduling.serialized_length()
-    }
-
-    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        self.args.write_bytes(writer)?;
-        self.target.write_bytes(writer)?;
-        self.entry_point.write_bytes(writer)?;
-        self.transaction_category.write_bytes(writer)?;
-        self.scheduling.write_bytes(writer)
-    }
-}
-
-impl FromBytes for TransactionV1Body {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (args, remainder) = RuntimeArgs::from_bytes(bytes)?;
-        let (target, remainder) = TransactionTarget::from_bytes(remainder)?;
-        let (entry_point, remainder) = TransactionEntryPoint::from_bytes(remainder)?;
-        let (kind, remainder) = u8::from_bytes(remainder)?;
-        let (scheduling, remainder) = TransactionScheduling::from_bytes(remainder)?;
-        let body = TransactionV1Body::new(args, target, entry_point, kind, scheduling);
-        Ok((body, remainder))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime_args;
+    use crate::{bytesrepr, runtime_args};
 
     #[test]
     fn bytesrepr_roundtrip() {

--- a/types/src/transaction/transaction_v1/transaction_v1_builder.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_builder.rs
@@ -63,7 +63,7 @@ impl<'a> TransactionV1Builder<'a> {
     /// The default scheduling for transactions, i.e. `Standard`.
     pub const DEFAULT_SCHEDULING: TransactionScheduling = TransactionScheduling::Standard;
 
-    fn new(body: TransactionV1Body) -> Self {
+    pub(super) fn new(body: TransactionV1Body) -> Self {
         TransactionV1Builder {
             chain_name: None,
             timestamp: Timestamp::now(),

--- a/types/src/transaction/transaction_v1/transaction_v1_header.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_header.rs
@@ -14,11 +14,24 @@ use tracing::debug;
 use super::TransactionV1;
 use super::{InitiatorAddr, PricingMode};
 use crate::{
-    bytesrepr::{self, FromBytes, ToBytes},
+    bytesrepr::{
+        Error::{self, Formatting},
+        FromBytes, ToBytes,
+    },
+    transaction::serialization::{
+        CalltableSerializationEnvelope, CalltableSerializationEnvelopeBuilder,
+    },
     Digest, TimeDiff, Timestamp,
 };
 #[cfg(any(feature = "std", test))]
 use crate::{InvalidTransactionV1, TransactionConfig, TransactionV1Hash};
+
+const CHAIN_NAME_INDEX: u16 = 0;
+const TIMESTAMP_INDEX: u16 = 1;
+const TTL_INDEX: u16 = 2;
+const BODY_HASH_INDEX: u16 = 3;
+const PRICING_MODE_INDEX: u16 = 4;
+const INITIATOR_ADDR_INDEX: u16 = 5;
 
 /// The header portion of a [`TransactionV1`].
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
@@ -43,6 +56,17 @@ pub struct TransactionV1Header {
 }
 
 impl TransactionV1Header {
+    fn serialized_field_lengths(&self) -> Vec<usize> {
+        vec![
+            self.chain_name.serialized_length(),
+            self.timestamp.serialized_length(),
+            self.ttl.serialized_length(),
+            self.body_hash.serialized_length(),
+            self.pricing_mode.serialized_length(),
+            self.initiator_addr.serialized_length(),
+        ]
+    }
+
     #[cfg(any(feature = "std", feature = "json-schema", test))]
     pub(super) fn new(
         chain_name: String,
@@ -176,40 +200,50 @@ impl TransactionV1Header {
 }
 
 impl ToBytes for TransactionV1Header {
-    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut buffer = bytesrepr::allocate_buffer(self)?;
-        self.write_bytes(&mut buffer)?;
-        Ok(buffer)
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        CalltableSerializationEnvelopeBuilder::new(self.serialized_field_lengths())?
+            .add_field(CHAIN_NAME_INDEX, &self.chain_name)?
+            .add_field(TIMESTAMP_INDEX, &self.timestamp)?
+            .add_field(TTL_INDEX, &self.ttl)?
+            .add_field(BODY_HASH_INDEX, &self.body_hash)?
+            .add_field(PRICING_MODE_INDEX, &self.pricing_mode)?
+            .add_field(INITIATOR_ADDR_INDEX, &self.initiator_addr)?
+            .binary_payload_bytes()
     }
-
     fn serialized_length(&self) -> usize {
-        self.chain_name.serialized_length()
-            + self.timestamp.serialized_length()
-            + self.ttl.serialized_length()
-            + self.body_hash.serialized_length()
-            + self.pricing_mode.serialized_length()
-            + self.initiator_addr.serialized_length()
-    }
-
-    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
-        self.chain_name.write_bytes(writer)?;
-        self.timestamp.write_bytes(writer)?;
-        self.ttl.write_bytes(writer)?;
-        self.body_hash.write_bytes(writer)?;
-        self.pricing_mode.write_bytes(writer)?;
-        self.initiator_addr.write_bytes(writer)
+        CalltableSerializationEnvelope::estimate_size(self.serialized_field_lengths())
     }
 }
 
 impl FromBytes for TransactionV1Header {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (chain_name, remainder) = String::from_bytes(bytes)?;
-        let (timestamp, remainder) = Timestamp::from_bytes(remainder)?;
-        let (ttl, remainder) = TimeDiff::from_bytes(remainder)?;
-        let (body_hash, remainder) = Digest::from_bytes(remainder)?;
-        let (pricing_mode, remainder) = PricingMode::from_bytes(remainder)?;
-        let (initiator_addr, remainder) = InitiatorAddr::from_bytes(remainder)?;
-        let transaction_header = TransactionV1Header {
+    fn from_bytes(bytes: &[u8]) -> Result<(TransactionV1Header, &[u8]), Error> {
+        let (binary_payload, remainder) =
+            crate::transaction::serialization::CalltableSerializationEnvelope::from_bytes(
+                6u32, bytes,
+            )?;
+        let window = binary_payload.start_consuming()?;
+        let window = window.ok_or(Formatting)?;
+        window.verify_index(CHAIN_NAME_INDEX)?;
+        let (chain_name, window) = window.deserialize_and_maybe_next::<String>()?;
+        let window = window.ok_or(Formatting)?;
+        window.verify_index(TIMESTAMP_INDEX)?;
+        let (timestamp, window) = window.deserialize_and_maybe_next::<Timestamp>()?;
+        let window = window.ok_or(Formatting)?;
+        window.verify_index(TTL_INDEX)?;
+        let (ttl, window) = window.deserialize_and_maybe_next::<TimeDiff>()?;
+        let window = window.ok_or(Formatting)?;
+        window.verify_index(BODY_HASH_INDEX)?;
+        let (body_hash, window) = window.deserialize_and_maybe_next::<Digest>()?;
+        let window = window.ok_or(Formatting)?;
+        window.verify_index(PRICING_MODE_INDEX)?;
+        let (pricing_mode, window) = window.deserialize_and_maybe_next::<PricingMode>()?;
+        let window = window.ok_or(Formatting)?;
+        window.verify_index(INITIATOR_ADDR_INDEX)?;
+        let (initiator_addr, window) = window.deserialize_and_maybe_next::<InitiatorAddr>()?;
+        if window.is_some() {
+            return Err(Formatting);
+        }
+        let from_bytes = TransactionV1Header {
             chain_name,
             timestamp,
             ttl,
@@ -217,7 +251,7 @@ impl FromBytes for TransactionV1Header {
             pricing_mode,
             initiator_addr,
         };
-        Ok((transaction_header, remainder))
+        Ok((from_bytes, remainder))
     }
 }
 


### PR DESCRIPTION
This is an extension to the `bytesrepr` serialization used in the rest of the node and it also uses the `
FromBytes` and `ToBytes` traits.
    From now on selected types will use a specific serialization approach which will be called "calltable" serialization.
    A "calltable-serialized" type is serialized as follow:

- For structs:
    -  Given type X with N attributes we assign a unique (in the scope of X) `u16` index to each of the structs attribute. The assumption is that the indexes are 0-based
    - We serialize each of the structs attribute using it's `ToBytes` implementation, producing binary payloads: _binary_vec<sub>0</sub>, binary_vec<sub>1</sub>, ..., binary_ve
c<sub>N-1</sub>_. We don't allow any of the _binary_vec<sub>i</sub>_ to be empty.
    - We construct a _bytes_ vector which is a concatenation of _binary_vec<sub>0</sub>, binary_vec<sub>1</sub>, ..., binary_vec<sub>N-1</sub>_
    - We construct a _fields_ vector. The _i-th_ element of _fields_ is a description of the _i-th_ attribute:
        - For field with index 0 this description will be:
              _field<sub>0</sub>_ = Field {
                 index: 0
                 offset: 0
              }
        - For each next field:
              *field<sub>i</sub>* = Field {
                  index: *i*
                  offset: *field<sub>i - 1</sub>.offset* + length(*binary_vec<sub>i - 1</sub>*)
              }
    - We construct an instance of `CalltableSerializationEnvelope {fields, bytes}`  and serialize it using it's `ToBytes` implementation.
- For enums:
    - Given an enum E with M variants we assign a `u8` unique index for each of the variant. The variant-index should start from 0 and be contiguous.
    - Given an enum instance *e* of variant *E<sub>j</sub>* (having variant index *j*) which has N attributes:
        - we assign a unique (in the scope of *E<sub>j</sub>) `u16` index to each of the enum variants attribute. The assumption is that the indexes are 1-based.
        - We serialize value of *j* as *binary_vec<sub>0</sub>* and each of *e* attribute as subsequent *binary_vec* (binary_vec<sub>1</sub>, binary_vec<sub>2</sub>,..., bi
nary_vec<sub>N</sub>). We don't allow any of the *binary_vec<sub>i</sub>* to be empty.
        -  We construct a *bytes* vector which is a concatenation of *binary_vec<sub>0</sub>, binary_vec<sub>1</sub>, ..., binary_vec<sub>N</sub>*.
        - We construct a *fields* vector. The *i-th* element of *fields* is a description of the *i-th* attribute:
            - For field with index 0 this description will be:
                 _field<sub>0</sub>_ = Field {
                   index: 0
                   offset: 0
                 }
            - For each next field:
                 _field<sub>i</sub>_ = Field {
                     index: *i*
                     offset: *field<sub>i - 1</sub>.offset* + length(*binary_vec<sub>i - 1</sub>*)
                 }
        - We construct an instance of `CalltableSerializationEnvelope {fields, bytes}`  and serialize it using it's `ToBytes` implementation.
        - To recap, each enum variant we serialize analogously to a `struct`, but we prepend a synthetic `u8` field which identifies the variant.
    
This PR applies calltable serialization to the following types:
- `InitiatorAddr` enum
- `PricingMode` enum
- `TransactionEntryPoint` enum
- `TransactionInvocationTarget` enum
- `TransactionScheduling` enum
- `TransactionTarget` enum
- `TransactionV1` struct
- `TransactionV1Body` struct
- `TransactionV1Header` struct
    
All other types (especially legacy ones, including those nested in "calltable-serialized" types) should use "regular" serialization logic.