### PR TITLE
Revert keeping zero bids in the auction state

### DIFF
--- a/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20210831.rs
@@ -439,10 +439,8 @@ fn regression_20210831_should_fail_to_activate_bid() {
     builder.exec(withdraw_bid_request).expect_success().commit();
 
     let bids = builder.get_bids();
-    let bid = bids
-        .validator_bid(&DEFAULT_ACCOUNT_PUBLIC_KEY)
-        .expect("should have zero bid");
-    assert!(bid.staked_amount().is_zero());
+    let bid = bids.validator_bid(&DEFAULT_ACCOUNT_PUBLIC_KEY);
+    assert!(bid.is_none());
 
     let sender = *ACCOUNT_2_ADDR;
     let activate_bid_args = runtime_args! {

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -2054,11 +2054,7 @@ fn should_undelegate_delegators_when_validator_unbonds() {
         .expect_success();
 
     let bids_after = builder.get_bids();
-    assert!(bids_after
-        .validator_bid(&VALIDATOR_1)
-        .expect("should still have zero bid")
-        .staked_amount()
-        .is_zero());
+    assert!(bids_after.validator_bid(&VALIDATOR_1).is_none());
 
     let unbonding_purses_after: UnbondingPurses = builder.get_unbonds();
     assert_ne!(unbonding_purses_after, unbonding_purses_before);
@@ -2261,11 +2257,7 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         .expect_success();
 
     let bids_after = builder.get_bids();
-    assert!(bids_after
-        .validator_bid(&VALIDATOR_1)
-        .expect("should still have zero bid")
-        .staked_amount()
-        .is_zero());
+    assert!(bids_after.validator_bid(&VALIDATOR_1).is_none());
 
     let unbonding_purses_before: UnbondingPurses = builder.get_unbonds();
 
@@ -2323,9 +2315,6 @@ fn should_undelegate_delegators_when_validator_fully_unbonds() {
         builder.run_auction(timestamp_millis, Vec::new());
         timestamp_millis += TIMESTAMP_MILLIS_INCREMENT;
     }
-
-    let bids_after_2 = builder.get_bids();
-    assert!(bids_after_2.validator_bid(&VALIDATOR_1).is_none());
 
     let validator_1_balance_after = builder.get_purse_balance(validator_1.main_purse());
     let delegator_1_balance_after = builder.get_purse_balance(delegator_1.main_purse());
@@ -4311,9 +4300,6 @@ fn should_enforce_max_delegators_per_validator_cap() {
         .len();
 
     assert_eq!(current_delegator_count, 1);
-
-    // Make the undelegation go through and remove the bid completely.
-    builder.advance_eras_by(DEFAULT_UNBONDING_DELAY + 1);
 
     let delegation_request_3 = ExecuteRequestBuilder::standard(
         *DELEGATOR_1_ADDR,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -3315,10 +3315,7 @@ fn delegator_full_unbond_during_first_reward_era() {
         U512::from(DELEGATOR_1_STAKE),
     );
     let delegator = get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
-    assert!(delegator
-        .expect("should still have zero bid")
-        .staked_amount()
-        .is_zero());
+    assert!(delegator.is_none());
 
     let withdraws = builder.get_unbonds();
     let unbonding_purses = withdraws

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -378,22 +378,27 @@ fn should_distribute_delegation_rate_zero() {
             VALIDATOR_1.clone(),
             validator_1_actual_payout + U512::from(VALIDATOR_1_STAKE),
         );
-        get_validator_bid(&mut builder, VALIDATOR_1.clone())
-            .expect("should still have zero bid")
-            .staked_amount()
+        assert!(get_validator_bid(&mut builder, VALIDATOR_1.clone()).is_none());
+        U512::zero()
     };
     assert_eq!(validator_1_balance, U512::zero());
 
-    let delegator_1_balance =
-        get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone())
-            .expect("validator withdrawing full stake also removes delegator 1 reinvested funds")
-            .staked_amount();
+    let delegator_1_balance = {
+        assert!(
+            get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone()).is_none(),
+            "validator withdrawing full stake also removes delegator 1 reinvested funds"
+        );
+        U512::zero()
+    };
     assert_eq!(delegator_1_balance, U512::zero());
 
-    let delegator_2_balance =
-        get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone())
-            .expect("validator withdrawing full stake also removes delegator 1 reinvested funds")
-            .staked_amount();
+    let delegator_2_balance = {
+        assert!(
+            get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone()).is_none(),
+            "validator withdrawing full stake also removes delegator 1 reinvested funds"
+        );
+        U512::zero()
+    };
     assert!(delegator_2_balance.is_zero());
 
     let era_info = get_era_info(&mut builder);
