### PR TITLE
Remove unchecked arithmetic

### DIFF
--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -3286,7 +3286,9 @@ where
     where
         T: AsRef<[HostFunctionCost]> + Copy,
     {
-        let cost = host_function.calculate_gas_cost(weights);
+        let cost = host_function
+            .calculate_gas_cost(weights)
+            .ok_or(ExecError::GasLimit)?; // Overflowing gas calculation means gas limit was exceeded
         self.gas(cost)?;
         Ok(())
     }

--- a/execution_engine/src/runtime_context/tests.rs
+++ b/execution_engine/src/runtime_context/tests.rs
@@ -993,7 +993,10 @@ fn should_meter_for_gas_storage_write() {
         gas_usage_before
     );
 
-    assert_eq!(gas_usage_after, gas_usage_before + expected_write_cost);
+    assert_eq!(
+        Some(gas_usage_after),
+        gas_usage_before.checked_add(expected_write_cost)
+    );
 }
 
 #[test]
@@ -1029,7 +1032,10 @@ fn should_meter_for_gas_storage_add() {
         gas_usage_before
     );
 
-    assert_eq!(gas_usage_after, gas_usage_before + expected_add_cost);
+    assert_eq!(
+        Some(gas_usage_after),
+        gas_usage_before.checked_add(expected_add_cost)
+    );
 }
 
 #[test]

--- a/execution_engine_testing/tests/src/test/check_transfer_success.rs
+++ b/execution_engine_testing/tests/src/test/check_transfer_success.rs
@@ -72,8 +72,10 @@ fn test_check_transfer_success_with_source_only() {
 
     let transaction_fee = builder.get_proposer_purse_balance() - proposer_starting_balance;
     let expected_source_ending_balance = Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE)
-        - Motes::new(transfer_amount)
-        - Motes::new(transaction_fee);
+        .checked_sub(Motes::new(transfer_amount))
+        .unwrap()
+        .checked_sub(Motes::new(transaction_fee))
+        .unwrap();
     let actual_source_ending_balance = Motes::new(builder.get_purse_balance(source_purse));
 
     assert_eq!(expected_source_ending_balance, actual_source_ending_balance);
@@ -133,8 +135,10 @@ fn test_check_transfer_success_with_source_only_errors() {
 
     let transaction_fee = builder.get_proposer_purse_balance() - proposer_starting_balance;
     let expected_source_ending_balance = Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE)
-        - Motes::new(transfer_amount)
-        - Motes::new(transaction_fee);
+        .checked_sub(Motes::new(transfer_amount))
+        .unwrap()
+        .checked_sub(Motes::new(transaction_fee))
+        .unwrap();
     let actual_source_ending_balance = Motes::new(builder.get_purse_balance(source_purse));
 
     assert!(expected_source_ending_balance != actual_source_ending_balance);
