### PR TITLE
Introduced keep alive monitor mechanism in the binary port. Introduce…

### DIFF
--- a/binary_port/src/binary_request.rs
+++ b/binary_port/src/binary_request.rs
@@ -132,7 +132,8 @@ pub enum BinaryRequest {
         /// Transaction to execute.
         transaction: Transaction,
     },
-    /// Minimalistic request to keep the connection alive if the client wants to have a long running connection.
+    /// Minimalistic request to keep the connection alive if the client wants to have a long
+    /// running connection.
     KeepAliveRequest,
 }
 

--- a/binary_port/src/response_type.rs
+++ b/binary_port/src/response_type.rs
@@ -119,6 +119,8 @@ pub enum ResponseType {
     PackageWithProof,
     /// Addressable entity information.
     AddressableEntityInformation,
+    /// Response to KeepAliveRequest query
+    KeepAliveInformation,
 }
 
 impl ResponseType {
@@ -226,6 +228,9 @@ impl TryFrom<u8> for ResponseType {
             x if x == ResponseType::AddressableEntityInformation as u8 => {
                 Ok(ResponseType::AddressableEntityInformation)
             }
+            x if x == ResponseType::KeepAliveInformation as u8 => {
+                Ok(ResponseType::KeepAliveInformation)
+            }
             _ => Err(()),
         }
     }
@@ -287,6 +292,9 @@ impl fmt::Display for ResponseType {
             ResponseType::PackageWithProof => write!(f, "PackageWithProof"),
             ResponseType::AddressableEntityInformation => {
                 write!(f, "AddressableEntityInformation")
+            }
+            ResponseType::KeepAliveInformation => {
+                write!(f, "KeepAliveInformation")
             }
         }
     }

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -2,6 +2,7 @@
 mod config;
 mod error;
 mod event;
+mod keep_alive_monitor;
 mod metrics;
 mod rate_limiter;
 #[cfg(test)]
@@ -42,6 +43,7 @@ use casper_types::{
     ContractWasmHash, Digest, EntityAddr, GlobalStateIdentifier, Key, Package, PackageAddr, Peers,
     ProtocolVersion, Rewards, SignedBlock, StoredValue, TimeDiff, Transaction, URef,
 };
+use keep_alive_monitor::KeepAliveMonitor;
 use thiserror::Error as ThisError;
 
 use datasize::DataSize;
@@ -53,6 +55,7 @@ use rate_limiter::{LimiterResponse, RateLimiter, RateLimiterError};
 use tokio::{
     join,
     net::{TcpListener, TcpStream},
+    select,
     sync::{Mutex, Notify, OwnedSemaphorePermit, Semaphore},
 };
 use tokio_util::codec::Framed;
@@ -217,6 +220,11 @@ where
             )
             .await
         }
+        BinaryRequest::KeepAliveRequest => BinaryResponse::from_raw_bytes(
+            ResponseType::KeepAliveInformation,
+            vec![],
+            protocol_version,
+        ),
     }
 }
 
@@ -1448,6 +1456,7 @@ async fn handle_client_loop<REv>(
     max_message_size_bytes: u32,
     rate_limiter: Arc<Mutex<RateLimiter>>,
     version: ProtocolVersion,
+    monitor: KeepAliveMonitor,
 ) -> Result<(), Error>
 where
     REv: From<Event>
