### PR TITLE
Fix handling zero bids in forced_undelegate

### DIFF
--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -823,8 +823,7 @@ fn should_forcibly_undelegate_after_setting_validator_limits() {
     builder.forced_undelegate(None, DEFAULT_PROTOCOL_VERSION, DEFAULT_BLOCK_TIME);
 
     let bids = builder.get_bids();
-    // The undelegation itself doesn't remove bids, only process_unbond does.
-    assert_eq!(bids.len(), 3);
+    assert_eq!(bids.len(), 2);
 
     assert!(builder.get_validator_weights(new_era + 1).is_none());
 

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -441,20 +441,32 @@ pub trait Auction:
                         amount,
                         None,
                     )?;
-                    match delegator.decrease_stake(amount, era_end_timestamp_millis) {
-                        Ok(_) => (),
-                        // Work around the case when the locked amounts table has yet to be
-                        // initialized (likely pre-90 day mark).
-                        Err(Error::DelegatorFundsLocked) => continue,
-                        Err(err) => return Err(err),
-                    }
+                    let updated_stake =
+                        match delegator.decrease_stake(amount, era_end_timestamp_millis) {
+                            Ok(updated_stake) => updated_stake,
+                            // Work around the case when the locked amounts table has yet to be
+                            // initialized (likely pre-90 day mark).
+                            Err(Error::DelegatorFundsLocked) => continue,
+                            Err(err) => return Err(err),
+                        };
                     let delegator_bid_addr = BidAddr::new_from_public_keys(
                         validator_public_key,
                         Some(&delegator_public_key),
                     );
 
-                    debug!("pruning delegator bid {}", delegator_bid_addr);
-                    self.prune_bid(delegator_bid_addr);
+                    if updated_stake.is_zero() {
+                        debug!("pruning delegator bid {}", delegator_bid_addr);
+                        self.prune_bid(delegator_bid_addr);
+                    } else {
+                        debug!(
+                            "forced undelegation for {} reducing {} by {} to {}",
+                            delegator_bid_addr, staked_amount, amount, updated_stake
+                        );
+                        self.write_bid(
+                            delegator_bid_addr.into(),
+                            BidKind::Delegator(Box::new(delegator)),
+                        )?;
+                    }
                 }
             }
         }

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -415,11 +415,16 @@ pub trait Auction:
             for mut delegator in delegators {
                 let staked_amount = delegator.staked_amount();
                 if staked_amount.is_zero() {
-                    // A delegator who has unbonded - nothing to do here, this will be removed when
-                    // unbonding is processed.
-                    continue;
-                }
-                if staked_amount < minimum_delegation_amount
+                    // If the stake is zero, we don't need to unbond anything - we can just prune
+                    // the bid outright. Also, we don't want to keep zero bids even if the minimum
+                    // allowed amount is zero, as they only use up space for no reason.
+                    let delegator_bid_addr = BidAddr::new_from_public_keys(
+                        validator_public_key,
+                        Some(delegator.delegator_public_key()),
+                    );
+                    debug!("pruning delegator bid {}", delegator_bid_addr);
+                    self.prune_bid(delegator_bid_addr);
+                } else if staked_amount < minimum_delegation_amount
                     || staked_amount > maximum_delegation_amount
                 {
                     let amount = if staked_amount < minimum_delegation_amount {
@@ -436,29 +441,20 @@ pub trait Auction:
                         amount,
                         None,
                     )?;
-                    let updated_stake =
-                        match delegator.decrease_stake(amount, era_end_timestamp_millis) {
-                            Ok(updated_stake) => updated_stake,
-                            // Work around the case when the locked amounts table has yet to be
-                            // initialized (likely pre-90 day mark).
-                            Err(Error::DelegatorFundsLocked) => continue,
-                            Err(err) => return Err(err),
-                        };
+                    match delegator.decrease_stake(amount, era_end_timestamp_millis) {
+                        Ok(_) => (),
+                        // Work around the case when the locked amounts table has yet to be
+                        // initialized (likely pre-90 day mark).
+                        Err(Error::DelegatorFundsLocked) => continue,
+                        Err(err) => return Err(err),
+                    }
                     let delegator_bid_addr = BidAddr::new_from_public_keys(
                         validator_public_key,
                         Some(&delegator_public_key),
                     );
 
-                    debug!(
-                        "forced undelegation for {} reducing {} by {} to {}",
-                        delegator_bid_addr, staked_amount, amount, updated_stake
-                    );
-
-                    // Keep the bid for now - it will get pruned when the unbonds are processed.
-                    self.write_bid(
-                        delegator_bid_addr.into(),
-                        BidKind::Delegator(Box::new(delegator)),
-                    )?;
+                    debug!("pruning delegator bid {}", delegator_bid_addr);
+                    self.prune_bid(delegator_bid_addr);
                 }
             }
         }


### PR DESCRIPTION
This PR reverts a change from #4802 left in by mistake (should have been reverted in #4827).

It also makes sure that we always prune zero bids, even if the minimum delegation amount allowed by a validator is zero.

Closes #4920

