### PR TITLE
Add gas price to appendable block

### DIFF
--- a/node/src/components/block_validator/event.rs
+++ b/node/src/components/block_validator/event.rs
@@ -1,6 +1,6 @@
 use derive_more::{Display, From};
 
-use casper_types::{FinalitySignature, FinalitySignatureId, Transaction, TransactionHash};
+use casper_types::{EraId, FinalitySignature, FinalitySignatureId, Transaction, TransactionHash};
 
 use crate::{
     components::fetcher::FetchResult, effect::requests::BlockValidationRequest,
@@ -32,4 +32,7 @@ pub(crate) enum Event {
         finality_signature_id: Box<FinalitySignatureId>,
         result: FetchResult<FinalitySignature>,
     },
+
+    #[display(fmt = "{} price for era {}", _1, _0)]
+    UpdateEraGasPrice(EraId, u8),
 }

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -157,7 +157,7 @@ pub(super) fn new_proposed_block_with_cited_signatures(
         ret.insert(LARGE_LANE_ID, standard.into_iter().collect());
         ret
     };
-    let block_payload = BlockPayload::new(transactions, vec![], cited_signatures, true);
+    let block_payload = BlockPayload::new(transactions, vec![], cited_signatures, true, 1u8);
     ProposedBlock::new(Arc::new(block_payload), block_context)
 }
 
@@ -604,6 +604,7 @@ impl ValidationContext {
             self.chainspec.clone(),
             reactor.validator_matrix.clone(),
             Config::default(),
+            1u8,
         );
 
         // Pass the block to the component. This future will eventually resolve to the result, i.e.
@@ -997,6 +998,7 @@ async fn should_fetch_from_multiple_peers() {
             Arc::new(chainspec),
             reactor.validator_matrix.clone(),
             Config::default(),
+            1u8,
         );
 
         // Have a validation request for each one of the peers. These futures will eventually all

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1157,6 +1157,7 @@ impl EraSupervisor {
                     }
                 });
                 let proposed_block = Arc::try_unwrap(value).unwrap_or_else(|arc| (*arc).clone());
+                println!("PB: {:?}", proposed_block);
                 let finalized_approvals: HashMap<_, _> =
                     proposed_block.all_transactions().cloned().collect();
                 if let Some(era_report) = report.as_ref() {

--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -1157,7 +1157,6 @@ impl EraSupervisor {
                     }
                 });
                 let proposed_block = Arc::try_unwrap(value).unwrap_or_else(|arc| (*arc).clone());
-                println!("PB: {:?}", proposed_block);
                 let finalized_approvals: HashMap<_, _> =
                     proposed_block.all_transactions().cloned().collect();
                 if let Some(era_report) = report.as_ref() {

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -149,6 +149,7 @@ fn send_a_valid_wire_unit() {
             vec![],
             Default::default(),
             false,
+            1u8,
         ))),
         seq_number,
         timestamp: now,
