### PR TITLE
Add a WAL to Highway

### DIFF
--- a/node/src/components/consensus/highway_core/active_validator.rs
+++ b/node/src/components/consensus/highway_core/active_validator.rs
@@ -1,9 +1,6 @@
 use std::{
     fmt::{self, Debug},
-    fs::{self, File},
-    io::{self, Read, Write},
     iter,
-    path::{Path, PathBuf},
 };
 
 use datasize::DataSize;
@@ -73,10 +70,6 @@ where
     next_timer: Timestamp,
     /// Panorama and context for a block we are about to propose when we get a consensus value.
     next_proposal: Option<(BlockContext<C>, Panorama<C>)>,
-    /// The path to the file storing the hash of our latest known unit (if any).
-    unit_file: Option<PathBuf>,
-    /// The last known unit created by us.
-    own_last_unit: Option<SignedWireUnit<C>>,
     /// The target fault tolerance threshold. The validator pauses (i.e. doesn't create new units)
     /// if not enough validators are online to finalize values at this FTT.
     target_ftt: Weight,
@@ -104,62 +97,21 @@ impl<C: Context> ActiveValidator<C> {
         current_time: Timestamp,
         start_time: Timestamp,
         state: &State<C>,
-        unit_file: Option<PathBuf>,
         target_ftt: Weight,
         instance_id: C::InstanceId,
     ) -> (Self, Vec<Effect<C>>) {
-        let own_last_unit = unit_file
-            .as_ref()
-            .map(read_last_unit)
-            .transpose()
-            .map_err(|err| match err.kind() {
-                io::ErrorKind::NotFound => (),
-                _ => panic!("got an error reading unit file {:?}: {:?}", unit_file, err),
-            })
-            .ok()
-            .flatten();
         let mut av = ActiveValidator {
             vidx,
             secret,
             next_round_len: state.params().init_round_len(),
             next_timer: state.params().start_timestamp(),
             next_proposal: None,
-            unit_file,
-            own_last_unit,
             target_ftt,
             paused: false,
         };
         let mut effects = av.schedule_timer(start_time, state);
         effects.push(av.send_ping(current_time, instance_id));
         (av, effects)
-    }
-
-    /// Returns whether validator's protocol state is fully synchronized and it's safe to start
-    /// creating units.
-    ///
-    /// If validator restarted within an era, it most likely had created units before that event. It
-    /// cannot start creating new units until its state is fully synchronized, otherwise it will
-    /// most likely equivocate.
-    fn can_vote(&self, state: &State<C>) -> bool {
-        self.own_last_unit
-            .as_ref()
-            .map_or(true, |swunit| state.has_unit(&swunit.hash()))
-    }
-
-    /// Returns whether validator's protocol state is synchronized up until the panorama of its own
-    /// last unit.
-    pub(crate) fn is_own_last_unit_panorama_sync(&self, state: &State<C>) -> bool {
-        self.own_last_unit.as_ref().map_or(true, |swunit| {
-            swunit
-                .wire_unit()
-                .panorama
-                .iter_correct_hashes()
-                .all(|hash| state.has_unit(hash))
-        })
-    }
-
-    pub(crate) fn take_own_last_unit(&mut self) -> Option<SignedWireUnit<C>> {
-        self.own_last_unit.take()
     }
 
     /// Sets the next round length to the new value.
@@ -430,10 +382,6 @@ impl<C: Context> ActiveValidator<C> {
         if value.is_none() && !panorama.has_correct() {
             return None; // Wait for the first proposal before creating a unit without a value.
         }
-        if !self.can_vote(state) {
-            info!(?self.own_last_unit, "not voting - last own unit unknown");
-            return None;
-        }
         if let Some((prop_context, _)) = self.next_proposal.take() {
             warn!(?prop_context, "canceling proposal due to unit");
         }
@@ -470,12 +418,6 @@ impl<C: Context> ActiveValidator<C> {
         }
         .into_hashed();
         let swunit = SignedWireUnit::new(hwunit, &self.secret);
-        write_last_unit(&self.unit_file, swunit.clone()).unwrap_or_else(|err| {
-            panic!(
-                "should successfully write unit's hash to {:?}, got {:?}",
-                self.unit_file, err
-            )
-        });
         Some(swunit)
     }
 
