### PR TITLE
Fix `node_should_rejoin_after_ejection` being flaky

### DIFF
--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -1901,7 +1901,7 @@ async fn node_should_rejoin_after_ejection() {
         fixture.chainspec.network_config.name.clone(),
         fixture.system_contract_hash(AUCTION),
         stopped_public_key.clone(),
-        1_000_000_000_000_000_000_u64.into(),
+        100_000_000_000_000_000_u64.into(),
         10,
         Timestamp::now(),
         TimeDiff::from_seconds(60),


### PR DESCRIPTION
This PR changes the bid amount in the `node_should_rejoin_after_ejection` test to be equal to the minimum account balance, set [here](https://github.com/casper-network/casper-node/blob/e6456b709ec1da1c6b703db2a04beeba960651c5/node/src/reactor/main_reactor/tests.rs#L301).

Since the fixture is initialized with random balances for nodes, and the minimum possible balance was less than the bid amount, sometimes the call to `add_bid` would fail with the `InsufficientFunds` error, causing the test to be flaky. This change should fix the issue.

Closes #4859 
