### PR TITLE
Add batch write operation to trie store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if 1.0.0",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -106,6 +107,12 @@ name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi_term"
@@ -189,6 +196,12 @@ name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "assert-json-diff"
@@ -429,6 +442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,7 +541,7 @@ dependencies = [
  "casper-types",
  "casper-wasm",
  "clap 2.34.0",
- "criterion",
+ "criterion 0.3.6",
  "dictionary",
  "dictionary-call",
  "fs_extra",
@@ -557,7 +576,7 @@ dependencies = [
  "casper-wasm",
  "casper-wasm-utils",
  "casper-wasmi",
- "criterion",
+ "criterion 0.3.6",
  "datasize",
  "either",
  "hex-buffer-serde 0.2.2",
@@ -677,7 +696,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "uint",
- "uuid",
+ "uuid 0.8.2",
  "vergen",
  "warp",
  "wheelbuf",
@@ -692,6 +711,7 @@ dependencies = [
  "base16",
  "bincode",
  "casper-types",
+ "criterion 0.5.1",
  "datasize",
  "either",
  "itertools 0.10.5",
@@ -702,6 +722,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "once_cell",
+ "pprof",
  "proptest",
  "rand",
  "rand_chacha",
@@ -710,7 +731,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -722,7 +743,7 @@ dependencies = [
  "bincode",
  "bitflags 1.3.2",
  "blake2",
- "criterion",
+ "criterion 0.3.6",
  "datasize",
  "derive_more",
  "derp",
@@ -870,6 +891,33 @@ version = "0.1.0"
 dependencies = [
  "casper-contract",
  "casper-types",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half 2.4.1",
 ]
 
 [[package]]
@@ -1082,6 +1130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,7 +1219,7 @@ dependencies = [
  "atty",
  "cast",
  "clap 2.34.0",
- "criterion-plot",
+ "criterion-plot 0.4.5",
  "csv",
  "itertools 0.10.5",
  "lazy_static",
@@ -1180,10 +1237,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.3.21",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
@@ -1429,6 +1522,15 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid 1.10.0",
 ]
 
 [[package]]
@@ -2053,6 +2155,18 @@ version = "0.1.0"
 dependencies = [
  "casper-contract",
  "casper-types",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2961,6 +3075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3370,24 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "inferno"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+dependencies = [
+ "ahash",
+ "indexmap 2.0.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
 ]
 
 [[package]]
@@ -3702,6 +3844,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "non-standard-payment"
 version = "0.1.0"
 dependencies = [
@@ -3762,6 +3915,16 @@ dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -4187,6 +4350,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if 1.0.0",
+ "criterion 0.5.1",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4370,6 +4555,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -4783,6 +4977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aee83dc281d5a3200d37b299acd13b81066ea126a7f16f0eae70fc9aed241d9"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5019,7 +5222,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
+ "half 1.8.2",
  "serde",
 ]
 
@@ -5273,6 +5476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5354,6 +5563,29 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "symbolic-common"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71297dc3e250f7dbdf8adb99e235da783d690f5819fdeb4cce39d9cfb0aca9f1"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid 1.10.0",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424fa2c9bf2c862891b9cfd354a752751a6730fd838a4691e7f6c2c7957b9daf"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -6160,6 +6392,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -214,8 +214,8 @@ pub fn execute_finalized_block(
                 artifacts.push(artifact_builder.build());
                 continue; // no reason to commit the effects, move on
             }
-            state_root_hash =
-                scratch_state.commit(state_root_hash, handle_refund_result.effects().clone())?;
+            state_root_hash = scratch_state
+                .commit_effects(state_root_hash, handle_refund_result.effects().clone())?;
         }
 
         let mut balance_identifier = {
@@ -259,7 +259,7 @@ pub fn execute_finalized_block(
                     }
                 };
                 state_root_hash =
-                    scratch_state.commit(state_root_hash, pay_result.effects().clone())?;
+                    scratch_state.commit_effects(state_root_hash, pay_result.effects().clone())?;
                 artifact_builder
                     .with_wasm_v1_result(pay_result)
                     .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
@@ -299,7 +299,7 @@ pub fn execute_finalized_block(
                 );
                 let hold_result = scratch_state.balance_hold(hold_request);
                 state_root_hash =
-                    scratch_state.commit(state_root_hash, hold_result.effects().clone())?;
+                    scratch_state.commit_effects(state_root_hash, hold_result.effects().clone())?;
                 artifact_builder
                     .with_balance_hold_result(&hold_result)
                     .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
@@ -319,8 +319,8 @@ pub fn execute_finalized_block(
                             runtime_args,
                         ));
                     let consumed = gas_limit;
-                    state_root_hash =
-                        scratch_state.commit(state_root_hash, transfer_result.effects().clone())?;
+                    state_root_hash = scratch_state
+                        .commit_effects(state_root_hash, transfer_result.effects().clone())?;
                     artifact_builder
                         .with_added_consumed(consumed)
                         .with_transfer_result(transfer_result)
@@ -339,8 +339,10 @@ pub fn execute_finalized_block(
                                 auction_method,
                             ));
                             let consumed = gas_limit;
-                            state_root_hash = scratch_state
-                                .commit(state_root_hash, bidding_result.effects().clone())?;
+                            state_root_hash = scratch_state.commit_effects(
+                                state_root_hash,
+                                bidding_result.effects().clone(),
+                            )?;
                             artifact_builder
                                 .with_added_consumed(consumed)
                                 .with_bidding_result(bidding_result)
@@ -369,8 +371,10 @@ pub fn execute_finalized_block(
                             let wasm_v1_result =
                                 execution_engine_v1.execute(&scratch_state, wasm_v1_request);
                             trace!(%transaction_hash, ?category, ?wasm_v1_result, "able to get wasm v1 result");
-                            state_root_hash = scratch_state
-                                .commit(state_root_hash, wasm_v1_result.effects().clone())?;
+                            state_root_hash = scratch_state.commit_effects(
+                                state_root_hash,
+                                wasm_v1_result.effects().clone(),
+                            )?;
                             // note: consumed is scraped from wasm_v1_result along w/ other fields
                             artifact_builder
                                 .with_wasm_v1_result(wasm_v1_result)
@@ -402,7 +406,7 @@ pub fn execute_finalized_block(
             );
             let hold_result = scratch_state.balance_hold(hold_request);
             state_root_hash =
-                scratch_state.commit(state_root_hash, hold_result.effects().clone())?;
+                scratch_state.commit_effects(state_root_hash, hold_result.effects().clone())?;
             artifact_builder
                 .with_balance_hold_result(&hold_result)
                 .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
@@ -475,7 +479,7 @@ pub fn execute_finalized_block(
                     let handle_refund_result = scratch_state.handle_refund(handle_refund_request);
                     let refunded_amount = handle_refund_result.refund_amount();
                     state_root_hash = scratch_state
-                        .commit(state_root_hash, handle_refund_result.effects().clone())?;
+                        .commit_effects(state_root_hash, handle_refund_result.effects().clone())?;
                     artifact_builder
                         .with_handle_refund_result(&handle_refund_result)
                         .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
@@ -500,7 +504,7 @@ pub fn execute_finalized_block(
                 );
                 let hold_result = scratch_state.balance_hold(hold_request);
                 state_root_hash =
-                    scratch_state.commit(state_root_hash, hold_result.effects().clone())?;
+                    scratch_state.commit_effects(state_root_hash, hold_result.effects().clone())?;
                 artifact_builder
                     .with_balance_hold_result(&hold_result)
                     .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
@@ -562,7 +566,7 @@ pub fn execute_finalized_block(
             }
         };
         state_root_hash =
-            scratch_state.commit(state_root_hash, handle_fee_result.effects().clone())?;
+            scratch_state.commit_effects(state_root_hash, handle_fee_result.effects().clone())?;
         artifact_builder
             .with_handle_fee_result(&handle_fee_result)
             .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
@@ -595,8 +599,8 @@ pub fn execute_finalized_block(
                     )
                 );
             }