@@ -1463,25 +1472,36 @@ where
         + Send,
 {
     let mut framed = Framed::new(stream, BinaryMessageCodec::new(max_message_size_bytes));
+    monitor.start().await;
+    let cancellation_token = monitor.get_cancellation_token();
 
     loop {
-        let Some(result) = framed.next().await else {
-            debug!("remote party closed the connection");
-            return Ok(());
-        };
-        let result = result?;
-        let payload = result.payload();
-        if payload.is_empty() {
-            return Err(Error::NoPayload);
-        };
+        select! {
+            maybe_bytes = framed.next() => {
+                let Some(result) = maybe_bytes else {
+                    debug!("remote party closed the connection");
+                    return Ok(());
+                };
+                monitor.tick().await;
+                let result = result?;
+                let payload = result.payload();
+                if payload.is_empty() {
+                    return Err(Error::NoPayload);
+                };
 
-        let (response, id) =
-            handle_payload(effect_builder, payload, version, Arc::clone(&rate_limiter)).await;
-        framed
-            .send(BinaryMessage::new(
-                BinaryResponseAndRequest::new(response, payload, id).to_bytes()?,
-            ))
-            .await?
+                let (response, id) =
+                    handle_payload(effect_builder, payload, version, Arc::clone(&rate_limiter)).await;
+                framed
+                    .send(BinaryMessage::new(
+                        BinaryResponseAndRequest::new(response, payload, id).to_bytes()?,
+                    ))
+                    .await?
+            }
+            _ = cancellation_token.cancelled() => {
+                debug!("Binary port connection stale - closing.");
+                return Ok(());
+            }
+        }
     }
 }
 
