### PR TITLE
Adding checks on GetRequest::Record check to make sure that we don't …

### DIFF
--- a/binary_port/Cargo.toml
+++ b/binary_port/Cargo.toml
@@ -21,13 +21,13 @@ schemars = { version = "0.8.16", features = ["preserve_order", "impl_json_schema
 bincode = "1.3.3"
 rand = "0.8.3"
 tokio-util = { version = "0.6.4", features = ["codec"] }
+strum = "0.26.2"
+strum_macros = "0.26.4"
 
 [dev-dependencies]
 casper-types = { path = "../types", features = ["datasize", "json-schema", "std", "testing"] }
 serde_json = "1"
 serde_test = "1"
-strum = "0.26.2"
-strum_macros = "0.26.4"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/binary_port/src/record_id.rs
+++ b/binary_port/src/record_id.rs
@@ -6,10 +6,15 @@ use serde::Serialize;
 
 #[cfg(test)]
 use casper_types::testing::TestRng;
+#[cfg(any(feature = "testing", test))]
+use strum::IntoEnumIterator;
+#[cfg(any(feature = "testing", test))]
+use strum_macros::EnumIter;
 
 /// An identifier of a record type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize)]
 #[repr(u16)]
+#[cfg_attr(any(feature = "testing", test), derive(EnumIter))]
 pub enum RecordId {
     /// Refers to `BlockHeader` record.
     BlockHeader = 0,
@@ -43,6 +48,10 @@ impl RecordId {
             7 => RecordId::FinalizedTransactionApprovals,
             _ => unreachable!(),
         }
+    }
+    #[cfg(any(feature = "testing", test))]
+    pub fn all() -> impl Iterator<Item = RecordId> {
+        RecordId::iter()
     }
 }
 

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -247,6 +247,9 @@ where
             key,
         } if RecordId::try_from(record_type_tag) == Ok(RecordId::Transfer) => {
             metrics.binary_port_get_record_count.inc();
+            if key.is_empty() {
+                return BinaryResponse::new_empty(protocol_version);
+            }
             let Ok(block_hash) = bytesrepr::deserialize_from_slice(&key) else {
                 debug!("received an incorrectly serialized key for a transfer record");
                 return BinaryResponse::new_error(ErrorCode::BadRequest, protocol_version);
@@ -267,6 +270,9 @@ where
             key,
         } => {
             metrics.binary_port_get_record_count.inc();
+            if key.is_empty() {
+                return BinaryResponse::new_empty(protocol_version);
+            }
             match RecordId::try_from(record_type_tag) {
                 Ok(record_id) => {
                     let Some(db_bytes) = effect_builder.get_raw_data(record_id, key).await else {

--- a/storage/src/block_store/lmdb/indexed_lmdb_block_store.rs
+++ b/storage/src/block_store/lmdb/indexed_lmdb_block_store.rs
@@ -895,6 +895,9 @@ impl<'t> DataReader<(DbTableId, Vec<u8>), DbRawBytesSpec>
         &self,
         (id, key): (DbTableId, Vec<u8>),
     ) -> Result<Option<DbRawBytesSpec>, BlockStoreError> {
+        if key.is_empty() {
+            return Ok(None);
+        }
         let store = &self.block_store.block_store;
         let res = match id {
             DbTableId::BlockHeader => store.block_header_dbs.get_raw(&self.txn, &key),

--- a/storage/src/block_store/lmdb/versioned_databases.rs
+++ b/storage/src/block_store/lmdb/versioned_databases.rs
@@ -175,6 +175,9 @@ where
         txn: &Tx,
         key: &[u8],
     ) -> Result<Option<DbRawBytesSpec>, LmdbExtError> {
+        if key.is_empty() {
+            return Ok(None);
+        }
         let value = txn.get(self.current, &key);
         match value {
             Ok(raw_bytes) => Ok(Some(DbRawBytesSpec::new_current(raw_bytes))),
@@ -583,5 +586,14 @@ mod tests {
             .dbs
             .for_each_value_in_legacy(&mut txn, &mut visitor)
             .unwrap();
+    }
+
+    #[test]
+    fn should_get_on_empty_key() {
+        let fixture = Fixture::new();
+        let txn = fixture.env.begin_ro_txn().unwrap();
+        let key = vec![];
+        let res = fixture.dbs.get_raw(&txn, &key);
+        assert!(matches!(res, Ok(None)));
     }
 }


### PR DESCRIPTION
…pass empty key fetches to lmdb storage (which results in a non-recoverable crash). Also changed DataReader and VersionedDatabases to reflect the same check.