@@ -191,8 +195,10 @@ fn test_check_transfer_success_with_source_and_target() {
 
     let transaction_fee = builder.get_proposer_purse_balance() - proposer_starting_balance;
     let expected_source_ending_balance = Motes::new(DEFAULT_ACCOUNT_INITIAL_BALANCE)
-        - Motes::new(transfer_amount)
-        - Motes::new(transaction_fee);
+        .checked_sub(Motes::new(transfer_amount))
+        .unwrap()
+        .checked_sub(Motes::new(transaction_fee))
+        .unwrap();
     let actual_source_ending_balance = Motes::new(builder.get_purse_balance(source_purse));
 
     assert_eq!(expected_source_ending_balance, actual_source_ending_balance);

--- a/execution_engine_testing/tests/src/test/gas_counter.rs
+++ b/execution_engine_testing/tests/src/test/gas_counter.rs
@@ -163,7 +163,12 @@ fn should_correctly_measure_gas_for_opcodes() {
     builder.exec(exec_request).commit().expect_success();
 
     let gas_cost = builder.last_exec_gas_cost();
-    let expected_cost = accounted_opcodes.clone().into_iter().map(Gas::from).sum();
+    let expected_cost = accounted_opcodes
+        .clone()
+        .into_iter()
+        .map(Gas::from)
+        .try_fold(Gas::default(), |acc, cost| acc.checked_add(cost))
+        .expect("should add gas costs");
     assert_eq!(
         gas_cost, expected_cost,
         "accounted costs {:?}",

--- a/execution_engine_testing/tests/src/test/regression/ee_598.rs
+++ b/execution_engine_testing/tests/src/test/regression/ee_598.rs
@@ -38,7 +38,9 @@ fn should_handle_unbond_for_more_than_stake_as_full_unbond_of_stake_ee_598_regre
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account = GenesisAccount::account(
             public_key,
-            Motes::new(GENESIS_VALIDATOR_STAKE) * Motes::new(2),
+            Motes::new(GENESIS_VALIDATOR_STAKE)
+                .checked_mul(Motes::new(2))
+                .unwrap(),
             Some(GenesisValidator::new(
                 Motes::new(GENESIS_VALIDATOR_STAKE),
                 DelegationRate::zero(),

--- a/execution_engine_testing/tests/src/test/regression/slow_input.rs
+++ b/execution_engine_testing/tests/src/test/regression/slow_input.rs
@@ -172,8 +172,10 @@ fn should_charge_extra_per_amount_of_br_table_elements() {
     );
 
     assert_eq!(
-        gas_cost_2 - gas_cost_1,
-        Gas::from((M_ELEMENTS - N_ELEMENTS) * DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER),
+        gas_cost_2.checked_sub(gas_cost_1),
+        Some(Gas::from(
+            (M_ELEMENTS - N_ELEMENTS) * DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER
+        )),
         "the cost difference should equal to exactly the size of br_table difference "
     );
 }

--- a/node/src/types/appendable_block.rs
+++ b/node/src/types/appendable_block.rs
@@ -215,7 +215,12 @@ impl Display for AppendableBlock {
         let auction_count = self.category_count(AUCTION_LANE_ID);
         let install_upgrade_count = self.category_count(INSTALL_UPGRADE_LANE_ID);
         let wasm_count = total_count - mint_count - auction_count - install_upgrade_count;
-        let total_gas_limit: Gas = self.transactions.values().map(|f| f.gas_limit).sum();
+        let total_gas_limit: Gas = self
+            .transactions
+            .values()
+            .map(|f| f.gas_limit)
+            .try_fold(Gas::new(0), |acc, gas| acc.checked_add(gas))
+            .unwrap_or(Gas::MAX);
         let total_approvals_count: usize = self
             .transactions
             .values()

--- a/storage/src/system/genesis.rs
+++ b/storage/src/system/genesis.rs
@@ -360,7 +360,7 @@ where
         for (validator_public_key, delegator_public_key, _, delegated_amount) in
             genesis_delegators.iter()
         {
-            if delegated_amount.is_zero() {
+            if *delegated_amount == &Motes::zero() {
                 return Err(GenesisError::InvalidDelegatedAmount {
                     public_key: (*delegator_public_key).clone(),
                 }

--- a/types/src/chainspec/vm_config/host_function_costs.rs
+++ b/types/src/chainspec/vm_config/host_function_costs.rs
@@ -156,14 +156,15 @@ where
     }
 
     /// Calculate gas cost for a host function
-    pub fn calculate_gas_cost(&self, weights: T) -> Gas {
+    pub fn calculate_gas_cost(&self, weights: T) -> Option<Gas> {
         let mut gas = Gas::new(self.cost);
         for (argument, weight) in self.arguments.as_ref().iter().zip(weights.as_ref()) {
             let lhs = Gas::new(*argument);
             let rhs = Gas::new(*weight);
-            gas += lhs * rhs;
+            let product = lhs.checked_mul(rhs)?;
+            gas = gas.checked_add(product)?;
         }
-        gas
+        Some(gas)
     }
 }
 
@@ -1088,7 +1089,7 @@ mod tests {
             + (ARGUMENT_COSTS[2] * WEIGHTS[2]);
         assert_eq!(
             host_function.calculate_gas_cost(WEIGHTS),
-            Gas::new(expected_cost)
+            Some(Gas::new(expected_cost))
         );
     }
 
@@ -1107,7 +1108,7 @@ mod tests {
         let large_value = U512::from(large_value);
         let rhs = large_value + (U512::from(4) * large_value * large_value);
 
-        assert_eq!(lhs, Gas::new(rhs));
+        assert_eq!(lhs, Some(Gas::new(rhs)));
     }
 }
 

--- a/types/src/execution/execution_result_v2.rs
+++ b/types/src/execution/execution_result_v2.rs
@@ -146,7 +146,9 @@ impl ExecutionResultV2 {
         let range = limit.value().as_u64();
 
         // can range from 0 to limit
-        let consumed = limit - Gas::new(rng.gen_range(0..=range));
+        let consumed = limit
+            .checked_sub(Gas::new(rng.gen_range(0..=range)))
+            .expect("consumed");
         let size_estimate = rng.gen();
 
         let payment = vec![PaymentInfo { source: rng.gen() }];

--- a/types/src/motes.rs
+++ b/types/src/motes.rs
@@ -1,15 +1,10 @@
 //! The `motes` module is used for working with Motes.
 
 use alloc::vec::Vec;
-use core::{
-    fmt,
-    iter::Sum,
-    ops::{Add, Div, Mul, Sub},
-};
+use core::fmt;
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
-use num::Zero;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -23,6 +18,9 @@ use crate::{
 pub struct Motes(U512);
 
 impl Motes {
+    /// The maximum value of `Motes`.
+    pub const MAX: Motes = Motes(U512::MAX);
+
     /// Constructs a new `Motes`.
     pub fn new<T: Into<U512>>(value: T) -> Self {
         Motes(value.into())
@@ -41,6 +39,17 @@ impl Motes {
     /// Checked integer subtraction. Computes `self - rhs`, returning `None` if underflow occurred.
     pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
         self.0.checked_sub(rhs.value()).map(Self::new)
+    }
+
+    /// Checked integer multiplication. Computes `self * rhs`, returning `None` if overflow
+    /// occurred.
+    pub fn checked_mul(&self, rhs: Self) -> Option<Self> {
+        self.0.checked_mul(rhs.value()).map(Self::new)
+    }
+
+    /// Checked integer division. Computes `self / rhs`, returning `None` if `rhs == 0`.
+    pub fn checked_div(&self, rhs: Self) -> Option<Self> {
+        self.0.checked_div(rhs.value()).map(Self::new)
     }
 
     /// Returns the inner `U512` value.
@@ -68,58 +77,6 @@ impl Motes {
 impl fmt::Display for Motes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
-    }
-}
-
-impl Add for Motes {
-    type Output = Motes;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        let val = self.value() + rhs.value();
-        Motes::new(val)
-    }
-}
-
-impl Sub for Motes {
-    type Output = Motes;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        let val = self.value() - rhs.value();
-        Motes::new(val)
-    }
-}
-
-impl Div for Motes {
-    type Output = Motes;
-
-    fn div(self, rhs: Self) -> Self::Output {
-        let val = self.value() / rhs.value();
-        Motes::new(val)
-    }
-}
-
-impl Mul for Motes {
-    type Output = Motes;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        let val = self.value() * rhs.value();
-        Motes::new(val)
-    }
-}
-
-impl Zero for Motes {
-    fn zero() -> Self {
-        Motes::zero()
-    }
-
-    fn is_zero(&self) -> bool {
-        self.0.is_zero()
-    }
-}
-
-impl Sum for Motes {
-    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Motes::zero(), Add::add)
     }
 }
 
@@ -172,8 +129,8 @@ mod tests {
         let right_motes = Motes::new(1);
         let expected_motes = Motes::new(2);
         assert_eq!(
-            (left_motes + right_motes),
-            expected_motes,
+            left_motes.checked_add(right_motes),
+            Some(expected_motes),
             "should be equal"
         )
     }
@@ -184,8 +141,8 @@ mod tests {
         let right_motes = Motes::new(1);
         let expected_motes = Motes::new(0);
         assert_eq!(
-            (left_motes - right_motes),
-            expected_motes,
+            left_motes.checked_sub(right_motes),
+            Some(expected_motes),
             "should be equal"
         )
     }
@@ -196,8 +153,8 @@ mod tests {
         let right_motes = Motes::new(10);
         let expected_motes = Motes::new(1000);
         assert_eq!(
-            (left_motes * right_motes),
-            expected_motes,
+            left_motes.checked_mul(right_motes),
+            Some(expected_motes),
             "should be equal"
         )
     }
@@ -208,8 +165,8 @@ mod tests {
         let right_motes = Motes::new(100);
         let expected_motes = Motes::new(10);
         assert_eq!(
-            (left_motes / right_motes),
-            expected_motes,
+            left_motes.checked_div(right_motes),
+            Some(expected_motes),
             "should be equal"
         )
     }


### PR DESCRIPTION
Closes #2103 

This PR removes unchecked arithmetic operations. Although nearly impossible this is for correctness reason to avoid using unchecked math even on large numbers.