@@ -197,6 +198,7 @@ fn detect_doppelganger() {
         vec![],
         Default::default(),
         false,
+        1u8,
     ));
     let wunit: WireUnit<ClContext> = WireUnit {
         panorama,

--- a/node/src/components/consensus/protocols/zug/tests.rs
+++ b/node/src/components/consensus/protocols/zug/tests.rs
@@ -323,6 +323,7 @@ fn new_payload(random_bit: bool) -> Arc<BlockPayload> {
         vec![],
         Default::default(),
         random_bit,
+        1u8,
     ))
 }
 

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -14,6 +14,7 @@ mod utils;
 
 use std::{
     cmp::Ordering,
+    collections::BTreeMap,
     convert::TryInto,
     fmt::{self, Debug, Formatter},
     path::Path,
@@ -503,6 +504,7 @@ impl ContractRuntime {
             ContractRuntimeRequest::UpdatePreState { new_pre_state } => {
                 let next_block_height = new_pre_state.next_block_height();
                 self.set_initial_state(new_pre_state);
+                let current_price = self.current_gas_price.gas_price();
                 async move {
                     let block_header = match effect_builder
                         .get_highest_complete_block_header_from_storage()
@@ -530,8 +532,16 @@ impl ContractRuntime {
                         }
                     };
 
+                    let payload = BlockPayload::new(
+                        BTreeMap::new(),
+                        vec![],
+                        Default::default(),
+                        false,
+                        current_price,
+                    );
+
                     let finalized_block = FinalizedBlock::new(
-                        BlockPayload::default(),
+                        payload,
                         Some(InternalEraReport::default()),
                         block_header.timestamp(),
                         block_header.next_block_era_id(),
@@ -631,7 +641,6 @@ impl ContractRuntime {
                         let chainspec = Arc::clone(&self.chainspec);
                         let metrics = Arc::clone(&self.metrics);
                         let shared_pre_state = Arc::clone(&self.execution_pre_state);
-                        let current_gas_price = self.current_gas_price.gas_price();
                         effects.extend(
                             exec_or_requeue(
                                 data_access_layer,
@@ -645,7 +654,6 @@ impl ContractRuntime {
                                 executable_block,
                                 key_block_height_for_activation_point,
                                 meta_block_state,
-                                current_gas_price,
                             )
                             .ignore(),
                         )

--- a/node/src/components/contract_runtime/tests.rs
+++ b/node/src/components/contract_runtime/tests.rs
@@ -340,7 +340,7 @@ async fn should_not_set_shared_pre_state_to_lower_block_height() {
         })
         .collect();
     txn_set.insert(MINT_LANE_ID, val);
-    let block_payload = BlockPayload::new(txn_set, vec![], Default::default(), true);
+    let block_payload = BlockPayload::new(txn_set, vec![], Default::default(), true, 1u8);
     let block_2 = ExecutableBlock::from_finalized_block_and_transactions(
         FinalizedBlock::new(
             block_payload,

--- a/node/src/components/transaction_buffer.rs
+++ b/node/src/components/transaction_buffer.rs
@@ -428,7 +428,6 @@ impl TransactionBuffer {
         let current_era_gas_price = match self.prices.get(&era_id) {
             Some(gas_price) => *gas_price,
             None => {
-                println!("In none case setting default val");
                 return AppendableBlock::new(
                     self.chainspec.transaction_config.clone(),
                     self.chainspec.vacancy_config.min_gas_price,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -925,6 +925,10 @@ impl reactor::Reactor for MainReactor {
                     transaction_buffer::Event::UpdateEraGasPrice(era_id, next_era_gas_price),
                 );
                 effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
+                let reactor_event = MainEvent::BlockValidator(
+                    block_validator::Event::UpdateEraGasPrice(era_id, next_era_gas_price),
+                );
+                effects.extend(self.dispatch_event(effect_builder, rng, reactor_event));
                 effects
             }
 
@@ -1216,6 +1220,7 @@ impl reactor::Reactor for MainReactor {
             Arc::clone(&chainspec),
             validator_matrix.clone(),
             config.block_validator,
+            chainspec.vacancy_config.min_gas_price,
         );
         let upgrade_watcher =
             UpgradeWatcher::new(chainspec.as_ref(), config.upgrade_watcher, &root_dir)?;

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -1715,6 +1715,7 @@ async fn empty_block_validation_regression() {
                             everyone_else.clone(),
                             Default::default(),
                             false,
+                            1u8,
                         )),
                         block_context,
                     },

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -41,15 +41,21 @@ pub(crate) enum AddError {
 #[derive(Clone, Eq, PartialEq, DataSize, Debug)]
 pub(crate) struct AppendableBlock {
     transaction_config: TransactionConfig,
+    current_gas_price: u8,
     transactions: BTreeMap<TransactionHash, TransactionFootprint>,
     timestamp: Timestamp,
 }
 
 impl AppendableBlock {
     /// Creates an empty `AppendableBlock`.
-    pub(crate) fn new(transaction_config: TransactionConfig, timestamp: Timestamp) -> Self {
+    pub(crate) fn new(
+        transaction_config: TransactionConfig,
+        current_gas_price: u8,
+        timestamp: Timestamp,
+    ) -> Self {
         AppendableBlock {
             transaction_config,
+            current_gas_price,
             transactions: BTreeMap::new(),
             timestamp,
         }
@@ -145,8 +151,11 @@ impl AppendableBlock {
     ) -> BlockPayload {
         let AppendableBlock {
             transactions: footprints,
+            current_gas_price: price,
             ..
         } = self;
+
+        println!("price {}", price);
 
         fn collate(
             category: u8,
@@ -175,7 +184,13 @@ impl AppendableBlock {
             collate(lane_id as u8, &mut transactions, &footprints);
         }
 
-        BlockPayload::new(transactions, accusations, rewarded_signatures, random_bit)
+        BlockPayload::new(
+            transactions,
+            accusations,
+            rewarded_signatures,
+            random_bit,
+            price,
+        )
     }
 
     pub(crate) fn timestamp(&self) -> Timestamp {

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -155,8 +155,6 @@ impl AppendableBlock {
             ..
         } = self;
 
-        println!("price {}", price);
-
         fn collate(
             category: u8,
             collater: &mut BTreeMap<u8, Vec<(TransactionHash, BTreeSet<Approval>)>>,

--- a/node/src/types/block/block_payload.rs
+++ b/node/src/types/block/block_payload.rs
@@ -19,14 +19,25 @@ use casper_types::{
 /// From the view of the consensus protocol this is the "consensus value": The protocol deals with
 /// finalizing an order of `BlockPayload`s. Only after consensus has been reached, the block's
 /// deploys actually get executed, and the executed block gets signed.
-#[derive(
-    Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize, Default,
-)]
+#[derive(Clone, DataSize, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BlockPayload {
     transactions: BTreeMap<u8, Vec<(TransactionHash, BTreeSet<Approval>)>>,
     accusations: Vec<PublicKey>,
     rewarded_signatures: RewardedSignatures,
     random_bit: bool,
+    current_gas_price: u8,
+}
+
+impl Default for BlockPayload {
+    fn default() -> Self {
+        Self {
+            transactions: Default::default(),
+            accusations: vec![],
+            rewarded_signatures: Default::default(),
+            random_bit: false,
+            current_gas_price: 1u8,
+        }
+    }
 }
 
 impl BlockPayload {
@@ -35,12 +46,14 @@ impl BlockPayload {
         accusations: Vec<PublicKey>,
         rewarded_signatures: RewardedSignatures,
         random_bit: bool,
+        current_gas_price: u8,
     ) -> Self {
         BlockPayload {
             transactions,
             accusations,
             rewarded_signatures,
             random_bit,
+            current_gas_price,
         }
     }
 
@@ -133,6 +146,11 @@ impl BlockPayload {
     /// The finality signatures for the past blocks that will be rewarded in this block.
     pub(crate) fn rewarded_signatures(&self) -> &RewardedSignatures {
         &self.rewarded_signatures
+    }
+
+    /// The current gas price to execute the payload against.
+    pub(crate) fn current_gas_price(&self) -> u8 {
+        self.current_gas_price
     }
 
     pub(crate) fn all_transaction_hashes(&self) -> impl Iterator<Item = TransactionHash> {

--- a/node/src/types/block/executable_block.rs
+++ b/node/src/types/block/executable_block.rs
@@ -20,6 +20,7 @@ pub struct ExecutableBlock {
     pub(crate) era_id: EraId,
     pub(crate) height: u64,
     pub(crate) proposer: Box<PublicKey>,
+    pub(crate) current_gas_price: u8,
     /// The transactions for the `FinalizedBlock`.
     pub(crate) transactions: Vec<Transaction>,
     pub(crate) transaction_map: BTreeMap<u8, Vec<TransactionHash>>,
@@ -70,6 +71,7 @@ impl ExecutableBlock {
             transaction_map: finalized_block.transactions,
             rewards: None,
             next_era_gas_price: None,
+            current_gas_price: finalized_block.current_gas_price,
         }
     }
 
@@ -92,6 +94,7 @@ impl ExecutableBlock {
             transaction_map: block.transactions().clone(),
             rewards: block.era_end().map(|era_end| era_end.rewards().clone()),
             next_era_gas_price: block.era_end().map(|era_end| era_end.next_era_gas_price()),
+            current_gas_price: block.header().current_gas_price(),
         }
     }
 }

--- a/node/src/types/block/finalized_block.rs
+++ b/node/src/types/block/finalized_block.rs
@@ -59,7 +59,6 @@ impl FinalizedBlock {
         proposer: PublicKey,
     ) -> Self {
         let current_gas_price = block_payload.current_gas_price();
-        println!("payload price {}", current_gas_price);
         let transactions = block_payload.finalized_payload();
 
         FinalizedBlock {

--- a/node/src/types/block/finalized_block.rs
+++ b/node/src/types/block/finalized_block.rs
@@ -35,6 +35,7 @@ pub struct FinalizedBlock {
     pub(crate) era_id: EraId,
     pub(crate) height: u64,
     pub(crate) proposer: Box<PublicKey>,
+    pub(crate) current_gas_price: u8,
 }
 
 /// `EraReport` used only internally. The one in types is a part of `EraEndV1`.
@@ -57,6 +58,8 @@ impl FinalizedBlock {
         height: u64,
         proposer: PublicKey,
     ) -> Self {
+        let current_gas_price = block_payload.current_gas_price();
+        println!("payload price {}", current_gas_price);
         let transactions = block_payload.finalized_payload();
 
         FinalizedBlock {
@@ -68,6 +71,7 @@ impl FinalizedBlock {
             era_id,
             height,
             proposer: Box::new(proposer),
+            current_gas_price,
         }
     }
 
@@ -137,7 +141,7 @@ impl FinalizedBlock {
         let rewarded_signatures = Default::default();
         let random_bit = rng.gen();
         let block_payload =
-            BlockPayload::new(transactions, vec![], rewarded_signatures, random_bit);
+            BlockPayload::new(transactions, vec![], rewarded_signatures, random_bit, 1u8);
 
         let era_report = if is_switch {
             Some(InternalEraReport::random(rng))
@@ -172,6 +176,7 @@ impl From<BlockV2> for FinalizedBlock {
             height: block.height(),
             proposer: Box::new(block.proposer().clone()),
             rewarded_signatures: block.rewarded_signatures().clone(),
+            current_gas_price: block.header().current_gas_price(),
         }
     }
 }
@@ -244,7 +249,7 @@ mod tests {
             ret.insert(AUCTION_LANE_ID, vec![]);
             ret
         };
-        let block_payload = BlockPayload::new(transactions, vec![], Default::default(), false);
+        let block_payload = BlockPayload::new(transactions, vec![], Default::default(), false, 1u8);
 
         let fb = FinalizedBlock::new(
             block_payload,

--- a/node/src/utils/specimen.rs
+++ b/node/src/utils/specimen.rs
@@ -442,9 +442,9 @@ where
                 //
                 // 1. The required seed bytes for Ed25519 and Secp256k1 are both the same length of
                 //    32 bytes.
-                // 2. While Secp256k1 does not allow the most trivial seed bytes of 0x00..0001, a
-                //    a hash function output seems to satisfy it, and our current hashing scheme
-                //    also output 32 bytes.
+                // 2. While Secp256k1 does not allow the most trivial seed bytes of 0x00..0001, a a
+                //    hash function output seems to satisfy it, and our current hashing scheme also
+                //    output 32 bytes.
                 let seed_bytes = Digest::hash(seed.to_be_bytes()).value();
 
                 match variant {
@@ -877,6 +877,7 @@ impl LargestSpecimen for BlockPayload {
         BlockPayload::new(
             transactions,
             vec_prop_specimen(estimator, "max_accusations_per_block", cache),
+            LargestSpecimen::largest_specimen(estimator, cache),
             LargestSpecimen::largest_specimen(estimator, cache),
             LargestSpecimen::largest_specimen(estimator, cache),
         )


### PR DESCRIPTION
CHANGELOG:

- Add new field `current_gas_price` to the appendable block
- Add new field `current_gas_price` to the executable and finalized block
- Added field `current_gas_price` to the block validator which checks the gas price in the proposed block and ensures the value matches, raises an invalid block if the price does not match