@@ -1594,12 +1614,19 @@ async fn handle_client<REv>(
         + From<ChainspecRawBytesRequest>
         + Send,
 {
+    let keep_alive_monitor = KeepAliveMonitor::new(
+        config.keepalive_check_interval,
+        config.keepalive_no_activity_timeout,
+        TimeDiff::from_millis(20),
+        5,
+    );
     if let Err(err) = handle_client_loop(
         stream,
         effect_builder,
         config.max_message_size_bytes,
         rate_limiter,
         protocol_version,
+        keep_alive_monitor,
     )
     .await
     {
@@ -1645,7 +1672,7 @@ async fn run_server<REv>(
     local_addr.set(bind_address).unwrap();
 
     loop {
-        tokio::select! {
+        select! {
             _ = shutdown_trigger.notified() => {
                 break;
             }

--- a/node/src/components/binary_port/config.rs
+++ b/node/src/components/binary_port/config.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+
+use casper_types::TimeDiff;
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +12,10 @@ const DEFAULT_MAX_MESSAGE_SIZE: u32 = 4 * 1024 * 1024;
 const DEFAULT_MAX_CONNECTIONS: usize = 5;
 /// Default maximum number of requests per second.
 const DEFAULT_QPS_LIMIT: usize = 110;
+/// Default interval between connection keepalive checks.
+const DEFAULT_KEEPALIVE_CHECK_INTERVAL: &str = "10sec";
+/// Default amount of time to wait for activity on a connection before considering it stale.
+const DEFAULT_KEEPALIVE_NO_ACTIVITY_TIMEOUT: &str = "120sec";
 
 /// Binary port server configuration.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -33,6 +40,11 @@ pub struct Config {
     pub max_connections: usize,
     /// Maximum number of requests per second.
     pub qps_limit: usize,
+    /// Time of interval between keepalive checks for a binary port connection.
+    pub keepalive_check_interval: TimeDiff,
+    /// Duration of time the keepalive mechanism waits for activity on a binary port connection
+    /// before considering it stale and closing it.
+    pub keepalive_no_activity_timeout: TimeDiff,
 }
 
 impl Config {
@@ -47,6 +59,11 @@ impl Config {
             max_message_size_bytes: DEFAULT_MAX_MESSAGE_SIZE,
             max_connections: DEFAULT_MAX_CONNECTIONS,
             qps_limit: DEFAULT_QPS_LIMIT,
+            keepalive_check_interval: TimeDiff::from_str(DEFAULT_KEEPALIVE_CHECK_INTERVAL).unwrap(),
+            keepalive_no_activity_timeout: TimeDiff::from_str(
+                DEFAULT_KEEPALIVE_NO_ACTIVITY_TIMEOUT,
+            )
+            .unwrap(),
         }
     }
 }

--- a/node/src/components/binary_port/event.rs
+++ b/node/src/components/binary_port/event.rs
@@ -47,6 +47,7 @@ impl Display for Event {
                 BinaryRequest::TrySpeculativeExec { transaction, .. } => {
                     write!(f, "try speculative exec ({})", transaction.hash())
                 }
+                BinaryRequest::KeepAliveRequest => write!(f, "keep alive request"),
             },
         }
     }

--- a/node/src/components/binary_port/keep_alive_monitor.rs
+++ b/node/src/components/binary_port/keep_alive_monitor.rs
@@ -1,0 +1,213 @@
+use casper_types::TimeDiff;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::{
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Mutex,
+    },
+    time::sleep,
+};
+use tokio_util::sync::CancellationToken;
+
+/// An object that allows killing connections if a period of inactivity has been detected.
+/// Whenever the binary port processes a message request for a given connection, the
+/// KeepAliveMonitor::tick() method should be called. The KeepAliveMonitor has the responsibility
+/// keep track when the last tick happened. If more time than configured happened since last "tick",
+/// we send a posion pill via cancelling a CancellationToken.
+pub(super) struct KeepAliveMonitor {
+    /// Address of the endpoint which the KeepAliveMonitor needs to observe
+    cancellation_token: CancellationToken,
+    /// Time the check job sleeps between checks
+    keepalive_check_interval: TimeDiff,
+    /// Time we wait for a tick message to be enqueued.
+    tick_message_enqueue_timeout: Duration,
+    /// The amount of inactivity on a binary port connection which will force a close from the
+    /// keepalive mechanism
+    keepalive_no_activity_timeout: TimeDiff,
+    /// Internal state of KeepAliveMonitor, it is the instant of time when the last bytes were
+    /// observed from `bind_address`
+    last_message_seen_at: Arc<Mutex<Option<Instant>>>,
+    /// This receiver should get messages every time there is something happening on the datasource
+    /// that we are monitoring for inactivity.
+    receiver: Arc<Mutex<Receiver<()>>>,
+    /// Internal queue which collects "ticks". A "tick" happens every time we observe any message
+    /// from `receiver` field.
+    sender: Sender<()>,
+}
+
+impl KeepAliveMonitor {
+    /// The `tick` should be called every time the binary port processes a message request for a
+    /// given connection. Internally, not every `tick` might actually update the
+    /// `last_message_seen_at`. We are using a channel to send tick messages. If the channel is
+    /// full, the tick message is dropped - but that would happen only in a situation where a lock
+    /// of `tick` are being called - we don't really care about being millisecond-precise in this
+    /// mechanism, we want to be able to detect staleness of binary port connections.
+    pub(super) async fn tick(&self) {
+        let _ = self
+            .sender
+            .send_timeout((), self.tick_message_enqueue_timeout)
+            .await;
+    }
+
+    /// Assembles a new `KeepAliveMonitor`. It still doesn't collect data, you need to call the
+    /// `start` function for that.
+    pub(super) fn new(
+        keepalive_check_interval: TimeDiff,
+        keepalive_no_activity_timeout: TimeDiff,
+        tick_message_enqueue_timeout: TimeDiff,
+        tick_message_queue_size: usize,
+    ) -> Self {
+        let cancellation_token = CancellationToken::new();
+        let last_message_seen_at = Arc::new(Mutex::new(None));
+        let (tx, rx) = channel(tick_message_queue_size);
+        KeepAliveMonitor {
+            cancellation_token,
+            keepalive_check_interval,
+            tick_message_enqueue_timeout: Duration::from(tick_message_enqueue_timeout),
+            keepalive_no_activity_timeout,
+            last_message_seen_at,
+            receiver: Arc::new(Mutex::new(rx)),
+            sender: tx,
+        }
+    }
+
+    pub(super) fn get_cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.clone()
+    }
+
+    /// Spawns tasks responsible for asynchronous checks of the monitored datasource.
+    /// If a configured time of inactivity is detected, `cancellation_token` is cancelled.
+    pub(super) async fn start(&self) {
+        self.spawn_last_seen_checker_task(
+            self.last_message_seen_at.clone(),
+            self.keepalive_check_interval,
+            self.keepalive_no_activity_timeout,
+            self.cancellation_token.clone(),
+        );
+        self.spawn_data_observing_task();
+    }
+
+    fn spawn_data_observing_task(&self) {
+        let receiver = self.receiver.clone();
+        let last_message_seen_at = self.last_message_seen_at.clone();
+        tokio::spawn(async move {
+            let mut guard = receiver.lock().await;
+            while (guard.recv().await).is_some() {
+                let now = Some(Instant::now());
+                let mut guard = last_message_seen_at.lock().await;
+                *guard = now;
+                drop(guard);
+            }
+        });
+    }
+
+    fn spawn_last_seen_checker_task(
+        &self,
+        last_activity_holder: Arc<Mutex<Option<Instant>>>,
+        keepalive_check_interval: TimeDiff,
+        no_message_timeout: TimeDiff,
+        cancellation_token: CancellationToken,
+    ) {
+        let no_message_timeout_duration = Duration::from(no_message_timeout);
+        let keepalive_check_interval_duration = Duration::from(keepalive_check_interval);
+        tokio::spawn(async move {
+            loop {
+                sleep(keepalive_check_interval_duration).await;
+                let mut guard = last_activity_holder.lock().await;
+                match &mut *guard {
+                    Some(last_seen_at) => {
+                        if last_seen_at.elapsed() > no_message_timeout_duration {
+                            cancellation_token.cancel();
+                            break;
+                        }
+                    }
+                    None => {
+                        // This scenario shouldn't happen often. It means that there was no data
+                        // observed before the first check happened.
+                        // We are setting last_seen_at value to now so that the keep alive can fail
+                        // in the off chance that the process
+                        // which is producing data hung before first message was produced
+                        *guard = Some(Instant::now());
+                    }
+                }
+                drop(guard);
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KeepAliveMonitor;
+    use casper_types::TimeDiff;
+    use std::{sync::Arc, time::Duration};
+    use tokio::{select, time::sleep};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_cancel_when_first_check_finds_no_activity() {
+        let monitor = KeepAliveMonitor::new(
+            TimeDiff::from_seconds(1),
+            TimeDiff::from_seconds(2),
+            TimeDiff::from_millis(20),
+            5,
+        );
+        monitor.start().await;
+        let cancellation_token = monitor.get_cancellation_token();
+        select! {
+            _ = cancellation_token.cancelled() => {},
+            _ = sleep(Duration::from_secs(10)) => {
+                unreachable!()
+            },
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_not_cancel_if_endpoint_produces_data() {
+        let monitor = Arc::new(KeepAliveMonitor::new(
+            TimeDiff::from_seconds(10),
+            TimeDiff::from_seconds(30),
+            TimeDiff::from_millis(20),
+            5,
+        ));
+        mock_server(monitor.clone(), 1);
+        monitor.start().await;
+        let cancellation_token = monitor.get_cancellation_token();
+        select! {
+            _ = cancellation_token.cancelled() => {
+                unreachable!()
+            },
+            _ = sleep(Duration::from_secs(15)) => {
+            },
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_cancel_if_no_activity_for_prolonged_period_of_time() {
+        let monitor = Arc::new(KeepAliveMonitor::new(
+            TimeDiff::from_seconds(1),
+            TimeDiff::from_seconds(3),
+            TimeDiff::from_millis(20),
+            5,
+        ));
+        mock_server(monitor.clone(), 1500); //1500 seconds of interval to make sure that the monitor won't see activity
+        monitor.start().await;
+        let cancellation_token = monitor.get_cancellation_token();
+        select! {
+            _ = cancellation_token.cancelled() => {
+            },
+            _ = sleep(Duration::from_secs(15)) => {
+                unreachable!()
+            },
+        }
+    }
+
+    fn mock_server(monitor: Arc<KeepAliveMonitor>, interval_in_seconds: u64) {
+        tokio::spawn(async move {
+            monitor.tick().await;
+            sleep(Duration::from_secs(interval_in_seconds)).await;
+        });
+    }
+}

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -327,6 +327,12 @@ max_connections = 5
 # The implementation uses a sliding window algorithm.
 qps_limit = 110
 
+# The amount of time between checks of the connection keepalive mechanism
+keepalive_check_interval = '20 seconds'
+
+# The amount of inactivity on a binary port connection which will force a close from the keepalive mechanism
+keepalive_no_activity_timeout = '180 seconds'
+
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -327,6 +327,12 @@ max_connections = 5
 # The implementation uses a sliding window algorithm.
 qps_limit = 110
 
+# The amount of time between checks of the connection keepalive mechanism
+keepalive_check_interval = '20 seconds'
+
+# The amount of inactivity on a binary port connection which will force a close from the keepalive mechanism
+keepalive_no_activity_timeout = '180 seconds'
+
 # ==============================================
 # Configuration options for the REST HTTP server
 # ==============================================

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -899,13 +899,14 @@ impl Key {
             Err(error) => return Err(FromStrError::EntryPoint(error.to_string())),
         }
 
-        if let Some(contract_entity_hash) = input.strip_prefix(STATE_PREFIX) {
-            let package_addr_bytes = checksummed_hex::decode(contract_entity_hash)
-                .map_err(|error| FromStrError::State(error.to_string()))?;
-
-            let entity_hash_addr: HashAddr = PackageAddr::try_from(package_addr_bytes.as_ref())
-                .map_err(|error| FromStrError::Package(error.to_string()))?;
-            return Ok(Key::State(EntityAddr::SmartContract(entity_hash_addr)));
+        if let Some(entity_addr_formatted) = input.strip_prefix(STATE_PREFIX) {
+            match EntityAddr::from_formatted_str(entity_addr_formatted) {
+                Ok(entity_addr) => return Ok(Key::State(entity_addr)),
+                Err(addressable_entity::FromStrError::InvalidPrefix) => {}
+                Err(error) => {
+                    return Err(FromStrError::State(error.to_string()));
+                }
+            }
         }
 
         Err(FromStrError::UnknownPrefix)
@@ -2607,13 +2608,6 @@ mod tests {
 
     #[test]
     fn serialization_roundtrip_json() {
-        let round_trip = |key: &Key| {
-            let encoded = serde_json::to_value(key).unwrap();
-            let decoded = serde_json::from_value(encoded.clone())
-                .unwrap_or_else(|_| panic!("{} {}", key, encoded));
-            assert_eq!(key, &decoded);
-        };
-
         for key in KEYS {
             round_trip(key);
         }
@@ -2659,6 +2653,19 @@ mod tests {
     }
 
     #[test]
+    fn state_json_deserialization() {
+        let mut test_rng = TestRng::new();
+        let state_key = Key::State(EntityAddr::new_account(test_rng.gen()));
+        round_trip(&state_key);
+
+        let state_key = Key::State(EntityAddr::new_system(test_rng.gen()));
+        round_trip(&state_key);
+
+        let state_key = Key::State(EntityAddr::new_smart_contract(test_rng.gen()));
+        round_trip(&state_key);
+    }
+
+    #[test]
     fn roundtrip() {
         bytesrepr::test_serialization_roundtrip(&ACCOUNT_KEY);
         bytesrepr::test_serialization_roundtrip(&HASH_KEY);
@@ -2687,5 +2694,12 @@ mod tests {
         bytesrepr::test_serialization_roundtrip(&MESSAGE_TOPIC_KEY);
         bytesrepr::test_serialization_roundtrip(&MESSAGE_KEY);
         bytesrepr::test_serialization_roundtrip(&NAMED_KEY);
+    }
+
+    fn round_trip(key: &Key) {
+        let encoded = serde_json::to_value(key).unwrap();
+        let decoded = serde_json::from_value(encoded.clone())
+            .unwrap_or_else(|_| panic!("{} {}", key, encoded));
+        assert_eq!(key, &decoded);
     }
 }


### PR DESCRIPTION
…d two new config properties for the binary port: keepalive_check_interval, keepalive_no_activity_timeout. From now on if a binary port connection is not used for a configured period of time it will be closed on the node side. Introduced a binary request variant BinaryRequest::KeepAliveRequest so that clients that want to keep the connection alive can use this low-overhead way to do that.