@@ -651,10 +656,7 @@ fn should_withdraw_bids_after_distribute() {
             undelegate_amount,
         );
         assert!(
-            get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone())
-                .expect("should still have zero bid")
-                .staked_amount()
-                .is_zero(),
+            get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone()).is_none(),
             "delegator 1 did not unstake full expected amount"
         );
         delegator_1_actual_payout
@@ -678,10 +680,7 @@ fn should_withdraw_bids_after_distribute() {
             undelegate_amount,
         );
         assert!(
-            get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone())
-                .expect("should still have zero bid")
-                .staked_amount()
-                .is_zero(),
+            get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_2.clone()).is_none(),
             "delegator 2 did not unstake full expected amount"
         );
         delegator_2_actual_payout
@@ -704,10 +703,7 @@ fn should_withdraw_bids_after_distribute() {
             withdraw_bid_amount,
         );
 
-        assert!(get_validator_bid(&mut builder, VALIDATOR_1.clone())
-            .expect("should still have zero bid")
-            .staked_amount()
-            .is_zero());
+        assert!(get_validator_bid(&mut builder, VALIDATOR_1.clone()).is_none());
 
         withdraw_bid_amount
     };
@@ -3169,10 +3165,7 @@ fn should_not_restake_after_full_unbond() {
         U512::from(DELEGATOR_1_STAKE),
     );
     let delegator = get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
-    assert!(delegator
-        .expect("should still have zero bid")
-        .staked_amount()
-        .is_zero());
+    assert!(delegator.is_none());
 
     let withdraws = builder.get_unbonds();
     let unbonding_purses = withdraws
@@ -3196,13 +3189,10 @@ fn should_not_restake_after_full_unbond() {
 
     builder.advance_era();
 
-    // Delegator's stake should remain at zero even though they were eligible for rewards in the
+    // Delegator should not remain delegated even though they were eligible for rewards in the
     // second era.
     let delegator = get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
-    assert!(delegator
-        .expect("should have zero bid")
-        .staked_amount()
-        .is_zero());
+    assert!(delegator.is_none());
 }
 
 // In this test, we set up a delegator and a validator, the delegator delegates to the validator.
