### PR TITLE
Bump transaction limits in the `ttl` test for block validator

### DIFF
--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -95,7 +95,7 @@ pub use vm_config::{
 
 /// A collection of configuration settings describing the state of the system at genesis and after
 /// upgrades to basic system functionality occurring after genesis.
-#[derive(PartialEq, Eq, Serialize, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Serialize, Debug, Default)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[serde(deny_unknown_fields)]
 pub struct Chainspec {

--- a/types/src/chainspec/transaction_config/transaction_v1_config.rs
+++ b/types/src/chainspec/transaction_config/transaction_v1_config.rs
@@ -201,12 +201,12 @@ impl TransactionV1Config {
     #[cfg(any(feature = "testing", test))]
     pub fn with_count_limits(
         mut self,
-        mint_count: Option<u64>,
+        mint: Option<u64>,
         auction: Option<u64>,
         install: Option<u64>,
-        large_limit: Option<u64>,
+        large: Option<u64>,
     ) -> Self {
-        if let Some(mint_count) = mint_count {
+        if let Some(mint_count) = mint {
             self.native_mint_lane[MAX_TRANSACTION_COUNT] = mint_count;
         }
         if let Some(auction_count) = auction {
@@ -224,7 +224,7 @@ impl TransactionV1Config {
             updated_lane[MAX_TRANSACTION_COUNT] = install_upgrade_count;
             self.wasm_lanes.push(updated_lane);
         }
-        if let Some(large_limit) = large_limit {
+        if let Some(large_limit) = large {
             let (index, lane) = self
                 .wasm_lanes
                 .iter()


### PR DESCRIPTION
This PR fixes the flakiness in `ttl()` test in block validator by bumping the chainspec limits for transactions.