### PR TITLE
Adjusted binary port default config settings

### DIFF
--- a/node/src/components/binary_port/config.rs
+++ b/node/src/components/binary_port/config.rs
@@ -6,9 +6,9 @@ const DEFAULT_ADDRESS: &str = "0.0.0.0:0";
 /// Default maximum message size.
 const DEFAULT_MAX_MESSAGE_SIZE: u32 = 4 * 1024 * 1024;
 /// Default maximum number of connections.
-const DEFAULT_MAX_CONNECTIONS: usize = 16;
+const DEFAULT_MAX_CONNECTIONS: usize = 5;
 /// Default maximum number of requests per second.
-const DEFAULT_MAX_QPS: usize = 100;
+const DEFAULT_QPS_LIMIT: usize = 110;
 
 /// Binary port server configuration.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -46,7 +46,7 @@ impl Config {
             allow_request_speculative_exec: false,
             max_message_size_bytes: DEFAULT_MAX_MESSAGE_SIZE,
             max_connections: DEFAULT_MAX_CONNECTIONS,
-            qps_limit: DEFAULT_MAX_QPS,
+            qps_limit: DEFAULT_QPS_LIMIT,
         }
     }
 }

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -321,11 +321,11 @@ allow_request_speculative_exec = false
 max_message_size_bytes = 4_194_304
 
 # Maximum number of connections to the server.
-max_connections = 16
+max_connections = 5
 
 # The global max rate of requests (per second) before they are limited.
 # The implementation uses a sliding window algorithm.
-qps_limit = 100
+qps_limit = 110
 
 # ==============================================
 # Configuration options for the REST HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -321,11 +321,11 @@ allow_request_speculative_exec = false
 max_message_size_bytes = 4_194_304
 
 # Maximum number of connections to the server.
-max_connections = 16
+max_connections = 5
 
 # The global max rate of requests (per second) before they are limited.
 # The implementation uses a sliding window algorithm.
-qps_limit = 10
+qps_limit = 110
 
 # ==============================================
 # Configuration options for the REST HTTP server
@@ -345,7 +345,7 @@ address = '0.0.0.0:8888'
 
 # The global max rate of requests (per second) before they are limited.
 # Request will be delayed to the next 1 second bucket once limited.
-qps_limit = 10
+qps_limit = 100
 
 # Specifies which origin will be reported as allowed by REST server.
 #


### PR DESCRIPTION
Lowered the "default" number of max concurrent binary port connections to `5` and bumped `qps_limit` on binary port to 110. These numbers should be revised on a case-by-case basis of each node deployment.