@@ -607,9 +549,6 @@ impl<C: Context> ActiveValidator<C> {
     /// Returns whether the incoming vertex was signed by our key even though we don't have it yet.
     /// This can only happen if another node is running with the same signing key.
     pub(crate) fn is_doppelganger_vertex(&self, vertex: &Vertex<C>, state: &State<C>) -> bool {
-        if !self.can_vote(state) {
-            return false;
-        }
         match vertex {
             Vertex::Unit(swunit) => {
                 // If we already have the unit in our local state,
@@ -641,45 +580,10 @@ impl<C: Context> ActiveValidator<C> {
     }
 }
 
-pub(crate) fn read_last_unit<C, P>(path: P) -> io::Result<SignedWireUnit<C>>
-where
-    C: Context,
-    P: AsRef<Path>,
-{
-    let mut file = File::open(path)?;
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)?;
-    Ok(serde_json::from_slice(&bytes)?)
-}
-
-pub(crate) fn write_last_unit<C: Context>(
-    unit_file: &Option<PathBuf>,
-    swunit: SignedWireUnit<C>,
-) -> io::Result<()> {
-    // If there is no unit_file set, do not write to it
-    let unit_file = if let Some(file) = unit_file.as_ref() {
-        file
-    } else {
-        return Ok(());
-    };
-
-    // Create the file (and its parents) as necessary
-    if let Some(parent_directory) = unit_file.parent() {
-        fs::create_dir_all(parent_directory)?;
-    }
-    let mut file = File::create(unit_file)?;
-
-    // Finally, write the data to file we created
-    let bytes = serde_json::to_vec(&swunit)?;
-
-    file.write_all(&bytes)
-}
-
 #[cfg(test)]
 #[allow(clippy::arithmetic_side_effects)] // Overflows in tests panic anyway.
 mod tests {
     use std::{collections::BTreeSet, fmt::Debug};
-    use tempfile::tempdir;
 
     use crate::components::consensus::{
         highway_core::highway_testing::TEST_INSTANCE_ID,
@@ -702,14 +606,6 @@ mod tests {
                 swunit
             } else {
                 panic!("Unexpected effect: {:?}", self);
-            }
-        }
-
-        fn unwrap_timer(self) -> Timestamp {
-            if let Eff::ScheduleTimer(timestamp) = self {
-                timestamp
-            } else {
-                panic!("expected `ScheduleTimer`, got: {:?}", self)
             }
         }
     }
@@ -747,7 +643,6 @@ mod tests {
                     start_time,
                     start_time,
                     &state,
-                    None,
                     target_ftt,
                     TEST_INSTANCE_ID,
                 );
@@ -983,7 +878,6 @@ mod tests {
             410.into(),
             410.into(),
             &state,
-            None,
             Weight(2),
             TEST_INSTANCE_ID,
         );
@@ -1006,7 +900,6 @@ mod tests {
             410.into(),
             410.into(),
             &state,
-            None,
             Weight(2),
             TEST_INSTANCE_ID,
         );
@@ -1020,111 +913,5 @@ mod tests {
         assert!(active_validator.is_doppelganger_vertex(&ping, &state));
         state.add_ping(ALICE, 500.into());
         assert!(!active_validator.is_doppelganger_vertex(&ping, &state));
-    }
-
-    #[test]
-    fn waits_until_synchronized() -> Result<(), AddUnitError<TestContext>> {
-        let instance_id = TEST_INSTANCE_ID;
-        let mut state = State::new_test(&[Weight(3)], 0);
-        let a0 = {
-            let a0 = add_unit!(state, ALICE, 0xB0; N)?;
-            state.wire_unit(&a0, instance_id).unwrap()
-        };
-        let a1 = {
-            let a1 = add_unit!(state, ALICE, None; a0.hash())?;
-            state.wire_unit(&a1, instance_id).unwrap()
-        };
-        let a2 = {
-            let a2 = add_unit!(state, ALICE, None; a1.hash())?;
-            state.wire_unit(&a2, instance_id).unwrap()
-        };
-        // Clean state. We want Alice to synchronize first.
-        state.retain_evidence_only();
-
-        let unit_file = {
-            let tmp_dir = tempdir().unwrap();
-            let unit_files_folder = tmp_dir.path().to_path_buf();
-            Some(unit_files_folder.join(format!("unit_{:?}.dat", instance_id)))
-        };
-
-        // Store `a2` unit as the Alice's last unit.
-        write_last_unit(&unit_file, a2.clone()).expect("storing unit should succeed");
-
-        // Alice's last unit is `a2` but `State` is empty. She must synchronize first.
-        let (mut alice, alice_init_effects) = ActiveValidator::new(
-            ALICE,
-            TestSecret(ALICE.0),
-            410.into(),
-            410.into(),
-            &state,
-            unit_file,
-            Weight(2),
-            TEST_INSTANCE_ID,
-        );
-
-        let mut next_proposal_timer = match &*alice_init_effects {
-            &[Effect::ScheduleTimer(timestamp), Effect::NewVertex(ValidVertex(Vertex::Ping(_)))]
-                if timestamp == 416.into() =>
-            {
-                timestamp
-            }
-            other => panic!("unexpected effects {:?}", other),
-        };
-
-        // Alice has to synchronize up until `a2` (including) before she starts proposing.
-        for unit in vec![a0, a1, a2.clone()] {
-            next_proposal_timer =
-                assert_no_proposal(&mut alice, &state, instance_id, next_proposal_timer);
-            state.add_unit(unit)?;
-        }
-
-        // After synchronizing the protocol state up until `last_own_unit`, Alice can now propose a
-        // new block.
-        let bctx = match &*alice.handle_timer(next_proposal_timer, &state, instance_id) {
-            [Eff::ScheduleTimer(_), Eff::RequestNewBlock(bctx, _)] => bctx.clone(),
-            effects => panic!("unexpected effects {:?}", effects),
-        };
-
-        let proposal_wunit =
-            unwrap_single(&alice.propose(0xC0FFEE, bctx, &state, instance_id)).unwrap_unit();
-        assert_eq!(
-            proposal_wunit.wire_unit().seq_number,
-            a2.wire_unit().seq_number + 1,
-            "new unit should have correct seq_number"
-        );
-        assert_eq!(
-            proposal_wunit.wire_unit().panorama,
-            panorama!(a2.hash()),
-            "new unit should cite the latest unit"
-        );
-
-        Ok(())
-    }
-
-    // Triggers new proposal by `validator` and verifies that it's empty – no block was proposed.
-    // Captures the next witness timer and calls the `validator` with that to return the timer for
-    // the next proposal.
-    fn assert_no_proposal(
-        validator: &mut ActiveValidator<TestContext>,
-        state: &State<TestContext>,
-        instance_id: u64,
-        proposal_timer: Timestamp,
-    ) -> Timestamp {
-        let (witness_timestamp, bctx) =
-            match &*validator.handle_timer(proposal_timer, state, instance_id) {
-                [Eff::ScheduleTimer(witness_timestamp), Eff::RequestNewBlock(bctx, _)] => {
-                    (*witness_timestamp, bctx.clone())
-                }
-                effects => panic!("unexpected effects {:?}", effects),
-            };
-
-        let effects = validator.propose(0xC0FFEE, bctx, state, instance_id);
-        assert!(
-            effects.is_empty(),
-            "should not propose blocks until its dependencies are synchronized: {:?}",
-            effects
-        );
-
-        unwrap_single(&validator.handle_timer(witness_timestamp, state, instance_id)).unwrap_timer()
     }
 }

--- a/node/src/components/consensus/highway_core/highway_testing.rs
+++ b/node/src/components/consensus/highway_core/highway_testing.rs
@@ -935,7 +935,8 @@ impl<DS: DeliveryStrategy> HighwayTestHarnessBuilder<DS> {
             |(vid, secrets): (ValidatorId, &mut HashMap<ValidatorId, TestSecret>)| {
                 let v_sec = secrets.remove(&vid).expect("Secret key should exist.");
 
-                let mut highway = Highway::new(instance_id, validators.clone(), params.clone());
+                let mut highway =
+                    Highway::new(instance_id, validators.clone(), params.clone(), None);
                 let effects = highway.activate_validator(vid, v_sec, start_time, None, Weight(ftt));
 
                 let finality_detector = FinalityDetector::new(Weight(ftt));

--- a/node/src/components/consensus/highway_core/synchronizer/tests.rs
+++ b/node/src/components/consensus/highway_core/synchronizer/tests.rs
@@ -38,7 +38,7 @@ fn purge_vertices() {
 
     // A Highway instance that's just used to create PreValidatedVertex instances below.
     let util_highway =
-        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone());
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone(), None);
 
     // Returns the WireUnit with the specified hash.
     let unit = |hash: u64| Vertex::Unit(state.wire_unit(&hash, TEST_INSTANCE_ID).unwrap());
@@ -50,7 +50,8 @@ fn purge_vertices() {
     // Create a synchronizer with a 0x20 ms timeout, and a Highway instance.
     let max_requests_for_vertex = 5;
     let mut sync = Synchronizer::<TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
-    let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
+    let mut highway =
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params, None);
 
     // At time 0x20, we receive c2, b0 and b1 — the latter ahead of their timestamp.
     // Since c2 is the first entry in the main queue, processing is scheduled.
@@ -126,7 +127,7 @@ fn do_not_download_synchronized_dependencies() {
 
     let mut state = State::new(WEIGHTS, params.clone(), vec![], vec![]);
     let util_highway =
-        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone());
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone(), None);
 
     // We use round exponent 0u8, so a round is 0x40 ms. With seed 0, Carol is the first leader.
     //
@@ -153,7 +154,8 @@ fn do_not_download_synchronized_dependencies() {
     let max_requests_for_vertex = 5;
     let mut sync = Synchronizer::<TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
 
-    let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
+    let mut highway =
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params, None);
     let now = 0x20.into();
 
     assert!(matches!(
@@ -232,7 +234,7 @@ fn transitive_proposal_dependency() {
 
     let mut state = State::new(WEIGHTS, params.clone(), vec![], vec![]);
     let util_highway =
-        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone());
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params.clone(), None);
 
     // Alice   a0 — a1
     //             /  \
@@ -257,7 +259,8 @@ fn transitive_proposal_dependency() {
     let max_requests_for_vertex = 5;
     let mut sync = Synchronizer::<TestContext>::new(WEIGHTS.len(), TEST_INSTANCE_ID);
 
-    let mut highway = Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params);
+    let mut highway =
+        Highway::<TestContext>::new(TEST_INSTANCE_ID, test_validators(), params, None);
     let now = 0x100.into();
 
     assert!(matches!(

--- a/node/src/components/consensus/protocols/highway.rs
+++ b/node/src/components/consensus/protocols/highway.rs
@@ -97,6 +97,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
         era_start_time: Timestamp,
         seed: u64,
         now: Timestamp,
+        protocol_state_file: Option<PathBuf>,
     ) -> (Box<dyn ConsensusProtocol<C>>, ProtocolOutcomes<C>) {
         let validators_count = validator_stakes.len();
         let validators = protocols::common::validators::<C>(faulty, inactive, validator_stakes);
@@ -170,7 +171,7 @@ impl<C: Context + 'static> HighwayProtocol<C> {
 
         let outcomes = Self::initialize_timers(now, era_start_time, &config.highway);
 
-        let highway = Highway::new(instance_id, validators, params);
+        let highway = Highway::new(instance_id, validators, params, protocol_state_file);
         let hw_proto = Box::new(HighwayProtocol {
             pending_values: HashMap::new(),
             finality_detector: FinalityDetector::new(ftt),

--- a/node/src/components/consensus/protocols/highway/tests.rs
+++ b/node/src/components/consensus/protocols/highway/tests.rs
@@ -89,6 +89,7 @@ where
         start_timestamp,
         0,
         start_timestamp,
+        None,
     );
     // We expect three messages:
     // * log participation timer,

--- a/node/src/components/consensus/utils.rs
+++ b/node/src/components/consensus/utils.rs
@@ -1,6 +1,7 @@
 //! Various utilities relevant to consensus.
 
 mod validators;
+pub(crate) mod wal;
 mod weight;
 
 pub use validators::{Validator, ValidatorIndex, ValidatorMap, Validators};


### PR DESCRIPTION
This will enable validators in a network running Highway to resume validating after a crash without the necessity to download the protocol state from other nodes. The WAL (Write-Ahead Log) will contain all the units added to the protocol state during the node's operation, which combined with the information from the stored blocks will make it possible to restore the protocol state to the point from before a crash.

Since Zug already uses a WAL, this will close the only remaining hole in the protocol state persistence story.

Closes #3904 
