### PR TITLE
Do not notify consensus about historical blocks

### DIFF
--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1553,21 +1553,9 @@ impl MainReactor {
                         ),
                     ));
                 }
-                MetaBlock::Historical(historical_meta_block) => {
-                    // Header type is the same for now so we can use the same `BlockAdded` event;
-                    // When the header will be versioned, a new event will be needed for the
-                    // consensus component.
-                    effects.extend(reactor::wrap_effects(
-                        MainEvent::Consensus,
-                        self.consensus.handle_event(
-                            effect_builder,
-                            rng,
-                            consensus::Event::BlockAdded {
-                                header: Box::new(historical_meta_block.block.clone_header()),
-                                header_hash: *historical_meta_block.block.hash(),
-                            },
-                        ),
-                    ));
+                MetaBlock::Historical(_historical_meta_block) => {
+                    // Historical meta blocks aren't of interest to consensus - consensus only
+                    // cares about new blocks. Hence, we can just do nothing here.
                 }
             }
         }


### PR DESCRIPTION
What it says on the tin. This should also stop consensus from emitting the log message about missing eras.

Closes #4378 
