### PR TITLE
Add block info support to EE and Casper VM (#4853)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "get-blockinfo"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "get-blocktime"
 version = "0.1.0"
 dependencies = [

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -124,7 +124,6 @@ impl ExecutionEngineV1 {
             Err(ese) => return WasmV1Result::precondition_failure(gas_limit, ese),
         };
         let access_rights = entity.extract_access_rights(entity_hash, &named_keys);
-        let block_time = block_info.block_time;
         Executor::new(self.config().clone()).exec(
             execution_kind,
             args,
@@ -134,7 +133,7 @@ impl ExecutionEngineV1 {
             access_rights,
             authorization_keys,
             account_hash,
-            block_time,
+            block_info,
             transaction_hash,
             gas_limit,
             protocol_version,

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -23,7 +23,7 @@ pub use engine_config::{
 };
 pub use error::Error;
 use execution_kind::ExecutionKind;
-pub use wasm_v1::{ExecutableItem, InvalidRequest, WasmV1Request, WasmV1Result};
+pub use wasm_v1::{BlockInfo, ExecutableItem, InvalidRequest, WasmV1Request, WasmV1Result};
 
 /// The maximum amount of motes that payment code execution can cost.
 pub const MAX_PAYMENT_AMOUNT: u64 = 2_500_000_000;
@@ -60,8 +60,7 @@ impl ExecutionEngineV1 {
         &self,
         state_provider: &impl StateProvider,
         WasmV1Request {
-            state_hash,
-            block_time,
+            block_info,
             transaction_hash,
             gas_limit,
             initiator_addr,
@@ -80,6 +79,7 @@ impl ExecutionEngineV1 {
 
         let account_hash = initiator_addr.account_hash();
         let protocol_version = self.config.protocol_version();
+        let state_hash = block_info.state_hash;
         let tc = match state_provider.tracking_copy(state_hash) {
             Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
             Ok(None) => return WasmV1Result::root_not_found(gas_limit, state_hash),
@@ -124,6 +124,7 @@ impl ExecutionEngineV1 {
             Err(ese) => return WasmV1Result::precondition_failure(gas_limit, ese),
         };
         let access_rights = entity.extract_access_rights(entity_hash, &named_keys);
+        let block_time = block_info.block_time;
         Executor::new(self.config().clone()).exec(
             execution_kind,
             args,

--- a/execution_engine/src/engine_state/wasm_v1.rs
+++ b/execution_engine/src/engine_state/wasm_v1.rs
@@ -9,9 +9,9 @@ use thiserror::Error;
 use casper_storage::data_access_layer::TransferResult;
 use casper_types::{
     account::AccountHash, bytesrepr::Bytes, contract_messages::Messages, execution::Effects,
-    BlockTime, DeployHash, Digest, ExecutableDeployItem, Gas, InitiatorAddr, Phase, PricingMode,
-    RuntimeArgs, Transaction, TransactionCategory, TransactionEntryPoint, TransactionHash,
-    TransactionInvocationTarget, TransactionTarget, TransactionV1, Transfer,
+    BlockHash, BlockTime, DeployHash, Digest, ExecutableDeployItem, Gas, InitiatorAddr, Phase,
+    PricingMode, RuntimeArgs, Transaction, TransactionCategory, TransactionEntryPoint,
+    TransactionHash, TransactionInvocationTarget, TransactionTarget, TransactionV1, Transfer,
 };
 
 use crate::engine_state::{DeployItem, Error as EngineError};
@@ -65,13 +65,51 @@ pub enum ExecutableItem {
     Invocation(TransactionInvocationTarget),
 }
 
-/// A request to execute the given Wasm on the V1 runtime.
-#[derive(Debug)]
-pub struct WasmV1Request {
+/// Block info.
+#[derive(Copy, Clone, Debug)]
+pub struct BlockInfo {
     /// State root hash of the global state in which the transaction will be executed.
     pub state_hash: Digest,
     /// Block time represented as a unix timestamp.
     pub block_time: BlockTime,
+    /// Parent block hash
+    pub parent_block_hash: BlockHash,
+    /// Block height
+    pub block_height: u64,
+}
+
+impl BlockInfo {
+    /// A new instance of `[BlockInfo]`.
+    pub fn new(
+        state_hash: Digest,
+        block_time: BlockTime,
+        parent_block_hash: BlockHash,
+        block_height: u64,
+    ) -> Self {
+        BlockInfo {
+            state_hash,
+            block_time,
+            parent_block_hash,
+            block_height,
+        }
+    }
+
+    /// Apply different state hash.
+    pub fn with_state_hash(&mut self, state_hash: Digest) {
+        self.state_hash = state_hash;
+    }
+
+    /// Block time.
+    pub fn block_time(&self) -> BlockTime {
+        self.block_time
+    }
+}
+
+/// A request to execute the given Wasm on the V1 runtime.
+#[derive(Debug)]
+pub struct WasmV1Request {
+    /// Block info.
+    pub block_info: BlockInfo,
     /// The hash identifying the transaction.
     pub transaction_hash: TransactionHash,
     /// The number of Motes per unit of Gas to be paid for execution.
@@ -92,8 +130,7 @@ pub struct WasmV1Request {
 
 impl WasmV1Request {
     pub(crate) fn new_from_executable_info(
-        state_hash: Digest,
-        block_time: BlockTime,
+        block_info: BlockInfo,
         gas_limit: Gas,
         transaction_hash: TransactionHash,
         initiator_addr: InitiatorAddr,
@@ -102,8 +139,7 @@ impl WasmV1Request {
     ) -> Self {
         let executable_item = executable_info.item();
         Self {
-            state_hash,
-            block_time,
+            block_info,
             transaction_hash,
             gas_limit,
             initiator_addr,
@@ -117,12 +153,11 @@ impl WasmV1Request {
 
     /// Creates a new request from a transaction for use as the session code.
     pub fn new_session(
-        state_hash: Digest,
-        block_time: BlockTime,
+        block_info: BlockInfo,
         gas_limit: Gas,
         transaction: &Transaction,
     ) -> Result<Self, InvalidRequest> {
-        let info = match transaction {
+        let session_info = match transaction {
             Transaction::Deploy(deploy) => {
                 SessionInfo::try_from((deploy.session(), deploy.hash()))?
             }
@@ -133,24 +168,22 @@ impl WasmV1Request {
         let initiator_addr = transaction.initiator_addr();
         let authorization_keys = transaction.signers();
         Ok(WasmV1Request::new_from_executable_info(
-            state_hash,
-            block_time,
+            block_info,
             gas_limit,
             transaction_hash,
             initiator_addr,
             authorization_keys,
-            info,
+            session_info,
         ))
     }
 
     /// Creates a new request from a transaction for use as custom payment.
     pub fn new_custom_payment(
-        state_hash: Digest,
-        block_time: BlockTime,
+        block_info: BlockInfo,
         gas_limit: Gas,
         transaction: &Transaction,
     ) -> Result<Self, InvalidRequest> {
-        let info = match transaction {
+        let payment_info = match transaction {
             Transaction::Deploy(deploy) => {
                 PaymentInfo::try_from((deploy.payment(), deploy.hash()))?
             }
@@ -161,20 +194,18 @@ impl WasmV1Request {
         let initiator_addr = transaction.initiator_addr();
         let authorization_keys = transaction.signers();
         Ok(WasmV1Request::new_from_executable_info(
-            state_hash,
-            block_time,
+            block_info,
             gas_limit,
             transaction_hash,
             initiator_addr,
             authorization_keys,
-            info,
+            payment_info,
         ))
     }
 
     /// Creates a new request from a deploy item for use as the session code.
     pub fn new_session_from_deploy_item(
-        state_hash: Digest,
-        block_time: BlockTime,
+        block_info: BlockInfo,
         gas_limit: Gas,
         DeployItem {
             ref address,
@@ -184,25 +215,23 @@ impl WasmV1Request {
             ..
         }: &DeployItem,
     ) -> Result<Self, InvalidRequest> {
-        let info = SessionInfo::try_from((session, deploy_hash))?;
+        let session_info = SessionInfo::try_from((session, deploy_hash))?;
         let transaction_hash = TransactionHash::Deploy(*deploy_hash);
         let initiator_addr = InitiatorAddr::AccountHash(*address);
         let authorization_keys = authorization_keys.clone();
         Ok(WasmV1Request::new_from_executable_info(
-            state_hash,
-            block_time,
+            block_info,
             gas_limit,
             transaction_hash,
             initiator_addr,
             authorization_keys,
-            info,
+            session_info,
         ))
     }
 
     /// Creates a new request from a deploy item for use as custom payment.
     pub fn new_custom_payment_from_deploy_item(
-        state_hash: Digest,
-        block_time: BlockTime,
+        block_info: BlockInfo,
         gas_limit: Gas,
         DeployItem {
             ref address,
@@ -212,18 +241,17 @@ impl WasmV1Request {
             ..
         }: &DeployItem,
     ) -> Result<Self, InvalidRequest> {
-        let info = PaymentInfo::try_from((payment, deploy_hash))?;
+        let payment_info = PaymentInfo::try_from((payment, deploy_hash))?;
         let transaction_hash = TransactionHash::Deploy(*deploy_hash);
         let initiator_addr = InitiatorAddr::AccountHash(*address);
         let authorization_keys = authorization_keys.clone();
         Ok(WasmV1Request::new_from_executable_info(
-            state_hash,
-            block_time,
+            block_info,
             gas_limit,
             transaction_hash,
             initiator_addr,
             authorization_keys,
-            info,
+            payment_info,
         ))
     }
 }
@@ -496,7 +524,10 @@ impl TryFrom<&TransactionV1> for SessionInfo {
             }
             TransactionTarget::Stored { id, .. } => {
                 let TransactionEntryPoint::Custom(entry_point) = v1_txn.entry_point() else {
-                    return Err(InvalidRequest::InvalidEntryPoint(transaction_hash, v1_txn.entry_point().to_string()));
+                    return Err(InvalidRequest::InvalidEntryPoint(
+                        transaction_hash,
+                        v1_txn.entry_point().to_string(),
+                    ));
                 };
                 let item = ExecutableItem::Invocation(id.clone());
                 ExecutableInfo {

--- a/execution_engine/src/engine_state/wasm_v1.rs
+++ b/execution_engine/src/engine_state/wasm_v1.rs
@@ -99,9 +99,24 @@ impl BlockInfo {
         self.state_hash = state_hash;
     }
 
+    /// State hash.
+    pub fn state_hash(&self) -> Digest {
+        self.state_hash
+    }
+
     /// Block time.
     pub fn block_time(&self) -> BlockTime {
         self.block_time
+    }
+
+    /// Parent block hash.
+    pub fn parent_block_hash(&self) -> BlockHash {
+        self.parent_block_hash
+    }
+
+    /// Block height.
+    pub fn block_height(&self) -> u64 {
+        self.block_height
     }
 }
 

--- a/execution_engine/src/execution/error.rs
+++ b/execution_engine/src/execution/error.rs
@@ -183,9 +183,9 @@ pub enum Error {
     /// The EntryPoints contains an invalid entry.
     #[error("The EntryPoints contains an invalid entry")]
     InvalidEntryPointType,
-    /// Invalid message topic operation.
-    #[error("The requested operation is invalid for a message topic")]
-    InvalidMessageTopicOperation,
+    /// Invalid operation.
+    #[error("The imputed operation is invalid")]
+    InvalidImputedOperation,
     /// Invalid string encoding.
     #[error("Invalid UTF-8 string encoding: {0}")]
     InvalidUtf8Encoding(Utf8Error),

--- a/execution_engine/src/execution/executor.rs
+++ b/execution_engine/src/execution/executor.rs
@@ -7,13 +7,13 @@ use casper_storage::{
 };
 use casper_types::{
     account::AccountHash, addressable_entity::NamedKeys, contract_messages::Messages,
-    execution::Effects, AddressableEntity, AddressableEntityHash, BlockTime, ContextAccessRights,
+    execution::Effects, AddressableEntity, AddressableEntityHash, ContextAccessRights,
     EntryPointType, Gas, Key, Phase, ProtocolVersion, RuntimeArgs, StoredValue, Tagged,
     TransactionHash, U512,
 };
 
 use crate::{
-    engine_state::{execution_kind::ExecutionKind, EngineConfig, WasmV1Result},
+    engine_state::{execution_kind::ExecutionKind, BlockInfo, EngineConfig, WasmV1Result},
     execution::ExecError,
     runtime::{Runtime, RuntimeStack},
     runtime_context::{CallingAddContractVersion, RuntimeContext},
@@ -53,7 +53,7 @@ impl Executor {
         access_rights: ContextAccessRights,
         authorization_keys: BTreeSet<AccountHash>,
         account_hash: AccountHash,
-        blocktime: BlockTime,
+        block_info: BlockInfo,
         txn_hash: TransactionHash,
         gas_limit: Gas,
         protocol_version: ProtocolVersion,
@@ -101,7 +101,7 @@ impl Executor {
             account_hash,
             address_generator,
             tracking_copy,
-            blocktime,
+            block_info,
             protocol_version,
             txn_hash,
             phase,
@@ -163,7 +163,7 @@ impl Executor {
         account_hash: AccountHash,
         address_generator: Rc<RefCell<AddressGenerator>>,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
-        blocktime: BlockTime,
+        block_info: BlockInfo,
         protocol_version: ProtocolVersion,
         txn_hash: TransactionHash,
         phase: Phase,
@@ -189,7 +189,7 @@ impl Executor {
             address_generator,
             tracking_copy,
             self.config.clone(),
-            blocktime,
+            block_info,
             protocol_version,
             txn_hash,
             phase,

--- a/execution_engine/src/resolvers/v1_function_index.rs
+++ b/execution_engine/src/resolvers/v1_function_index.rs
@@ -60,6 +60,7 @@ pub(crate) enum FunctionIndex {
     ManageMessageTopic,
     EmitMessage,
     LoadCallerInformation,
+    GetBlockInfoIndex,
 }
 
 impl From<FunctionIndex> for usize {

--- a/execution_engine/src/resolvers/v1_resolver.rs
+++ b/execution_engine/src/resolvers/v1_resolver.rs
@@ -253,6 +253,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::EmitMessage.into(),
             ),
+            "casper_get_block_info" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 2][..], None),
+                FunctionIndex::GetBlockInfoIndex.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -434,11 +434,48 @@ where
             .map_err(|e| ExecError::Interpreter(e.into()).into())
     }
 
+    /// Writes requested field from runtime context's block info to dest_ptr in the Wasm memory.
+    fn get_block_info(&self, field_idx: u8, dest_ptr: u32) -> Result<(), Trap> {
+        if field_idx == 0 {
+            // original functionality
+            return self.get_blocktime(dest_ptr);
+        }
+        let block_info = self.context.get_block_info();
+
+        let mut data: Vec<u8> = vec![];
+        if field_idx == 1 {
+            data = block_info
+                .block_height()
+                .into_bytes()
+                .map_err(ExecError::BytesRepr)?;
+        }
+        if field_idx == 2 {
+            data = block_info
+                .parent_block_hash()
+                .into_bytes()
+                .map_err(ExecError::BytesRepr)?;
+        }
+        if field_idx == 3 {
+            data = block_info
+                .state_hash()
+                .into_bytes()
+                .map_err(ExecError::BytesRepr)?;
+        }
+        if data.is_empty() {
+            Err(ExecError::InvalidImputedOperation.into())
+        } else {
+            Ok(self
+                .try_get_memory()?
+                .set(dest_ptr, &data)
+                .map_err(|e| ExecError::Interpreter(e.into()))?)
+        }
+    }
+
     /// Writes current blocktime to dest_ptr in Wasm memory.
     fn get_blocktime(&self, dest_ptr: u32) -> Result<(), Trap> {
-        let blocktime = self
-            .context
-            .get_blocktime()
+        let block_info = self.context.get_block_info();
+        let blocktime = block_info
+            .block_time()
             .into_bytes()
             .map_err(ExecError::BytesRepr)?;
         self.try_get_memory()?
@@ -2017,10 +2054,8 @@ where
 
         for (_, topic_hash) in previous_message_topics.iter() {
             let topic_key = Key::message_topic(entity_addr, *topic_hash);
-            let summary = StoredValue::MessageTopic(MessageTopicSummary::new(
-                0,
-                self.context.get_blocktime(),
-            ));
+            let block_time = self.context.get_block_info().block_time();
+            let summary = StoredValue::MessageTopic(MessageTopicSummary::new(0, block_time));
             self.context.metered_write_gs_unsafe(topic_key, summary)?;
         }
 
@@ -3557,7 +3592,7 @@ where
             return Ok(Err(ApiError::MessageTopicNotRegistered));
         };
 
-        let current_blocktime = self.context.get_blocktime();
+        let current_blocktime = self.context.get_block_info().block_time();
         let topic_message_index = if prev_topic_summary.blocktime() != current_blocktime {
             for index in 1..prev_topic_summary.message_count() {
                 self.context

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -41,7 +41,10 @@ use casper_types::{
     DICTIONARY_ITEM_KEY_MAX_LENGTH, KEY_HASH_LENGTH, U512,
 };
 
-use crate::{engine_state::EngineConfig, execution::ExecError};
+use crate::{
+    engine_state::{BlockInfo, EngineConfig},
+    execution::ExecError,
+};
 
 /// Number of bytes returned from the `random_bytes` function.
 pub const RANDOM_BYTES_COUNT: usize = 32;
@@ -64,7 +67,7 @@ pub struct RuntimeContext<'a, R> {
     access_rights: ContextAccessRights,
     args: RuntimeArgs,
     authorization_keys: BTreeSet<AccountHash>,
-    blocktime: BlockTime,
+    block_info: BlockInfo,
     transaction_hash: TransactionHash,
     gas_limit: Gas,
     gas_counter: Gas,
@@ -104,7 +107,7 @@ where
         address_generator: Rc<RefCell<AddressGenerator>>,
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
         engine_config: EngineConfig,
-        blocktime: BlockTime,
+        block_info: BlockInfo,
         protocol_version: ProtocolVersion,
         transaction_hash: TransactionHash,
         phase: Phase,
@@ -132,7 +135,7 @@ where
             entity_key,
             authorization_keys,
             account_hash,
-            blocktime,
+            block_info,
             transaction_hash,
             gas_limit,
             gas_counter,
@@ -165,7 +168,7 @@ where
         let tracking_copy = self.state();
         let engine_config = self.engine_config.clone();
 
-        let blocktime = self.blocktime;
+        let block_info = self.block_info;
         let protocol_version = self.protocol_version;
         let transaction_hash = self.transaction_hash;
         let phase = self.phase;
@@ -186,7 +189,7 @@ where
             entity_key,
             authorization_keys,
             account_hash,
-            blocktime,
+            block_info,
             transaction_hash,
             gas_limit,
             gas_counter,
@@ -265,9 +268,9 @@ where
         self.remove_key_from_entity(name)
     }
 
-    /// Returns the block time.
-    pub fn get_blocktime(&self) -> BlockTime {
-        self.blocktime
+    /// Returns block info.
+    pub fn get_block_info(&self) -> BlockInfo {
+        self.block_info
     }
 
     /// Returns the transaction hash.
@@ -1425,7 +1428,8 @@ where
         };
 
         let topic_key = Key::Message(MessageAddr::new_topic_addr(entity_addr, topic_name_hash));
-        let summary = StoredValue::MessageTopic(MessageTopicSummary::new(0, self.get_blocktime()));
+        let block_time = self.block_info.block_time();
+        let summary = StoredValue::MessageTopic(MessageTopicSummary::new(0, block_time));
 
         let entity_value = self.addressable_entity_to_validated_value(entity)?;
 

--- a/execution_engine/src/runtime_context/tests.rs
+++ b/execution_engine/src/runtime_context/tests.rs
@@ -17,16 +17,16 @@ use casper_types::{
     bytesrepr::ToBytes,
     execution::TransformKindV2,
     system::{AUCTION, HANDLE_PAYMENT, MINT, STANDARD_PAYMENT},
-    AccessRights, AddressableEntity, AddressableEntityHash, BlockGlobalAddr, BlockTime,
-    ByteCodeHash, CLValue, ContextAccessRights, EntityAddr, EntityKind, EntryPointType, Gas, Key,
-    PackageHash, Phase, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, StoredValue,
+    AccessRights, AddressableEntity, AddressableEntityHash, BlockGlobalAddr, BlockHash, BlockTime,
+    ByteCodeHash, CLValue, ContextAccessRights, Digest, EntityAddr, EntityKind, EntryPointType,
+    Gas, Key, PackageHash, Phase, ProtocolVersion, PublicKey, RuntimeArgs, SecretKey, StoredValue,
     SystemEntityRegistry, Tagged, Timestamp, TransactionHash, TransactionV1Hash, URef,
     KEY_HASH_LENGTH, U256, U512,
 };
 use tempfile::TempDir;
 
 use super::{CallingAddContractVersion, ExecError, RuntimeContext};
-use crate::engine_state::EngineConfig;
+use crate::engine_state::{BlockInfo, EngineConfig};
 
 const TXN_HASH_RAW: [u8; 32] = [1u8; 32];
 const PHASE: Phase = Phase::Session;
@@ -159,7 +159,12 @@ fn new_runtime_context<'a>(
         Rc::new(RefCell::new(address_generator)),
         Rc::new(RefCell::new(tracking_copy)),
         TEST_ENGINE_CONFIG.clone(),
-        BlockTime::new(0),
+        BlockInfo::new(
+            Digest::default(),
+            BlockTime::new(0),
+            BlockHash::default(),
+            0,
+        ),
         ProtocolVersion::V1_0_0,
         TransactionHash::V1(TransactionV1Hash::from_raw([1u8; 32])),
         Phase::Session,
@@ -426,7 +431,12 @@ fn contract_key_addable_valid() {
         Rc::new(RefCell::new(address_generator)),
         Rc::clone(&tracking_copy),
         EngineConfig::default(),
-        BlockTime::new(0),
+        BlockInfo::new(
+            Digest::default(),
+            BlockTime::new(0),
+            BlockHash::default(),
+            0,
+        ),
         ProtocolVersion::V1_0_0,
         TransactionHash::V1(TransactionV1Hash::from_raw(TXN_HASH_RAW)),
         PHASE,
@@ -484,7 +494,12 @@ fn contract_key_addable_invalid() {
         Rc::new(RefCell::new(address_generator)),
         Rc::clone(&tracking_copy),
         EngineConfig::default(),
-        BlockTime::new(0),
+        BlockInfo::new(
+            Digest::default(),
+            BlockTime::new(0),
+            BlockHash::default(),
+            0,
+        ),
         ProtocolVersion::V1_0_0,
         TransactionHash::V1(TransactionV1Hash::from_raw(TXN_HASH_RAW)),
         PHASE,

--- a/execution_engine_testing/test_support/src/execute_request_builder.rs
+++ b/execution_engine_testing/test_support/src/execute_request_builder.rs
@@ -26,6 +26,8 @@ pub struct ExecuteRequest {
 pub struct ExecuteRequestBuilder {
     state_hash: Digest,
     block_time: BlockTime,
+    block_height: u64,
+    parent_block_hash: BlockHash,
     transaction_hash: TransactionHash,
     initiator_addr: InitiatorAddr,
     payment: Option<ExecutableItem>,
@@ -95,6 +97,8 @@ impl ExecuteRequestBuilder {
         ExecuteRequestBuilder {
             state_hash: session.block_info.state_hash,
             block_time: session.block_info.block_time,
+            block_height: session.block_info.block_height,
+            parent_block_hash: session.block_info.parent_block_hash,
             transaction_hash: session.transaction_hash,
             initiator_addr: session.initiator_addr,
             payment,
@@ -156,6 +160,8 @@ impl ExecuteRequestBuilder {
         ExecuteRequestBuilder {
             state_hash: session.block_info.state_hash,
             block_time: session.block_info.block_time,
+            block_height: session.block_info.block_height,
+            parent_block_hash: session.block_info.parent_block_hash,
             transaction_hash: session.transaction_hash,
             initiator_addr: session.initiator_addr,
             payment,
@@ -285,6 +291,24 @@ impl ExecuteRequestBuilder {
         self
     }
 
+    /// Sets the block height of the [`WasmV1Request`]s.
+    pub fn with_block_height(mut self, block_height: u64) -> Self {
+        self.block_height = block_height;
+        self
+    }
+
+    /// Sets the parent block hash of the [`WasmV1Request`]s.
+    pub fn with_parent_block_hash(mut self, parent_block_hash: BlockHash) -> Self {
+        self.parent_block_hash = parent_block_hash;
+        self
+    }
+
+    /// Sets the parent block hash of the [`WasmV1Request`]s.
+    pub fn with_state_hash(mut self, state_hash: Digest) -> Self {
+        self.state_hash = state_hash;
+        self
+    }
+
     /// Sets the authorization keys used by the [`WasmV1Request`]s.
     pub fn with_authorization_keys(mut self, authorization_keys: BTreeSet<AccountHash>) -> Self {
         self.authorization_keys = authorization_keys;
@@ -296,6 +320,8 @@ impl ExecuteRequestBuilder {
         let ExecuteRequestBuilder {
             state_hash,
             block_time,
+            block_height,
+            parent_block_hash,
             transaction_hash,
             initiator_addr,
             payment,
@@ -309,7 +335,7 @@ impl ExecuteRequestBuilder {
             authorization_keys,
         } = self;
 
-        let block_info = BlockInfo::new(state_hash, block_time, BlockHash::default(), 0);
+        let block_info = BlockInfo::new(state_hash, block_time, parent_block_hash, block_height);
         let maybe_custom_payment = payment.map(|executable_item| WasmV1Request {
             block_info,
             transaction_hash,
@@ -322,7 +348,6 @@ impl ExecuteRequestBuilder {
             phase: Phase::Payment,
         });
 
-        let block_info = BlockInfo::new(state_hash, block_time, BlockHash::default(), 0);
         let session = WasmV1Request {
             block_info,
             transaction_hash,

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -185,7 +185,8 @@ impl<S: ScratchProvider> WasmTestBuilder<S> {
             .as_ref()
             .expect("scratch state should exist");
 
-        exec_request.state_hash = self.post_state_hash.expect("expected post_state_hash");
+        let state_hash = self.post_state_hash.expect("expected post_state_hash");
+        exec_request.block_info.with_state_hash(state_hash);
 
         // First execute the request against our scratch global state.
         let execution_result = self.execution_engine.execute(cached_state, exec_request);
@@ -828,7 +829,8 @@ where
     /// If the custom payment is `Some` and its execution fails, the session request is not
     /// attempted.
     pub fn exec_wasm_v1(&mut self, mut request: WasmV1Request) -> &mut Self {
-        request.state_hash = self.post_state_hash.expect("expected post_state_hash");
+        let state_hash = self.post_state_hash.expect("expected post_state_hash");
+        request.block_info.with_state_hash(state_hash);
         let result = self
             .execution_engine
             .execute(self.data_access_layer.as_ref(), request);
@@ -842,7 +844,8 @@ where
     pub fn exec(&mut self, mut exec_request: ExecuteRequest) -> &mut Self {
         let mut effects = Effects::new();
         if let Some(mut payment) = exec_request.custom_payment {
-            payment.state_hash = self.post_state_hash.expect("expected post_state_hash");
+            let state_hash = self.post_state_hash.expect("expected post_state_hash");
+            payment.block_info.with_state_hash(state_hash);
             let payment_result = self
                 .execution_engine
                 .execute(self.data_access_layer.as_ref(), payment);
@@ -856,7 +859,8 @@ where
                 return self;
             }
         }
-        exec_request.session.state_hash = self.post_state_hash.expect("expected post_state_hash");
+        let state_hash = self.post_state_hash.expect("expected post_state_hash");
+        exec_request.session.block_info.with_state_hash(state_hash);
 
         let session_result = self
             .execution_engine

--- a/execution_engine_testing/tests/src/test/contract_api/get_block_info.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_block_info.rs
@@ -1,0 +1,113 @@
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, LOCAL_GENESIS_REQUEST,
+};
+use casper_types::bytesrepr::ToBytes;
+use casper_types::{runtime_args, BlockHash};
+
+const CONTRACT_GET_BLOCKINFO: &str = "get_blockinfo.wasm";
+const ARG_FIELD_IDX: &str = "field_idx";
+
+const FIELD_IDX_BLOCK_TIME: u8 = 0;
+const ARG_KNOWN_BLOCK_TIME: &str = "known_block_time";
+
+#[ignore]
+#[test]
+fn should_run_get_block_time() {
+    let block_time: u64 = 42;
+
+    let exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_GET_BLOCKINFO,
+        runtime_args! {
+            ARG_FIELD_IDX => FIELD_IDX_BLOCK_TIME,
+            ARG_KNOWN_BLOCK_TIME => block_time
+        },
+    )
+    .with_block_time(block_time)
+    .build();
+    LmdbWasmTestBuilder::default()
+        .run_genesis(LOCAL_GENESIS_REQUEST.clone())
+        .exec(exec_request)
+        .commit()
+        .expect_success();
+}
+
+const FIELD_IDX_BLOCK_HEIGHT: u8 = 1;
+const ARG_KNOWN_BLOCK_HEIGHT: &str = "known_block_height";
+
+#[ignore]
+#[test]
+fn should_run_get_block_height() {
+    let block_height: u64 = 1;
+
+    let exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_GET_BLOCKINFO,
+        runtime_args! {
+            ARG_FIELD_IDX => FIELD_IDX_BLOCK_HEIGHT,
+            ARG_KNOWN_BLOCK_HEIGHT => block_height
+        },
+    )
+    .with_block_height(block_height)
+    .build();
+    LmdbWasmTestBuilder::default()
+        .run_genesis(LOCAL_GENESIS_REQUEST.clone())
+        .exec(exec_request)
+        .expect_success()
+        .commit();
+}
+
+const FIELD_IDX_PARENT_BLOCK_HASH: u8 = 2;
+const ARG_KNOWN_BLOCK_PARENT_HASH: &str = "known_block_parent_hash";
+
+#[ignore]
+#[test]
+fn should_run_get_block_parent_hash() {
+    let block_hash = BlockHash::default();
+    let digest = block_hash.inner();
+    let digest_bytes = digest.to_bytes().expect("should serialize");
+    let bytes = casper_types::bytesrepr::Bytes::from(digest_bytes);
+
+    let exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_GET_BLOCKINFO,
+        runtime_args! {
+            ARG_FIELD_IDX => FIELD_IDX_PARENT_BLOCK_HASH,
+            ARG_KNOWN_BLOCK_PARENT_HASH => bytes
+        },
+    )
+    .with_parent_block_hash(block_hash)
+    .build();
+    LmdbWasmTestBuilder::default()
+        .run_genesis(LOCAL_GENESIS_REQUEST.clone())
+        .exec(exec_request)
+        .expect_success()
+        .commit();
+}
+
+const FIELD_IDX_STATE_HASH: u8 = 3;
+const ARG_KNOWN_STATE_HASH: &str = "known_state_hash";
+
+#[ignore]
+#[test]
+fn should_run_get_state_hash() {
+    let mut builder = LmdbWasmTestBuilder::default();
+    builder.run_genesis(LOCAL_GENESIS_REQUEST.clone());
+
+    let state_hash = builder.get_post_state_hash();
+    let digest_bytes = state_hash.to_bytes().expect("should serialize");
+    let bytes = casper_types::bytesrepr::Bytes::from(digest_bytes);
+
+    let exec_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_GET_BLOCKINFO,
+        runtime_args! {
+            ARG_FIELD_IDX => FIELD_IDX_STATE_HASH,
+            ARG_KNOWN_STATE_HASH => bytes
+        },
+    )
+    .with_state_hash(state_hash)
+    .build();
+
+    builder.exec(exec_request).expect_success().commit();
+}

--- a/execution_engine_testing/tests/src/test/contract_api/get_block_info.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/get_block_info.rs
@@ -1,8 +1,7 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, LOCAL_GENESIS_REQUEST,
 };
-use casper_types::bytesrepr::ToBytes;
-use casper_types::{runtime_args, BlockHash};
+use casper_types::{bytesrepr::ToBytes, runtime_args, BlockHash};
 
 const CONTRACT_GET_BLOCKINFO: &str = "get_blockinfo.wasm";
 const ARG_FIELD_IDX: &str = "field_idx";

--- a/execution_engine_testing/tests/src/test/contract_api/mod.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/mod.rs
@@ -3,6 +3,7 @@ mod add_contract_version;
 mod create_purse;
 mod dictionary;
 mod get_arg;
+mod get_block_info;
 mod get_blocktime;
 mod get_call_stack;
 mod get_caller;

--- a/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
+++ b/execution_engine_testing/tests/src/test/deploy/non_standard_payment.rs
@@ -3,9 +3,11 @@ use casper_engine_test_support::{
     DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION, LOCAL_GENESIS_REQUEST,
     MINIMUM_ACCOUNT_CREATION_BALANCE,
 };
-use casper_execution_engine::engine_state::WasmV1Request;
+use casper_execution_engine::engine_state::{BlockInfo, WasmV1Request};
 use casper_storage::data_access_layer::BalanceIdentifier;
-use casper_types::{account::AccountHash, runtime_args, Digest, Gas, RuntimeArgs, Timestamp, U512};
+use casper_types::{
+    account::AccountHash, runtime_args, BlockHash, Digest, Gas, RuntimeArgs, Timestamp, U512,
+};
 
 const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 const DO_NOTHING_WASM: &str = "do_nothing.wasm";
@@ -88,12 +90,12 @@ fn should_charge_non_main_purse() {
         .build();
 
     let block_time = Timestamp::now().millis();
-
+    let parent_block_hash = BlockHash::default();
+    let block_info = BlockInfo::new(Digest::default(), block_time.into(), parent_block_hash, 1);
     builder
         .exec_wasm_v1(
             WasmV1Request::new_custom_payment_from_deploy_item(
-                Digest::default(),
-                block_time.into(),
+                block_info,
                 Gas::from(12_500_000_000_u64),
                 &deploy_item,
             )

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -3,7 +3,9 @@ use std::{collections::BTreeMap, convert::TryInto, sync::Arc, time::Instant};
 use itertools::Itertools;
 use tracing::{debug, error, info, trace, warn};
 
-use casper_execution_engine::engine_state::{ExecutionEngineV1, WasmV1Request, WasmV1Result};
+use casper_execution_engine::engine_state::{
+    BlockInfo, ExecutionEngineV1, WasmV1Request, WasmV1Result,
+};
 use casper_storage::{
     block_store::types::ApprovalsHashes,
     data_access_layer::{
@@ -58,7 +60,8 @@ pub fn execute_finalized_block(
     next_era_gas_price: Option<u8>,
     last_switch_block_hash: Option<BlockHash>,
 ) -> Result<BlockAndExecutionArtifacts, BlockExecutionError> {
-    if executable_block.height != execution_pre_state.next_block_height() {
+    let block_height = executable_block.height;
+    if block_height != execution_pre_state.next_block_height() {
         return Err(BlockExecutionError::WrongBlockHeight {
             executable_block: Box::new(executable_block),
             execution_pre_state: Box::new(execution_pre_state),
@@ -78,11 +81,14 @@ pub fn execute_finalized_block(
     // scrape variables from execution pre state
     let parent_hash = execution_pre_state.parent_hash();
     let parent_seed = execution_pre_state.parent_seed();
+    let parent_block_hash = execution_pre_state.parent_hash();
     let pre_state_root_hash = execution_pre_state.pre_state_root_hash();
     let mut state_root_hash = pre_state_root_hash; // initial state root is parent's state root
 
     // scrape variables from executable block
     let block_time = BlockTime::new(executable_block.timestamp.millis());
+    let block_info = BlockInfo::new(state_root_hash, block_time, parent_block_hash, block_height);
+
     let proposer = executable_block.proposer.clone();
     let era_id = executable_block.era_id;
     let mut artifacts = Vec::with_capacity(executable_block.transactions.len());
@@ -233,8 +239,7 @@ pub fn execute_finalized_block(
                     chainspec.transaction_config.native_transfer_minimum_motes * 5,
                 );
                 let pay_result = match WasmV1Request::new_custom_payment(
-                    state_root_hash,
-                    block_time,
+                    block_info,
                     custom_payment_gas_limit,
                     &transaction,
                 ) {
@@ -360,12 +365,7 @@ pub fn execute_finalized_block(
                 }
                 _ => {
                     let wasm_v1_start = Instant::now();
-                    match WasmV1Request::new_session(
-                        state_root_hash,
-                        block_time,
-                        gas_limit,
-                        &transaction,
-                    ) {
+                    match WasmV1Request::new_session(block_info, gas_limit, &transaction) {
                         Ok(wasm_v1_request) => {
                             trace!(%transaction_hash, ?category, ?wasm_v1_request, "able to get wasm v1 request");
                             let wasm_v1_result =
@@ -749,7 +749,7 @@ pub fn execute_finalized_block(
             protocol_version,
             state_root_hash,
             era_report.clone(),
-            executable_block.timestamp.millis(),
+            block_info.block_time().value(),
             executable_block.era_id.successor(),
         ) {
             StepResult::RootNotFound => {
@@ -802,7 +802,7 @@ pub fn execute_finalized_block(
 
     // Pruning -- this is orthogonal to the contents of the block, but we deliberately do it
     // at the end to avoid an read ordering issue during block execution.
-    if let Some(previous_block_height) = executable_block.height.checked_sub(1) {
+    if let Some(previous_block_height) = block_height.checked_sub(1) {
         if let Some(keys_to_prune) = calculate_prune_eras(
             activation_point_era_id,
             key_block_height_for_activation_point,
@@ -957,7 +957,7 @@ pub fn execute_finalized_block(
         era_end,
         executable_block.timestamp,
         executable_block.era_id,
-        executable_block.height,
+        block_height,
         protocol_version,
         (*proposer).clone(),
         executable_block.transaction_map,
@@ -1015,6 +1015,8 @@ where
     S: StateProvider,
 {
     let state_root_hash = block_header.state_root_hash();
+    let parent_block_hash = block_header.block_hash();
+    let block_height = block_header.height();
     let block_time = block_header
         .timestamp()
         .saturating_add(chainspec.core_config.minimum_block_time);
@@ -1050,15 +1052,19 @@ where
                 block_header.block_hash(),
             ))
         } else {
-            let wasm_v1_result = match WasmV1Request::new_session(
+            let block_info = BlockInfo::new(
                 *state_root_hash,
                 block_time.into(),
-                gas_limit,
-                &transaction,
-            ) {
-                Ok(wasm_v1_request) => execution_engine_v1.execute(state_provider, wasm_v1_request),
-                Err(error) => WasmV1Result::invalid_executable_item(gas_limit, error),
-            };
+                parent_block_hash,
+                block_height,
+            );
+            let wasm_v1_result =
+                match WasmV1Request::new_session(block_info, gas_limit, &transaction) {
+                    Ok(wasm_v1_request) => {
+                        execution_engine_v1.execute(state_provider, wasm_v1_request)
+                    }
+                    Err(error) => WasmV1Result::invalid_executable_item(gas_limit, error),
+                };
             SpeculativeExecutionResult::WasmV1(utils::spec_exec_from_wasm_v1_result(
                 wasm_v1_result,
                 block_header.block_hash(),

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -250,6 +250,7 @@ mod tests {
             manage_message_topic: HostFunction::new(100, [0, 1, 2, 4]),
             emit_message: HostFunction::new(100, [0, 1, 2, 3]),
             cost_increase_per_message: 50,
+            get_block_info: HostFunction::new(330, [0, 0]),
         });
     static EXPECTED_GENESIS_WASM_COSTS: Lazy<WasmConfig> = Lazy::new(|| {
         WasmConfig::new(

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -318,6 +318,7 @@ enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
 manage_message_topic = { cost = 200, arguments = [0, 30_000, 0, 0] }
 emit_message = { cost = 200, arguments = [0, 30_000, 0, 120_000] }
 cost_increase_per_message = 50
+get_block_info = { cost = 330, arguments = [0, 0] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -328,6 +328,7 @@ enable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
 manage_message_topic = { cost = 200, arguments = [0, 30_000, 0, 0] }
 emit_message = { cost = 200, arguments = [0, 30_000, 0, 120_000] }
 cost_increase_per_message = 50
+get_block_info = { cost = 330, arguments = [0, 0] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/smart_contracts/contract/src/contract_api/runtime.rs
+++ b/smart_contracts/contract/src/contract_api/runtime.rs
@@ -7,11 +7,11 @@ use casper_types::{
     account::AccountHash,
     addressable_entity::NamedKeys,
     api_error,
-    bytesrepr::{self, FromBytes},
+    bytesrepr::{self, FromBytes, U64_SERIALIZED_LENGTH},
     contract_messages::{MessagePayload, MessageTopicOperation},
     system::Caller,
-    AddressableEntityHash, ApiError, BlockTime, CLTyped, CLValue, EntityVersion, Key, PackageHash,
-    Phase, RuntimeArgs, URef, BLAKE2B_DIGEST_LENGTH, BLOCKTIME_SERIALIZED_LENGTH,
+    AddressableEntityHash, ApiError, BlockTime, CLTyped, CLValue, Digest, EntityVersion, Key,
+    PackageHash, Phase, RuntimeArgs, URef, BLAKE2B_DIGEST_LENGTH, BLOCKTIME_SERIALIZED_LENGTH,
     PHASE_SERIALIZED_LENGTH,
 };
 
@@ -247,6 +247,59 @@ pub fn get_blocktime() -> BlockTime {
             dest_non_null_ptr.as_ptr(),
             BLOCKTIME_SERIALIZED_LENGTH,
             BLOCKTIME_SERIALIZED_LENGTH,
+        )
+    };
+    bytesrepr::deserialize(bytes).unwrap_or_revert()
+}
+
+/// The default length of hashes such as account hash, state hash, hash addresses, etc.
+pub const DEFAULT_HASH_LENGTH: u8 = 32;
+/// Index for the block time field of block info.
+pub const BLOCK_TIME_FIELD_IDX: u8 = 0;
+/// Index for the block height field of block info.
+pub const BLOCK_HEIGHT_FIELD_IDX: u8 = 1;
+/// Index for the parent block hash field of block info.
+pub const PARENT_BLOCK_HASH_FIELD_IDX: u8 = 2;
+/// Index for the state hash field of block info.
+pub const STATE_HASH_FIELD_IDX: u8 = 3;
+
+/// Returns the block height.
+pub fn get_block_height() -> u64 {
+    let dest_non_null_ptr = contract_api::alloc_bytes(U64_SERIALIZED_LENGTH);
+    let bytes = unsafe {
+        ext_ffi::casper_get_block_info(BLOCK_HEIGHT_FIELD_IDX, dest_non_null_ptr.as_ptr());
+        Vec::from_raw_parts(
+            dest_non_null_ptr.as_ptr(),
+            U64_SERIALIZED_LENGTH,
+            U64_SERIALIZED_LENGTH,
+        )
+    };
+    bytesrepr::deserialize(bytes).unwrap_or_revert()
+}
+
+/// Returns the parent block hash.
+pub fn get_parent_block_hash() -> Digest {
+    let dest_non_null_ptr = contract_api::alloc_bytes(DEFAULT_HASH_LENGTH as usize);
+    let bytes = unsafe {
+        ext_ffi::casper_get_block_info(PARENT_BLOCK_HASH_FIELD_IDX, dest_non_null_ptr.as_ptr());
+        Vec::from_raw_parts(
+            dest_non_null_ptr.as_ptr(),
+            DEFAULT_HASH_LENGTH as usize,
+            DEFAULT_HASH_LENGTH as usize,
+        )
+    };
+    bytesrepr::deserialize(bytes).unwrap_or_revert()
+}
+
+/// Returns the state root hash.
+pub fn get_state_hash() -> Digest {
+    let dest_non_null_ptr = contract_api::alloc_bytes(DEFAULT_HASH_LENGTH as usize);
+    let bytes = unsafe {
+        ext_ffi::casper_get_block_info(STATE_HASH_FIELD_IDX, dest_non_null_ptr.as_ptr());
+        Vec::from_raw_parts(
+            dest_non_null_ptr.as_ptr(),
+            DEFAULT_HASH_LENGTH as usize,
+            DEFAULT_HASH_LENGTH as usize,
         )
     };
     bytesrepr::deserialize(bytes).unwrap_or_revert()

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -843,4 +843,18 @@ extern "C" {
         call_stack_len_ptr: *mut usize,
         result_size_ptr: *mut usize,
     ) -> i32;
+
+    /// This function gets the requested field at `field_ptr`. It is up to
+    /// the caller to ensure that the correct number of bytes for the field data
+    /// are allocated at `dest_ptr`, otherwise data corruption in the wasm memory may occur.
+    ///
+    /// # Arguments
+    ///
+    /// * `field_ptr` - what info field is requested?
+    ///     0 => block time (functionally equivalent to earlier get_blocktime ffi)
+    ///     1 => block height
+    ///     2 => parent block hash
+    ///     3 => state hash
+    /// * `dest_ptr` => pointer in wasm memory where to write the result
+    pub fn casper_get_block_info(field_idx: u8, dest_ptr: *const u8);
 }

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -844,13 +844,13 @@ extern "C" {
         result_size_ptr: *mut usize,
     ) -> i32;
 
-    /// This function gets the requested field at `field_ptr`. It is up to
+    /// This function gets the requested field at `field_idx`. It is up to
     /// the caller to ensure that the correct number of bytes for the field data
     /// are allocated at `dest_ptr`, otherwise data corruption in the wasm memory may occur.
     ///
     /// # Arguments
     ///
-    /// * `field_ptr` - what info field is requested?
+    /// * `field_idx` - what info field is requested?
     ///     0 => block time (functionally equivalent to earlier get_blocktime ffi)
     ///     1 => block height
     ///     2 => parent block hash

--- a/smart_contracts/contract/src/ext_ffi.rs
+++ b/smart_contracts/contract/src/ext_ffi.rs
@@ -851,10 +851,10 @@ extern "C" {
     /// # Arguments
     ///
     /// * `field_idx` - what info field is requested?
-    ///     0 => block time (functionally equivalent to earlier get_blocktime ffi)
-    ///     1 => block height
-    ///     2 => parent block hash
-    ///     3 => state hash
+    /// * 0 => block time (functionally equivalent to earlier get_blocktime ffi)
+    /// * 1 => block height
+    /// * 2 => parent block hash
+    /// * 3 => state hash
     /// * `dest_ptr` => pointer in wasm memory where to write the result
     pub fn casper_get_block_info(field_idx: u8, dest_ptr: *const u8);
 }

--- a/smart_contracts/contracts/test/get-blockinfo/Cargo.toml
+++ b/smart_contracts/contracts/test/get-blockinfo/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "get-blockinfo"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2021"
+
+[[bin]]
+name = "get_blockinfo"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/get-blockinfo/src/main.rs
+++ b/smart_contracts/contracts/test/get-blockinfo/src/main.rs
@@ -1,0 +1,60 @@
+#![no_std]
+#![no_main]
+
+use casper_contract::contract_api::runtime;
+use casper_contract::contract_api::runtime::revert;
+use casper_contract::unwrap_or_revert::UnwrapOrRevert;
+use casper_types::bytesrepr::{Bytes, FromBytes};
+use casper_types::{ApiError, BlockTime, Digest};
+
+const ARG_FIELD_IDX: &str = "field_idx";
+const FIELD_IDX_BLOCK_TIME: u8 = 0;
+const FIELD_IDX_BLOCK_HEIGHT: u8 = 1;
+const FIELD_IDX_PARENT_BLOCK_HASH: u8 = 2;
+const FIELD_IDX_STATE_HASH: u8 = 3;
+
+const CURRENT_UBOUND: u8 = FIELD_IDX_STATE_HASH;
+const ARG_KNOWN_BLOCK_TIME: &str = "known_block_time";
+const ARG_KNOWN_BLOCK_HEIGHT: &str = "known_block_height";
+const ARG_KNOWN_BLOCK_PARENT_HASH: &str = "known_block_parent_hash";
+const ARG_KNOWN_STATE_HASH: &str = "known_state_hash";
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let field_idx: u8 = runtime::get_named_arg(ARG_FIELD_IDX);
+    if field_idx > CURRENT_UBOUND {
+        revert(ApiError::Unhandled);
+    }
+    if field_idx == FIELD_IDX_BLOCK_TIME {
+        let expected = BlockTime::new(runtime::get_named_arg(ARG_KNOWN_BLOCK_TIME));
+        let actual: BlockTime = runtime::get_blocktime();
+        if expected != actual {
+            revert(ApiError::User(field_idx as u16));
+        }
+    }
+    if field_idx == FIELD_IDX_BLOCK_HEIGHT {
+        let expected: u64 = runtime::get_named_arg(ARG_KNOWN_BLOCK_HEIGHT);
+        let actual = runtime::get_block_height();
+        if expected != actual {
+            revert(ApiError::User(field_idx as u16));
+        }
+    }
+    if field_idx == FIELD_IDX_PARENT_BLOCK_HASH {
+        let bytes: Bytes = runtime::get_named_arg(ARG_KNOWN_BLOCK_PARENT_HASH);
+        let (expected, _rem) = Digest::from_bytes(bytes.inner_bytes())
+            .unwrap_or_revert_with(ApiError::User(CURRENT_UBOUND as u16 + 1));
+        let actual = runtime::get_parent_block_hash();
+        if expected != actual {
+            revert(ApiError::User(field_idx as u16));
+        }
+    }
+    if field_idx == FIELD_IDX_STATE_HASH {
+        let bytes: Bytes = runtime::get_named_arg(ARG_KNOWN_STATE_HASH);
+        let (expected, _rem) = Digest::from_bytes(bytes.inner_bytes())
+            .unwrap_or_revert_with(ApiError::User(CURRENT_UBOUND as u16 + 2));
+        let actual = runtime::get_state_hash();
+        if expected != actual {
+            revert(ApiError::User(field_idx as u16));
+        }
+    }
+}

--- a/smart_contracts/contracts/test/get-blockinfo/src/main.rs
+++ b/smart_contracts/contracts/test/get-blockinfo/src/main.rs
@@ -1,11 +1,14 @@
 #![no_std]
 #![no_main]
 
-use casper_contract::contract_api::runtime;
-use casper_contract::contract_api::runtime::revert;
-use casper_contract::unwrap_or_revert::UnwrapOrRevert;
-use casper_types::bytesrepr::{Bytes, FromBytes};
-use casper_types::{ApiError, BlockTime, Digest};
+use casper_contract::{
+    contract_api::{runtime, runtime::revert},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::{
+    bytesrepr::{Bytes, FromBytes},
+    ApiError, BlockTime, Digest,
+};
 
 const ARG_FIELD_IDX: &str = "field_idx";
 const FIELD_IDX_BLOCK_TIME: u8 = 0;

--- a/types/src/chainspec/vm_config/host_function_costs.rs
+++ b/types/src/chainspec/vm_config/host_function_costs.rs
@@ -337,6 +337,8 @@ pub struct HostFunctionCosts {
     pub manage_message_topic: HostFunction<[Cost; 4]>,
     /// Cost of calling the `casper_emit_message` host function.
     pub emit_message: HostFunction<[Cost; 4]>,
+    /// Cost of calling the `get_block_info` host function.
+    pub get_block_info: HostFunction<[Cost; 2]>,
 }
 
 impl Zero for HostFunctionCosts {
@@ -390,6 +392,7 @@ impl Zero for HostFunctionCosts {
             manage_message_topic: HostFunction::zero(),
             emit_message: HostFunction::zero(),
             cost_increase_per_message: Zero::zero(),
+            get_block_info: HostFunction::zero(),
         }
     }
 
@@ -443,6 +446,7 @@ impl Zero for HostFunctionCosts {
             enable_contract_version,
             manage_message_topic,
             emit_message,
+            get_block_info,
         } = self;
         read_value.is_zero()
             && dictionary_get.is_zero()
@@ -492,6 +496,7 @@ impl Zero for HostFunctionCosts {
             && emit_message.is_zero()
             && cost_increase_per_message.is_zero()
             && add_package_version.is_zero()
+            && get_block_info.is_zero()
     }
 }
 
@@ -679,6 +684,7 @@ impl Default for HostFunctionCosts {
                 ],
             ),
             cost_increase_per_message: DEFAULT_COST_INCREASE_PER_MESSAGE_EMITTED,
+            get_block_info: HostFunction::new(DEFAULT_FIXED_COST, [NOT_USED, NOT_USED]),
         }
     }
 }
@@ -734,6 +740,7 @@ impl ToBytes for HostFunctionCosts {
         ret.append(&mut self.manage_message_topic.to_bytes()?);
         ret.append(&mut self.emit_message.to_bytes()?);
         ret.append(&mut self.cost_increase_per_message.to_bytes()?);
+        ret.append(&mut self.get_block_info.to_bytes()?);
         Ok(ret)
     }
 
@@ -786,6 +793,7 @@ impl ToBytes for HostFunctionCosts {
             + self.manage_message_topic.serialized_length()
             + self.emit_message.serialized_length()
             + self.cost_increase_per_message.serialized_length()
+            + self.get_block_info.serialized_length()
     }
 }
 
@@ -839,6 +847,7 @@ impl FromBytes for HostFunctionCosts {
         let (manage_message_topic, rem) = FromBytes::from_bytes(rem)?;
         let (emit_message, rem) = FromBytes::from_bytes(rem)?;
         let (cost_increase_per_message, rem) = FromBytes::from_bytes(rem)?;
+        let (get_block_info, rem) = FromBytes::from_bytes(rem)?;
         Ok((
             HostFunctionCosts {
                 read_value,
@@ -889,6 +898,7 @@ impl FromBytes for HostFunctionCosts {
                 manage_message_topic,
                 emit_message,
                 cost_increase_per_message,
+                get_block_info,
             },
             rem,
         ))
@@ -947,6 +957,7 @@ impl Distribution<HostFunctionCosts> for Standard {
             manage_message_topic: rng.gen(),
             emit_message: rng.gen(),
             cost_increase_per_message: rng.gen(),
+            get_block_info: rng.gen(),
         }
     }
 }
@@ -1014,6 +1025,7 @@ pub mod gens {
             manage_message_topic in host_function_cost_arb(),
             emit_message in host_function_cost_arb(),
             cost_increase_per_message in num::u32::ANY,
+            get_block_info in host_function_cost_arb(),
         ) -> HostFunctionCosts {
             HostFunctionCosts {
                 read_value,
@@ -1064,6 +1076,7 @@ pub mod gens {
                 manage_message_topic,
                 emit_message,
                 cost_increase_per_message,
+                get_block_info
             }
         }
     }


### PR DESCRIPTION
This PR adds block info support to the ExecutionEngine and Casper VM. Wasm based logic can request the following fields via a new ffi method directly:

    /// This function gets the requested field at `field_idx`. It is up to
    /// the caller to ensure that the correct number of bytes for the field data
    /// are allocated at `dest_ptr`, otherwise data corruption in the wasm memory may occur.
    ///
    /// # Arguments
    ///
    /// * `field_idx` - what info field is requested?
    ///     0 => block time (functionally equivalent to earlier get_blocktime ffi)
    ///     1 => block height
    ///     2 => parent block hash
    ///     3 => state hash
    /// * `dest_ptr` => pointer in wasm memory where to write the result
    pub fn casper_get_block_info(field_idx: u8, dest_ptr: *const u8);

Alternately, the following convenience methods in the contract api offer easy access to each of the four fields, handling the ffi interactions for the user:
* get_blocktime() -> BlockTime (pre-existing)
* get_block_height() -> u64
* get_parent_block_hash() -> Digest
* get_state_hash() -> Digest

This new mechanism is extensible, and we may add more fields in future releases.