### PR TITLE
Revert casper ffi change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2024-0344
+	$(CARGO) audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0367
 
 .PHONY: audit-as
 audit-as:

--- a/execution_engine/src/resolvers/v1_function_index.rs
+++ b/execution_engine/src/resolvers/v1_function_index.rs
@@ -36,7 +36,7 @@ pub(crate) enum FunctionIndex {
     GetMainPurseIndex,
     ReadHostBufferIndex,
     CreateContractPackageAtHash,
-    AddPackageVersion,
+    AddContractVersion,
     DisableContractVersion,
     CallVersionedContract,
     CreateContractUserGroup,

--- a/execution_engine/src/resolvers/v1_resolver.rs
+++ b/execution_engine/src/resolvers/v1_resolver.rs
@@ -160,9 +160,9 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 8][..], Some(ValueType::I32)),
                 FunctionIndex::CreateContractUserGroup.into(),
             ),
-            "casper_add_package_version" => FuncInstance::alloc_host(
+            "casper_add_contract_version" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 11][..], Some(ValueType::I32)),
-                FunctionIndex::AddPackageVersion.into(),
+                FunctionIndex::AddContractVersion.into(),
             ),
             "casper_disable_contract_version" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),

--- a/execution_engine/src/runtime/externals.rs
+++ b/execution_engine/src/runtime/externals.rs
@@ -605,7 +605,7 @@ where
                 )?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
-            FunctionIndex::AddPackageVersion => {
+            FunctionIndex::AddContractVersion => {
                 // args(0)  = pointer to package hash in wasm memory
                 // args(1)  = size of package hash in wasm memory
                 // args(2)  = pointer to entity version in wasm memory

--- a/smart_contracts/contract/src/contract_api/storage.rs
+++ b/smart_contracts/contract/src/contract_api/storage.rs
@@ -336,7 +336,7 @@ pub fn add_contract_version(
     let mut entity_version: EntityVersion = 0;
 
     let ret = unsafe {
-        ext_ffi::casper_add_package_version(
+        ext_ffi::casper_add_contract_version(
             package_hash_ptr,
             package_hash_size,
             &mut entity_version as *mut EntityVersion, // Fixed width

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -480,7 +480,7 @@ extern "C" {
     /// * `message_topics_size` - size of serialized BTreeMap<String, MessageTopicOperation>
     /// * `output_ptr` - pointer to a memory where host assigned contract hash is set to
     /// * `output_size` - expected width of output (currently 32)
-    pub fn casper_add_package_version(
+    pub fn casper_add_contract_version(
         package_hash_ptr: *const u8,
         package_hash_size: usize,
         version_ptr: *const u32,


### PR DESCRIPTION
CHANGELOG:

- Reverts a name change in the external FFI allowing stored byte code to be callable