@@ -3351,8 +3341,5 @@ fn delegator_full_unbond_during_first_reward_era() {
     // Delegator's stake should remain at zero delegated even though they were eligible for rewards
     // in the second era.
     let delegator = get_delegator_bid(&mut builder, VALIDATOR_1.clone(), DELEGATOR_1.clone());
-    assert!(delegator
-        .expect("should still have zero bid")
-        .staked_amount()
-        .is_zero());
+    assert!(delegator.is_none());
 }

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -715,6 +715,7 @@ pub fn execute_finalized_block(
         let step_processing_start = Instant::now();
 
         // force undelegate delegators outside delegation limits before the auction runs
+        debug!("starting forced undelegations");
         let forced_undelegate_req = ForcedUndelegateRequest::new(
             native_runtime_config.clone(),
             state_root_hash,
@@ -734,7 +735,9 @@ pub fn execute_finalized_block(
                 state_root_hash = post_state_hash;
             }
         }
+        debug!("forced undelegations success");
 
+        debug!("committing step");
         let step_effects = match commit_step(
             native_runtime_config,
             &scratch_state,
@@ -758,6 +761,7 @@ pub fn execute_finalized_block(
                 effects
             }
         };
+        debug!("step committed");
 
         let era_validators_req = EraValidatorsRequest::new(state_root_hash, protocol_version);
         let era_validators_result = data_access_layer.era_validators(era_validators_req);

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -660,7 +660,6 @@ impl MainReactor {
                 debug!("is synced to ttl");
                 return Ok(Some(SyncBackInstruction::TtlSynced));
             }
-            debug!("is not synced to ttl");
         }
 
         Ok(None)

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -594,6 +594,7 @@ impl MainReactor {
         match self.storage.get_highest_orphaned_block_header() {
             HighestOrphanedBlockResult::Orphan(highest_orphaned_block_header) => {
                 if let Some(synched) = self.synched(&highest_orphaned_block_header)? {
+                    debug!(?synched, "synched result");
                     return Ok(Some(synched));
                 }
                 let (sync_hash, sync_era) =
@@ -647,13 +648,19 @@ impl MainReactor {
             .map_err(|err| err.to_string())?
             .last()
         {
+            debug!(
+                highest_switch_timestamp=?highest_switch_block_header.timestamp(),
+                highest_orphaned_timestamp=?highest_orphaned_block_header.timestamp(),
+                "checking max ttl");
             let max_ttl: MaxTtl = self.chainspec.transaction_config.max_ttl.into();
             if max_ttl.synced_to_ttl(
                 highest_switch_block_header.timestamp(),
                 highest_orphaned_block_header,
             ) {
+                debug!("is synced to ttl");
                 return Ok(Some(SyncBackInstruction::TtlSynced));
             }
+            debug!("is not synced to ttl");
         }
 
         Ok(None)

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -550,6 +550,8 @@ pub trait Auction:
         include_credits: bool,
         credit_cap: Ratio<U512>,
     ) -> Result<(), ApiError> {
+        debug!("run_auction called");
+
         if self.get_caller() != PublicKey::System.to_account_hash() {
             return Err(Error::InvalidCaller.into());
         }
@@ -563,7 +565,9 @@ pub trait Auction:
         let mut era_id: EraId = detail::get_era_id(self)?;
 
         // Process unbond requests
+        debug!("processing unbond requests");
         detail::process_unbond_requests(self, max_delegators_per_validator)?;
+        debug!("processing unbond request successful");
 
         let mut validator_bids_detail = detail::get_validator_bids(self, era_id)?;
 
@@ -656,6 +660,8 @@ pub trait Auction:
         if bids_modified {
             detail::set_validator_bids(self, validator_bids)?;
         }
+
+        debug!("run_auction successful");
 
         Ok(())
     }

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
-    convert::TryInto,
-    ops::Mul,
-};
+use std::{collections::BTreeMap, convert::TryInto, ops::Mul};
 
 use num_rational::Ratio;
 
@@ -397,9 +393,6 @@ pub fn process_unbond_requests<P: Auction + ?Sized>(
 
     let unbonding_delay = get_unbonding_delay(provider)?;
 
-    let mut processed_validators = BTreeSet::new();
-    let mut still_unbonding_public_keys = HashSet::new();
-
     for unbonding_list in unbonding_purses.values_mut() {
         let mut new_unbonding_list = Vec::new();
 
@@ -408,11 +401,13 @@ pub fn process_unbond_requests<P: Auction + ?Sized>(
             // current era id + unbonding delay is equal or greater than the `era_of_creation` that
             // was calculated on `unbond` attempt.
             if current_era_id >= unbonding_purse.era_of_creation() + unbonding_delay {
-                // remember the validator's key, so that we can later check if we can prune their
-                // bid now that the unbond has been processed
-                processed_validators.insert(unbonding_purse.validator_public_key().clone());
-                match handle_redelegation(provider, unbonding_purse, max_delegators_per_validator)?
-                {
+                let redelegation_result =
+                    handle_redelegation(provider, unbonding_purse, max_delegators_per_validator)
+                        .map_err(|err| {
+                            error!(?err, ?unbonding_purse, "error processing unbond");
+                            err
+                        })?;
+                match redelegation_result {
                     UnbondRedelegationOutcome::SuccessfullyRedelegated => {
                         // noop; on successful redelegation, no actual unbond occurs
                     }
@@ -424,56 +419,16 @@ pub fn process_unbond_requests<P: Auction + ?Sized>(
                     | uro @ UnbondRedelegationOutcome::Withdrawal => {
                         // Move funds from bid purse to unbonding purse
                         provider.unbond(unbonding_purse).map_err(|err| {
-                            error!("Error unbonding purse {err:?} ({uro:?})");
+                            error!(?err, ?uro, "error unbonding purse");
                             ApiError::from(Error::TransferToUnbondingPurse)
                         })?
                     }
                 }
             } else {
                 new_unbonding_list.push(unbonding_purse.clone());
-                // remember the key of the unbonder that is still not fully unbonded - so that we
-                // don't prune bids of validators that still have delegators waiting for unbonding,
-                // or the waiting delegators
-                still_unbonding_public_keys.insert(unbonding_purse.unbonder_public_key().clone());
             }
         }
         *unbonding_list = new_unbonding_list;
-    }
-
-    // revisit the validators for which we processed some unbonds and see if we can now prune their
-    // or their delegators' bids
-    for validator_public_key in processed_validators {
-        let validator_bid_addr = BidAddr::new_from_public_keys(&validator_public_key, None);
-        let validator_bid = read_current_validator_bid(provider, validator_bid_addr.into())?;
-        let validator_public_key = validator_bid.validator_public_key().clone(); // use the current
-                                                                                 // public key
-        let mut delegator_bids = read_delegator_bids(provider, &validator_public_key)?;
-
-        // prune the delegators that have no stake and no remaining unbonds to be processed
-        delegator_bids.retain(|delegator| {
-            if delegator.staked_amount().is_zero()
-                && !still_unbonding_public_keys.contains(delegator.delegator_public_key())
-            {
-                let delegator_bid_addr = BidAddr::new_from_public_keys(
-                    &validator_public_key,
-                    Some(delegator.delegator_public_key()),
-                );
-                debug!("pruning delegator bid {}", delegator_bid_addr);
-                provider.prune_bid(delegator_bid_addr);
-                false
-            } else {
-                true
-            }
-        });
-
-        // if the validator has no delegators, no stake and no remaining unbonds, prune them, too
-        if !still_unbonding_public_keys.contains(&validator_public_key)
-            && delegator_bids.is_empty()
-            && validator_bid.staked_amount().is_zero()
-        {
-            debug!("pruning validator bid {}", validator_bid_addr);
-            provider.prune_bid(validator_bid_addr);
-        }
     }
 
     set_unbonding_purses(provider, unbonding_purses)?;
@@ -642,16 +597,13 @@ where
 {
     let bid_key: Key = BidAddr::from(validator_public_key.clone()).into();
     let bonding_purse = match read_current_validator_bid(provider, bid_key) {
-        Ok(mut validator_bid) if !validator_bid.staked_amount().is_zero() => {
-            // Only distribute to the bonding purse if the staked amount is not zero - an amount of
-            // zero indicates a validator that has unbonded, but whose unbonds haven't been
-            // processed yet.
+        Ok(mut validator_bid) => {
             let purse = *validator_bid.bonding_purse();
             validator_bid.increase_stake(amount)?;
             provider.write_bid(bid_key, BidKind::Validator(validator_bid))?;
             purse
         }
-        Ok(_) | Err(Error::ValidatorNotFound) => {
+        Err(Error::ValidatorNotFound) => {
             // check to see if there are unbond entries for this recipient, and if there are
             // apply the amount to the unbond entry with the highest era.
             let account_hash = validator_public_key.to_account_hash();
@@ -771,12 +723,6 @@ where
     }
     if amount > U512::from(validator_bid.maximum_delegation_amount()) {
         return Err(Error::DelegationAmountTooLarge.into());
-    }
-
-    if validator_bid.staked_amount().is_zero() {
-        // The validator has unbonded, but the unbond has not yet been processed, and so an empty
-        // bid still exists. Treat this case as if there was no such validator.
-        return Err(Error::ValidatorNotFound.into());
     }
 
     // is there already a record for this delegator?


### PR DESCRIPTION
This reverts the changes introduced in #4719, as they are no longer needed since #4728 got merged and they were the reason behind the recent issues in tests.

Since the logic introduced in #4719 expected zero bids to exist until the unbonds are processed, and 1.5 removed them upon bid withdrawal / undelegation, this caused issues during the upgrade: 2.0 was attempting to remove zero bids which had already been removed, and failing with a `ValidatorNotFound` error. Thus, the simplest fix was to revert those changes.

This PR also adds a few debug messages that proved to be useful in figuring out this issue.

Closes #4808, #4811, #4812