-            state_root_hash =
-                scratch_state.commit(state_root_hash, handle_refund_result.effects().clone())?;
+            state_root_hash = scratch_state
+                .commit_effects(state_root_hash, handle_refund_result.effects().clone())?;
         }
 
         artifacts.push(artifact_builder.build());
@@ -635,7 +639,7 @@ pub fn execute_finalized_block(
                     .into(),
             ),
         ));
-        scratch_state.commit(state_root_hash, effects)?;
+        scratch_state.commit_effects(state_root_hash, effects)?;
         transaction_ids
             .into_iter()
             .map(|id| id.approvals_hash())

--- a/node/src/components/contract_runtime/tests.rs
+++ b/node/src/components/contract_runtime/tests.rs
@@ -513,7 +513,7 @@ mod trie_chunking_tests {
         let post_state_hash = &contract_runtime
             .data_access_layer()
             .as_ref()
-            .commit(empty_state_root, effects)
+            .commit_effects(empty_state_root, effects)
             .expect("applying effects to succeed");
         (contract_runtime, *post_state_hash)
     }

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -140,7 +140,7 @@ async fn setup() -> (
         .main_reactor()
         .contract_runtime()
         .data_access_layer()
-        .commit(*highest_block.state_root_hash(), effects.effects)
+        .commit_effects(*highest_block.state_root_hash(), effects.effects)
         .expect("should commit effects");
 
     // Get the binary port address.

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -39,7 +39,13 @@ proptest = "1.0.0"
 rand = "0.8.3"
 serde_json = "1"
 base16 = "0.2.1"
+criterion = { version = "0.5.1", features = ["html_reports"] }
+pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 
 [package.metadata.docs.rs]
 all-features = true
 rustc-args = ["--cfg", "docsrs"]
+
+[[bench]]
+name = "global_state_key_write_bench"
+harness = false

--- a/storage/benches/global_state_key_write_bench.rs
+++ b/storage/benches/global_state_key_write_bench.rs
@@ -8,7 +8,10 @@ use casper_storage::global_state::{
     store::Store,
     transaction_source::{lmdb::LmdbEnvironment, Transaction, TransactionSource},
     trie::Trie,
-    trie_store::{lmdb::LmdbTrieStore, operations::WriteResult},
+    trie_store::{
+        lmdb::LmdbTrieStore,
+        operations::{batch_write, WriteResult},
+    },
 };
 use casper_types::{bytesrepr::ToBytes, testing::TestRng, Digest, Key};
 use lmdb::{DatabaseFlags, RwTransaction};
@@ -20,12 +23,12 @@ use casper_storage::global_state::trie_store::operations::write;
 pub(crate) const DB_SIZE: usize = 8_520_428_800;
 pub(crate) const MAX_READERS: u32 = 512;
 
-fn write_batch(
+fn write_sequential(
     trie_store: &LmdbTrieStore,
     txn: &mut RwTransaction,
     mut root_hash: Digest,
     data: Vec<(Key, u32)>,
-) {
+) -> Digest {
     for (key, value) in data.iter() {
         let write_result =
             write::<Key, u32, _, _, error::Error>(txn, trie_store, &root_hash, key, value).unwrap();
@@ -34,66 +37,161 @@ fn write_batch(
                 root_hash = hash;
             }
             WriteResult::AlreadyExists => (),
-            WriteResult::RootNotFound => panic!("write_leaves given an invalid root"),
+            WriteResult::RootNotFound => panic!("invalid root hash"),
         };
     }
+    root_hash
 }
 
-fn empty_store() -> (LmdbEnvironment, LmdbTrieStore, Digest) {
+fn create_empty_store() -> (LmdbEnvironment, LmdbTrieStore) {
     let _temp_dir = tempdir().unwrap();
     let environment = LmdbEnvironment::new(_temp_dir.path(), DB_SIZE, MAX_READERS, true).unwrap();
     let store = LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap();
 
+    (environment, store)
+}
+
+fn store_empty_root(env: &LmdbEnvironment, store: &LmdbTrieStore) -> Digest {
     let trie: Trie<Key, u32> = Trie::node(&[]);
     let trie_bytes = trie.to_bytes().unwrap();
     let hash = Digest::hash(trie_bytes);
 
-    let mut txn = environment.create_read_write_txn().unwrap();
+    let mut txn = env.create_read_write_txn().unwrap();
     store.put(&mut txn, &hash, &trie).unwrap();
     txn.commit().unwrap();
 
-    (environment, store, hash)
+    hash
 }
 
-fn custom_iteration_write_bench(c: &mut Criterion) {
-    let mut rng = TestRng::new();
-
+fn sequential_write_bench(c: &mut Criterion, rng: &mut TestRng) {
+    let mut sequential_write_group = c.benchmark_group("trie_store_sequential_write");
     for batch_size in [1000, 10_000] {
-        //[1000u32, 10_000, 100_000, 250_000] {
-        let mut group = c.benchmark_group(format!("trie_store_batch_write_{}", batch_size));
-        group.throughput(Throughput::Elements(batch_size as u64));
+        sequential_write_group.throughput(Throughput::Elements(batch_size as u64));
 
         if batch_size > 150_000 {
             // Reduce the sample size to allow faster runtime.
-            group.sample_size(30);
+            sequential_write_group.sample_size(30);
         }
 
-        group.bench_function("write_batch", |b| {
+        sequential_write_group.bench_function(format!("write_sequential_{}", batch_size), |b| {
             b.iter_custom(|iter| {
                 let mut total = Duration::default();
                 for _ in 0..iter {
-                    let (env, store, root_hash) = empty_store();
+                    let (env, store) = create_empty_store();
+                    let root_hash = store_empty_root(&env, &store);
                     let mut txn = env.create_read_write_txn().unwrap();
-                    let data: Vec<(Key, u32)> = (0u32..batch_size)
-                        .into_iter()
-                        .map(|val| (rng.gen(), val))
-                        .collect();
+                    let data: Vec<(Key, u32)> =
+                        (0u32..batch_size).map(|val| (rng.gen(), val)).collect();
 
                     let start = Instant::now();
-                    write_batch(&store, &mut txn, root_hash, data);
+                    write_sequential(&store, &mut txn, root_hash, data);
                     total = total.checked_add(start.elapsed()).unwrap();
                 }
 
                 total
             })
         });
-        group.finish();
     }
+    sequential_write_group.finish();
+}
+
+fn batch_write_with_empty_store(c: &mut Criterion, rng: &mut TestRng) {
+    let mut batch_write_group = c.benchmark_group("batch_write_with_empty_store");
+
+    for batch_size in [1000, 10_000] {
+        batch_write_group.throughput(Throughput::Elements(batch_size as u64));
+
+        if batch_size > 150_000 {
+            // Reduce the sample size to allow faster runtime.
+            batch_write_group.sample_size(30);
+        }
+
+        batch_write_group.bench_function(format!("write_batch_{}", batch_size), |b| {
+            b.iter_custom(|iter| {
+                let mut total = Duration::default();
+                for _ in 0..iter {
+                    let (environment, store) = create_empty_store();
+                    let root_hash = store_empty_root(&environment, &store);
+                    let mut txn = environment.create_read_write_txn().unwrap();
+                    let data: Vec<(Key, u32)> =
+                        (0u32..batch_size).map(|val| (rng.gen(), val)).collect();
+
+                    let start = Instant::now();
+                    let _ = batch_write::<Key, u32, _, _, _, error::Error>(
+                        &mut txn,
+                        &store,
+                        &root_hash,
+                        data.into_iter(),
+                    )
+                    .unwrap();
+                    total = total.checked_add(start.elapsed()).unwrap();
+                }
+
+                total
+            })
+        });
+    }
+    batch_write_group.finish();
+}
+
+fn batch_write_with_populated_store(c: &mut Criterion, rng: &mut TestRng) {
+    let mut batch_write_group = c.benchmark_group("batch_write_with_populated_store");
+
+    for batch_size in [1000, 10_000] {
+        batch_write_group.throughput(Throughput::Elements(batch_size as u64));
+
+        if batch_size > 150_000 {
+            // Reduce the sample size to allow faster runtime.
+            batch_write_group.sample_size(30);
+        }
+
+        batch_write_group.bench_function(format!("write_batch_{}", batch_size), |b| {
+            b.iter_custom(|iter| {
+                let mut total = Duration::default();
+                for _ in 0..iter {
+                    let (environment, store) = create_empty_store();
+                    let root_hash = store_empty_root(&environment, &store);
+                    let mut txn = environment.create_read_write_txn().unwrap();
+                    let initial_data: Vec<(Key, u32)> =
+                        (0u32..200).map(|val| (rng.gen(), val)).collect();
+
+                    // Pre-populate trie store with some data.
+                    let root_hash = write_sequential(&store, &mut txn, root_hash, initial_data);
+
+                    // Create a cache backed up by the pre-populated store. Any already existing
+                    // nodes will be read-back into the cache.
+                    let data: Vec<(Key, u32)> =
+                        (0u32..batch_size).map(|val| (rng.gen(), val)).collect();
+
+                    let start = Instant::now();
+                    let _ = batch_write::<Key, u32, _, _, _, error::Error>(
+                        &mut txn,
+                        &store,
+                        &root_hash,
+                        data.into_iter(),
+                    )
+                    .unwrap();
+                    total = total.checked_add(start.elapsed()).unwrap();
+                }
+
+                total
+            })
+        });
+    }
+    batch_write_group.finish();
+}
+
+fn trie_store_batch_write_bench(c: &mut Criterion) {
+    let mut rng = TestRng::new();
+
+    sequential_write_bench(c, &mut rng);
+    batch_write_with_empty_store(c, &mut rng);
+    batch_write_with_populated_store(c, &mut rng);
 }
 
 criterion_group! {
   name = benches;
   config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-  targets = custom_iteration_write_bench
+  targets = trie_store_batch_write_bench
 }
 criterion_main!(benches);

--- a/storage/benches/global_state_key_write_bench.rs
+++ b/storage/benches/global_state_key_write_bench.rs
@@ -1,0 +1,99 @@
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use pprof::criterion::{Output, PProfProfiler};
+
+use casper_storage::global_state::{
+    error,
+    store::Store,
+    transaction_source::{lmdb::LmdbEnvironment, Transaction, TransactionSource},
+    trie::Trie,
+    trie_store::{lmdb::LmdbTrieStore, operations::WriteResult},
+};
+use casper_types::{bytesrepr::ToBytes, testing::TestRng, Digest, Key};
+use lmdb::{DatabaseFlags, RwTransaction};
+use rand::Rng;
+use tempfile::tempdir;
+
+use casper_storage::global_state::trie_store::operations::write;
+
+pub(crate) const DB_SIZE: usize = 8_520_428_800;
+pub(crate) const MAX_READERS: u32 = 512;
+
+fn write_batch(
+    trie_store: &LmdbTrieStore,
+    txn: &mut RwTransaction,
+    mut root_hash: Digest,
+    data: Vec<(Key, u32)>,
+) {
+    for (key, value) in data.iter() {
+        let write_result =
+            write::<Key, u32, _, _, error::Error>(txn, trie_store, &root_hash, key, value).unwrap();
+        match write_result {
+            WriteResult::Written(hash) => {
+                root_hash = hash;
+            }
+            WriteResult::AlreadyExists => (),
+            WriteResult::RootNotFound => panic!("write_leaves given an invalid root"),
+        };
+    }
+}
+
+fn empty_store() -> (LmdbEnvironment, LmdbTrieStore, Digest) {
+    let _temp_dir = tempdir().unwrap();
+    let environment = LmdbEnvironment::new(_temp_dir.path(), DB_SIZE, MAX_READERS, true).unwrap();
+    let store = LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap();
+
+    let trie: Trie<Key, u32> = Trie::node(&[]);
+    let trie_bytes = trie.to_bytes().unwrap();
+    let hash = Digest::hash(trie_bytes);
+
+    let mut txn = environment.create_read_write_txn().unwrap();
+    store.put(&mut txn, &hash, &trie).unwrap();
+    txn.commit().unwrap();
+
+    (environment, store, hash)
+}
+
+fn custom_iteration_write_bench(c: &mut Criterion) {
+    let mut rng = TestRng::new();
+
+    for batch_size in [1000, 10_000] {
+        //[1000u32, 10_000, 100_000, 250_000] {
+        let mut group = c.benchmark_group(format!("trie_store_batch_write_{}", batch_size));
+        group.throughput(Throughput::Elements(batch_size as u64));
+
+        if batch_size > 150_000 {
+            // Reduce the sample size to allow faster runtime.
+            group.sample_size(30);
+        }
+
+        group.bench_function("write_batch", |b| {
+            b.iter_custom(|iter| {
+                let mut total = Duration::default();
+                for _ in 0..iter {
+                    let (env, store, root_hash) = empty_store();
+                    let mut txn = env.create_read_write_txn().unwrap();
+                    let data: Vec<(Key, u32)> = (0u32..batch_size)
+                        .into_iter()
+                        .map(|val| (rng.gen(), val))
+                        .collect();
+
+                    let start = Instant::now();
+                    write_batch(&store, &mut txn, root_hash, data);
+                    total = total.checked_add(start.elapsed()).unwrap();
+                }
+
+                total
+            })
+        });
+        group.finish();
+    }
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+  targets = custom_iteration_write_bench
+}
+criterion_main!(benches);

--- a/storage/src/data_access_layer.rs
+++ b/storage/src/data_access_layer.rs
@@ -115,8 +115,22 @@ impl<S> CommitProvider for DataAccessLayer<S>
 where
     S: CommitProvider,
 {
-    fn commit(&self, state_hash: Digest, effects: Effects) -> Result<Digest, GlobalStateError> {
-        self.state.commit(state_hash, effects)
+    fn commit_effects(
+        &self,
+        state_hash: Digest,
+        effects: Effects,
+    ) -> Result<Digest, GlobalStateError> {
+        self.state.commit_effects(state_hash, effects)
+    }
+
+    fn commit_values(
+        &self,
+        state_hash: Digest,
+        values_to_write: Vec<(casper_types::Key, casper_types::StoredValue)>,
+        keys_to_prune: std::collections::BTreeSet<casper_types::Key>,
+    ) -> Result<Digest, GlobalStateError> {
+        self.state
+            .commit_values(state_hash, values_to_write, keys_to_prune)
     }
 }
 

--- a/storage/src/global_state/error.rs
+++ b/storage/src/global_state/error.rs
@@ -6,6 +6,8 @@ use casper_types::{bytesrepr, Digest, Key};
 
 use crate::global_state::{state::CommitError, trie::TrieRaw};
 
+use super::trie_store::TrieStoreCacheError;
+
 /// Error enum representing possible errors in global state interactions.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -41,6 +43,10 @@ pub enum Error {
     /// Cannot provide proofs over working state in a cache (programmer error).
     #[error("Attempt to generate proofs using non-empty cache.")]
     CannotProvideProofsOverCachedData,
+
+    /// Encountered a cache error.
+    #[error("Cache error")]
+    CacheError(#[from] TrieStoreCacheError),
 }
 
 impl<T> From<sync::PoisonError<T>> for Error {

--- a/storage/src/global_state/trie/mod.rs
+++ b/storage/src/global_state/trie/mod.rs
@@ -421,6 +421,15 @@ impl<K, V> Trie<K, V> {
             .map(|bytes| Digest::hash_into_chunks_if_necessary(&bytes))
     }
 
+    /// Returns bytes representation of this Trie and the hash over those bytes.
+    pub fn trie_hash_and_bytes(&self) -> Result<(Digest, Vec<u8>), bytesrepr::Error>
+    where
+        Self: ToBytes,
+    {
+        self.to_bytes()
+            .map(|bytes| (Digest::hash_into_chunks_if_necessary(&bytes), bytes))
+    }
+
     /// Returns a pointer block, if possible.
     pub fn as_pointer_block(&self) -> Option<&PointerBlock> {
         if let Self::Node { pointer_block } = self {

--- a/storage/src/global_state/trie_store/cache/mod.rs
+++ b/storage/src/global_state/trie_store/cache/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use casper_types::{
     bytesrepr::{self, Bytes, FromBytes, ToBytes},
     Digest, Pointer,
@@ -267,8 +269,8 @@ where
         match node {
             TrieCacheNode::Leaf { key, value } => {
                 let trie_leaf = Trie::leaf(key, value);
-                let hash = trie_leaf.trie_hash()?;
-                store.put(txn, &hash, &trie_leaf)?;
+                let (hash, trie_bytes) = trie_leaf.trie_hash_and_bytes()?;
+                store.put_raw(txn, &hash, Cow::from(trie_bytes))?;
                 Ok(Pointer::LeafPointer(hash))
             }
             TrieCacheNode::Branch { mut pointer_block } => {
@@ -287,8 +289,8 @@ where
                 let trie_node = Trie::<K, V>::Node {
                     pointer_block: Box::new(trie_pointer_block),
                 };
-                let hash = trie_node.trie_hash()?;
-                store.put(txn, &hash, &trie_node)?;
+                let (hash, trie_bytes) = trie_node.trie_hash_and_bytes()?;
+                store.put_raw(txn, &hash, Cow::from(trie_bytes))?;
                 Ok(Pointer::NodePointer(hash))
             }
             TrieCacheNode::Extension { pointer, affix } => {
@@ -300,8 +302,8 @@ where
                 }?;
 
                 let trie_extension = Trie::<K, V>::extension(affix.to_vec(), pointer);
-                let hash = trie_extension.trie_hash()?;
-                store.put(txn, &hash, &trie_extension)?;
+                let (hash, trie_bytes) = trie_extension.trie_hash_and_bytes()?;
+                store.put_raw(txn, &hash, Cow::from(trie_bytes))?;
                 Ok(Pointer::NodePointer(hash))
             }
         }

--- a/storage/src/global_state/trie_store/cache/mod.rs
+++ b/storage/src/global_state/trie_store/cache/mod.rs
@@ -1,0 +1,388 @@
+use casper_types::{
+    bytesrepr::{self, Bytes, FromBytes, ToBytes},
+    Digest, Pointer,
+};
+
+use crate::global_state::{
+    transaction_source::{Readable, Writable},
+    trie::{PointerBlock, Trie, RADIX},
+};
+
+use super::{operations::common_prefix, TrieStore};
+
+#[derive(Clone, Debug, thiserror::Error, Eq, PartialEq)]
+pub enum CacheError {
+    /// Root not found.
+    #[error("Root not found: {0:?}")]
+    RootNotFound(Digest),
+}
+
+// Pointer used by the cache to determine if the node is stored or is loaded in memory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CachePointer<K, V> {
+    InMem(TrieCacheNode<K, V>),
+    Stored(Pointer),
+}
+
+impl<K, V> CachePointer<K, V> {
+    /// Loads the node in memory from the specified store if it's not already loaded.
+    /// Returns an error if the node can't be found in the store.
+    fn load_from_store<T, S, E>(&mut self, txn: &T, store: &S) -> Result<(), E>
+    where
+        K: FromBytes,
+        V: FromBytes,
+        T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
+        S: TrieStore<K, V>,
+        S::Error: From<T::Error>,
+        E: From<S::Error> + From<bytesrepr::Error> + From<CacheError>,
+    {
+        if let CachePointer::Stored(pointer) = self {
+            let Some(stored_node) = store.get(txn, pointer.hash())? else {
+                return Err(CacheError::RootNotFound(pointer.into_hash()).into());
+            };
+            let trie_cache_node = stored_node.into();
+            *self = CachePointer::InMem(trie_cache_node);
+        }
+        Ok(())
+    }
+}
+
+/// A node representation used by the cache. This follows the Trie implementation for easy
+/// conversion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TrieCacheNode<K, V> {
+    Leaf {
+        key: K,
+        value: V,
+    },
+    Branch {
+        pointer_block: Vec<Option<CachePointer<K, V>>>,
+    },
+    Extension {
+        affix: Bytes,
+        pointer: Box<CachePointer<K, V>>,
+    },
+}
+
+impl<K, V> From<Trie<K, V>> for TrieCacheNode<K, V> {
+    fn from(node: Trie<K, V>) -> Self {
+        match node {
+            Trie::Leaf { key, value } => Self::Leaf { key, value },
+            Trie::Node { pointer_block } => {
+                let mut new_pointer_block = Vec::with_capacity(RADIX);
+                for i in 0..RADIX {
+                    new_pointer_block.push(pointer_block[i].map(|ptr| CachePointer::Stored(ptr)));
+                }
+                Self::Branch {
+                    pointer_block: new_pointer_block,
+                }
+            }
+            Trie::Extension { affix, pointer } => Self::Extension {
+                affix,
+                pointer: Box::new(CachePointer::Stored(pointer)),
+            },
+        }
+    }
+}
+
+// An in-memory cache for Trie nodes that is backed up by a store.
+pub struct TrieCache<'a, K, V, S> {
+    root: TrieCacheNode<K, V>,
+    store: &'a S,
+}
+
+impl<'a, K, V, S> TrieCache<'a, K, V, S>
+where
+    K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+    V: ToBytes + FromBytes + Clone + Eq,
+    S: TrieStore<K, V> + 'a,
+{
+    pub fn new_from_store<T, E>(txn: &mut T, store: &'a S, root: &Digest) -> Result<Self, E>
+    where
+        T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
+        S::Error: From<T::Error>,
+        E: From<S::Error> + From<bytesrepr::Error> + From<CacheError>,
+    {
+        match store.get(txn, root)? {
+            Some(node) => Ok(Self {
+                root: node.into(),
+                store,
+            }),
+            None => Err(CacheError::RootNotFound(*root).into()),
+        }
+    }
+
+    pub fn insert_with_store<T, E>(
+        &mut self,
+        new_key: K,
+        new_value: V,
+        txn: &mut T,
+    ) -> Result<(), E>
+    where
+        T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
+        S::Error: From<T::Error>,
+        E: From<S::Error> + From<bytesrepr::Error> + From<CacheError>,
+    {
+        let path: Vec<u8> = new_key.to_bytes()?;
+
+        let mut depth: usize = 0;
+        let mut current = &mut self.root;
+
+        while depth < path.len() {
+            match current {
+                TrieCacheNode::Branch { pointer_block } => {
+                    let index: usize = {
+                        assert!(depth < path.len(), "depth must be < {}", path.len());
+                        path[depth].into()
+                    };
+
+                    let pointer = &mut pointer_block[index];
+                    if let Some(next) = pointer {
+                        if depth == path.len() - 1 {
+                            let leaf = TrieCacheNode::Leaf {
+                                key: new_key,
+                                value: new_value,
+                            };
+                            *next = CachePointer::InMem(leaf);
+                            return Ok(());
+                        } else {
+                            depth += 1;
+
+                            next.load_from_store::<_, _, E>(txn, self.store)?;
+                            if let CachePointer::InMem(next) = next {
+                                current = next;
+                            } else {
+                                unreachable!("Stored pointer should have been converted");
+                            }
+                        }
+                    } else {
+                        let leaf = TrieCacheNode::Leaf {
+                            key: new_key,
+                            value: new_value,
+                        };
+                        let _ = std::mem::replace(pointer, Some(CachePointer::InMem(leaf)));
+                        return Ok(());
+                    }
+                }
+                TrieCacheNode::Leaf {
+                    key: old_key,
+                    value: old_value,
+                } => {
+                    if *old_key == new_key {
+                        *old_value = new_value;
+                    } else {
+                        let mut pointer_block = Vec::with_capacity(RADIX);
+                        pointer_block.resize_with(RADIX, || None::<CachePointer<K, V>>);
+                        let old_key_bytes = old_key.to_bytes()?;
+
+                        let shared_path = common_prefix(&old_key_bytes, &path);
+
+                        let existing_idx = old_key_bytes[shared_path.len()] as usize;
+                        pointer_block[existing_idx] =
+                            Some(CachePointer::InMem(TrieCacheNode::Leaf {
+                                key: old_key.clone(),
+                                value: old_value.clone(),
+                            }));
+
+                        let new_idx = path[shared_path.len()] as usize;
+                        pointer_block[new_idx] = Some(CachePointer::InMem(TrieCacheNode::Leaf {
+                            key: new_key,
+                            value: new_value,
+                        }));
+
+                        let new_affix = { &shared_path[depth..] };
+                        *current = if !new_affix.is_empty() {
+                            TrieCacheNode::Extension {
+                                affix: Bytes::from(new_affix),
+                                pointer: Box::new(CachePointer::InMem(TrieCacheNode::Branch {
+                                    pointer_block,
+                                })),
+                            }
+                        } else {
+                            TrieCacheNode::Branch { pointer_block }
+                        };
+                    }
+                    return Ok(());
+                }
+                TrieCacheNode::Extension { affix, ref pointer }
+                    if path.len() < depth + affix.len()
+                        || affix.as_ref() != &path[depth..depth + affix.len()] =>
+                {
+                    // We might be trying to store a key that is shorter than the keys that are
+                    // already stored. In this case, we would need to split this extension.
+                    // We also need to split this extension if the affix changes.
+
+                    // Is there something common between the new key and the old key?
+                    let shared_prefix = common_prefix(affix, &path[depth..]);
+
+                    // Need to split the node at the byte that is different.
+                    let mut pointer_block = Vec::with_capacity(RADIX);
+                    pointer_block.resize_with(RADIX, || None::<CachePointer<K, V>>);
+
+                    // Add the new key under a leaf where the paths diverge.
+                    pointer_block[path[depth + shared_prefix.len()] as usize] =
+                        Some(CachePointer::InMem(TrieCacheNode::Leaf {
+                            key: new_key,
+                            value: new_value,
+                        }));
+
+                    let post_branch_affix = &affix[shared_prefix.len() + 1..];
+                    if !post_branch_affix.is_empty() {
+                        let post_extension = TrieCacheNode::Extension {
+                            affix: Bytes::from(post_branch_affix),
+                            pointer: pointer.clone(),
+                        };
+                        let existing_idx = affix[shared_prefix.len()] as usize;
+                        pointer_block[existing_idx] = Some(CachePointer::InMem(post_extension));
+                    } else {
+                        let existing_idx = affix[shared_prefix.len()] as usize;
+                        pointer_block[existing_idx] = Some(*pointer.clone());
+                    }
+
+                    let new_branch = TrieCacheNode::Branch { pointer_block };
+                    let next = if !shared_prefix.is_empty() {
+                        // Create an extension node with the common part
+                        TrieCacheNode::Extension {
+                            affix: Bytes::from(shared_prefix),
+                            pointer: Box::new(CachePointer::InMem(new_branch)),
+                        }
+                    } else {
+                        new_branch
+                    };
+
+                    *current = next;
+                    return Ok(());
+                }
+                TrieCacheNode::Extension {
+                    affix,
+                    ref mut pointer,
+                } => {
+                    depth += affix.len();
+                    pointer.load_from_store::<_, _, E>(txn, self.store)?;
+                    if let CachePointer::InMem(next) = pointer.as_mut() {
+                        current = next;
+                    } else {
+                        unreachable!("Stored pointer should have been converted");
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn traverse_and_store<T, E>(
+        node: TrieCacheNode<K, V>,
+        txn: &mut T,
+        store: &S,
+    ) -> Result<Pointer, E>
+    where
+        T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
+        S::Error: From<T::Error>,
+        E: From<S::Error> + From<bytesrepr::Error> + From<CacheError>,
+    {
+        match node {
+            TrieCacheNode::Leaf { key, value } => {
+                let trie_leaf = Trie::leaf(key, value);
+                let hash = trie_leaf.trie_hash()?;
+                store.put(txn, &hash, &trie_leaf)?;
+                Ok(Pointer::LeafPointer(hash))
+            }
+            TrieCacheNode::Branch { mut pointer_block } => {
+                let mut trie_pointer_block = PointerBlock::new();
+                for i in 0..RADIX {
+                    trie_pointer_block[i] = Option::take(&mut pointer_block[i])
+                        .map(|child| match child {
+                            CachePointer::InMem(in_mem_child) => {
+                                Self::traverse_and_store::<_, E>(in_mem_child, txn, store)
+                            }
+                            CachePointer::Stored(ptr) => Ok(ptr),
+                        })
+                        .transpose()?;
+                }
+
+                let trie_node = Trie::<K, V>::Node {
+                    pointer_block: Box::new(trie_pointer_block),
+                };
+                let hash = trie_node.trie_hash()?;
+                store.put(txn, &hash, &trie_node)?;
+                Ok(Pointer::NodePointer(hash))
+            }
+            TrieCacheNode::Extension { pointer, affix } => {
+                let pointer = match *pointer {
+                    CachePointer::InMem(in_mem_ptr) => {
+                        Self::traverse_and_store::<_, E>(in_mem_ptr, txn, store)
+                    }
+                    CachePointer::Stored(ptr) => Ok(ptr),
+                }?;
+
+                let trie_extension = Trie::<K, V>::extension(affix.to_vec(), pointer);
+                let hash = trie_extension.trie_hash()?;
+                store.put(txn, &hash, &trie_extension)?;
+                Ok(Pointer::NodePointer(hash))
+            }
+        }
+    }
+
+    pub fn store_cache<T, E>(self, txn: &mut T) -> Result<Digest, E>
+    where
+        T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
+        S::Error: From<T::Error>,
+        E: From<S::Error> + From<bytesrepr::Error> + From<CacheError>,
+    {
+        Self::traverse_and_store::<_, E>(self.root, txn, self.store)
+            .map(|root_pointer| root_pointer.into_hash())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl<'a, K, V, S> TrieCache<'a, K, V, S>
+    where
+        K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        V: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+        S: TrieStore<K, V>,
+    {
+        fn traverse(node: TrieCacheNode<K, V>) -> Pointer {
+            match node {
+                TrieCacheNode::Leaf { key, value } => {
+                    // Process the leaf node
+                    let trie_leaf = Trie::leaf(key, value);
+                    let hash = trie_leaf.trie_hash().unwrap();
+                    Pointer::LeafPointer(hash)
+                }
+                TrieCacheNode::Branch { mut pointer_block } => {
+                    let mut trie_pointer_block = PointerBlock::new();
+                    for i in 0..RADIX {
+                        trie_pointer_block[i] = Option::take(pointer_block.get_mut(i).unwrap())
+                            .map(|child| match child {
+                                CachePointer::InMem(in_mem_child) => Self::traverse(in_mem_child),
+                                CachePointer::Stored(ptr) => ptr,
+                            });
+                    }
+
+                    let trie_node = Trie::<K, V>::Node {
+                        pointer_block: Box::new(trie_pointer_block),
+                    };
+                    let hash = trie_node.trie_hash().unwrap();
+                    Pointer::NodePointer(hash)
+                }
+                TrieCacheNode::Extension { pointer, affix } => {
+                    let pointer = match *pointer {
+                        CachePointer::InMem(in_mem_ptr) => Self::traverse(in_mem_ptr),
+                        CachePointer::Stored(ptr) => ptr,
+                    };
+
+                    let trie_extension = Trie::<K, V>::extension(affix.to_vec(), pointer);
+                    let hash = trie_extension.trie_hash().unwrap();
+                    Pointer::NodePointer(hash)
+                }
+            }
+        }
+
+        pub fn calculate_root_hash(self) -> Digest {
+            Self::traverse(self.root).into_hash()
+        }
+    }
+}

--- a/storage/src/global_state/trie_store/mod.rs
+++ b/storage/src/global_state/trie_store/mod.rs
@@ -3,6 +3,12 @@
 //! See the [lmdb](lmdb/index.html#usage) modules for usage examples.
 pub mod lmdb;
 pub mod operations;
+
+// An in-mem cache backed up by a store that is used to optimize batch writes.
+mod cache;
+
+pub(crate) use cache::CacheError as TrieStoreCacheError;
+
 #[cfg(test)]
 mod tests;
 

--- a/storage/src/global_state/trie_store/operations/mod.rs
+++ b/storage/src/global_state/trie_store/operations/mod.rs
@@ -967,10 +967,10 @@ where
     S::Error: From<T::Error>,
     E: From<S::Error> + From<bytesrepr::Error> + From<TrieStoreCacheError>,
 {
-    let mut cache = TrieCache::<K, V, _>::new_from_store::<_, E>(txn, store, root)?;
+    let mut cache = TrieCache::<K, V, _>::new::<_, E>(txn, store, root)?;
 
     for (key, value) in values {
-        cache.insert_with_store::<_, E>(key, value, txn)?;
+        cache.insert::<_, E>(key, value, txn)?;
     }
     cache.store_cache::<_, E>(txn)
 }

--- a/storage/src/global_state/trie_store/operations/tests/write.rs
+++ b/storage/src/global_state/trie_store/operations/tests/write.rs
@@ -553,3 +553,151 @@ mod variable_sized_keys {
         .expect("Expected new root hash after write");
     }
 }
+
+mod batch_write_with_random_keys {
+    use crate::global_state::trie_store::cache::TrieCache;
+
+    use super::*;
+
+    use casper_types::{testing::TestRng, Key};
+    use rand::Rng;
+
+    #[test]
+    fn compare_random_keys_seq_write_with_batch_cache_write() {
+        let mut rng = TestRng::new();
+
+        for _ in 0..100 {
+            let (mut seq_write_root_hash, tries) = create_empty_trie::<Key, u32>().unwrap();
+            let context = LmdbTestContext::new(&tries).unwrap();
+            let mut txn = context.environment.create_read_write_txn().unwrap();
+
+            // Create some random keys and values.
+            let data: Vec<(Key, u32)> = (0u32..4000).map(|val| (rng.gen(), val)).collect();
+
+            // Write all the keys sequentially to the store
+            for (key, value) in data.iter() {
+                let write_result = write::<Key, u32, _, _, error::Error>(
+                    &mut txn,
+                    &context.store,
+                    &seq_write_root_hash,
+                    key,
+                    value,
+                )
+                .unwrap();
+                match write_result {
+                    WriteResult::Written(hash) => {
+                        seq_write_root_hash = hash; // Update the state root hash; we'll use it to
+                                                    // compare with the cache root hash.
+                    }
+                    WriteResult::AlreadyExists => (),
+                    WriteResult::RootNotFound => panic!("write_leaves given an invalid root"),
+                };
+            }
+
+            // Create an empty store that backs up the cache.
+            let (cache_root_hash, tries) = create_empty_trie::<Key, u32>().unwrap();
+            let context = LmdbTestContext::new(&tries).unwrap();
+            let mut txn = context.environment.create_read_write_txn().unwrap();
+
+            let mut trie_cache = TrieCache::<Key, u32, _>::new_from_store::<_, error::Error>(
+                &mut txn,
+                &context.store,
+                &cache_root_hash,
+            )
+            .unwrap();
+            for (key, value) in data.iter() {
+                trie_cache
+                    .insert_with_store::<_, error::Error>(*key, *value, &mut txn)
+                    .unwrap();
+            }
+
+            let cache_root_hash = trie_cache.store_cache::<_, error::Error>(&mut txn).unwrap();
+
+            if seq_write_root_hash != cache_root_hash {
+                println!("Root Hash is: {:?}", seq_write_root_hash);
+                println!("Cache root Hash is: {:?}", cache_root_hash);
+                println!("Faulty keys: ");
+
+                for (key, _) in data.iter() {
+                    println!("{}", key.to_formatted_string());
+                }
+                panic!("ROOT hash mismatch");
+            }
+        }
+    }
+
+    #[test]
+    fn compare_random_keys_write_with_cache_and_readback() {
+        let mut rng = TestRng::new();
+
+        // create a store
+        let (mut root_hash, tries) = create_empty_trie::<Key, u32>().unwrap();
+        let context = LmdbTestContext::new(&tries).unwrap();
+        let mut txn = context.environment.create_read_write_txn().unwrap();
+
+        // Create initial keys and values.
+        let initial_keys: Vec<(Key, u32)> = (0u32..1000).map(|val| (rng.gen(), val)).collect();
+
+        // Store these keys and values using sequential write;
+        for (key, value) in initial_keys.iter() {
+            let write_result = write::<Key, u32, _, _, error::Error>(
+                &mut txn,
+                &context.store,
+                &root_hash,
+                key,
+                value,
+            )
+            .unwrap();
+            match write_result {
+                WriteResult::Written(hash) => {
+                    root_hash = hash;
+                }
+                WriteResult::AlreadyExists => (),
+                WriteResult::RootNotFound => panic!("write_leaves given an invalid root"),
+            };
+        }
+
+        // Create some test data.
+        let data: Vec<(Key, u32)> = (0u32..1000).map(|val| (rng.gen(), val)).collect();
+
+        // Create a cache backed up by the store that has the initial data.
+        let mut trie_cache = TrieCache::<Key, u32, _>::new_from_store::<_, error::Error>(
+            &mut txn,
+            &context.store,
+            &root_hash,
+        )
+        .unwrap();
+
+        // Insert the test data into the cache.
+        for (key, value) in data.iter() {
+            trie_cache
+                .insert_with_store::<_, error::Error>(*key, *value, &mut txn)
+                .unwrap();
+        }
+
+        // Get the generated root hash
+        let cache_root_hash = trie_cache.calculate_root_hash();
+
+        // now write the same keys to the store one by one and check if we get the same root hash.
+        let mut seq_write_root_hash = root_hash;
+        for (key, value) in data.iter() {
+            let write_result = write::<Key, u32, _, _, error::Error>(
+                &mut txn,
+                &context.store,
+                &seq_write_root_hash,
+                key,
+                value,
+            )
+            .unwrap();
+            match write_result {
+                WriteResult::Written(hash) => {
+                    seq_write_root_hash = hash;
+                }
+                WriteResult::AlreadyExists => (),
+                WriteResult::RootNotFound => panic!("write_leaves given an invalid root"),
+            };
+        }
+
+        assert_eq!(cache_root_hash, seq_write_root_hash);
+    }
+}

--- a/storage/src/global_state/trie_store/operations/tests/write.rs
+++ b/storage/src/global_state/trie_store/operations/tests/write.rs
@@ -599,15 +599,15 @@ mod batch_write_with_random_keys {
             let context = LmdbTestContext::new(&tries).unwrap();
             let mut txn = context.environment.create_read_write_txn().unwrap();
 
-            let mut trie_cache = TrieCache::<Key, u32, _>::new_from_store::<_, error::Error>(
-                &mut txn,
+            let mut trie_cache = TrieCache::<Key, u32, _>::new::<_, error::Error>(
+                &txn,
                 &context.store,
                 &cache_root_hash,
             )
             .unwrap();
             for (key, value) in data.iter() {
                 trie_cache
-                    .insert_with_store::<_, error::Error>(*key, *value, &mut txn)
+                    .insert::<_, error::Error>(*key, *value, &txn)
                     .unwrap();
             }
 
@@ -661,17 +661,14 @@ mod batch_write_with_random_keys {
         let data: Vec<(Key, u32)> = (0u32..1000).map(|val| (rng.gen(), val)).collect();
 
         // Create a cache backed up by the store that has the initial data.
-        let mut trie_cache = TrieCache::<Key, u32, _>::new_from_store::<_, error::Error>(
-            &mut txn,
-            &context.store,
-            &root_hash,
-        )
-        .unwrap();
+        let mut trie_cache =
+            TrieCache::<Key, u32, _>::new::<_, error::Error>(&txn, &context.store, &root_hash)
+                .unwrap();
 
         // Insert the test data into the cache.
         for (key, value) in data.iter() {
             trie_cache
-                .insert_with_store::<_, error::Error>(*key, *value, &mut txn)
+                .insert::<_, error::Error>(*key, *value, &txn)
                 .unwrap();
         }
 

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -250,6 +250,10 @@ impl<M: Meter<Key, StoredValue>> TrackingCopyCache<M> {
     pub fn is_pruned(&self, key: &Key) -> bool {
         self.prunes_cached.contains(key)
     }
+
+    pub(self) fn into_muts(self) -> (BTreeMap<KeyWithByteRepr, StoredValue>, BTreeSet<Key>) {
+        (self.muts_cached, self.prunes_cached)
+    }
 }
 
 /// A helper type for `TrackingCopyCache` that allows convenient storage and access
@@ -384,6 +388,13 @@ where
     /// Returns a copy of the execution effects cached by this instance.
     pub fn effects(&self) -> Effects {
         self.effects.clone()
+    }
+
+    pub fn destructure(self) -> (Vec<(Key, StoredValue)>, BTreeSet<Key>, Effects) {
+        let (writes, prunes) = self.cache.into_muts();
+        let writes: Vec<(Key, StoredValue)> = writes.into_iter().map(|(k, v)| (k.0, v)).collect();
+
+        (writes, prunes, self.effects)
     }
 
     pub fn get(&mut self, key: &Key) -> Result<Option<StoredValue>, TrackingCopyError> {


### PR DESCRIPTION
When inserting a batch of values to the trie store we don't really care about interstitial state root hashes. Writing (key, value) pairs to the trie store sequentially will cause the trie to re-hash after every insert. This leads to poor insert performace and also increased storage space to hold trie nodes that will potentially never be accessed.
    
In this PR we create an in-memory cache of the trie backed by the store. Existing nodes are read back from the trie store when needed.
After the entire batch is written in memory, we traverse the trie once to convert the in-mem nodes, hash and store them to disk, resulting in a single state root hash for the entire batch write operation.
    
The cache insert algorithm matches the sequential write algorithm such that writing (key, value) pairs sequentially produces the exact same end state trie (and of course the exact same state root hash) as inserting pairs using a batch write operation.

This PR also adds a benchmark to compare the performance between sequential writes of random (key, value) pairs vs batch write of the same data.
The results running the benchmark on an Apple M1 processor can be found in the table below:

| Batch Size (elements) | 1000 | 10000 | Speedup for 1000 | Speedup for 10000 | 
| --- | --- | --- | --- | --- |
| trie_store_sequential_write | 88.331 | 52.645 | | |
| batch_write_with_empty_store | 1352.7 | 391.86 | 14.31 | 6.44 |
| batch_write_with_populated_store | 928.90 | 376.64 | 9.51 | 6.15 |

This shows a significant improvement of the batch write implementation vs the sequential implementation. The thing to note is that the speedup is less for larger batches. This is because we still need to write the final list of nodes to the database. As batches grow, this operation consumes a larger chunk of the total time vs the re-hashing operation which this implementation aims to optimise out.

The trade-off with this implementation is that it consumes extra memory for the cache. The memory consumption is unmanaged by the implementation so care needs to be used when calling this operation in order not to push the node in an OOM situation.

Further work:
- [x] ~~don't deserialize values when reading from storage; the cache doesn't care about the values so there's no need to deserialize them; we can employ the use of `LazilyDeserializedTrie` instead of `Trie`~~
  - Using `LazilyDeserializedTrie` would not bring considerable improvements since we only load leaves from disk when we need to change them. In order to determine how we change the leaf we need to compare its key so we would have needed to deserialise it anyway. It's true that we don't need to deserialise the value though if the keys match we would have needed to serialise the new key to overwrite the old value so we wouldn't gain too much.
  - Instead we optimise the code by avoiding serialising the Trie nodes twice when we eventually store the values to disk; this small change brings another ~10% improvement over the previous version (updated the table to reflect new values)
- [ ] refactor the code to avoid cloning some of the cache pointers
- [x] use this batch write operation in migration logic; this PR only adds the operation but does not use it anywhere in the node. We need to review the opportunities to use batch write and use this new operation.