### PR TITLE
Changed json serialization for Message struct

### DIFF
--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -5011,14 +5011,7 @@
       "properties": {
         "hash_addr": {
           "description": "The identity of the entity that produced the message.",
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "maxItems": 32,
-          "minItems": 32
+          "type": "string"
         },
         "message": {
           "description": "The payload of the message.",

--- a/types/src/contract_messages/messages.rs
+++ b/types/src/contract_messages/messages.rs
@@ -5,6 +5,7 @@ use crate::{
 
 use alloc::{string::String, vec::Vec};
 use core::{convert::TryFrom, fmt::Debug};
+use thiserror::Error;
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
@@ -15,7 +16,10 @@ use rand::{
 };
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
-use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{self, Error as SerdeError},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 #[cfg(any(feature = "testing", test))]
 use crate::testing::TestRng;
@@ -207,11 +211,12 @@ impl FromBytes for MessagePayload {
 }
 
 /// Message that was emitted by an addressable entity during execution.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct Message {
     /// The identity of the entity that produced the message.
+    #[cfg_attr(feature = "json-schema", schemars(with = "String"))]
     hash_addr: HashAddr,
     /// The payload of the message.
     message: MessagePayload,
@@ -223,6 +228,118 @@ pub struct Message {
     topic_index: u32,
     /// Message index in the block.
     block_index: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct HumanReadableMessage {
+    hash_addr: String,
+    message: MessagePayload,
+    topic_name: String,
+    topic_name_hash: TopicNameHash,
+    topic_index: u32,
+    block_index: u64,
+}
+
+impl From<&Message> for HumanReadableMessage {
+    fn from(message: &Message) -> Self {
+        Self {
+            hash_addr: base16::encode_lower(&message.hash_addr),
+            message: message.message.clone(),
+            topic_name: message.topic_name.clone(),
+            topic_name_hash: message.topic_name_hash,
+            topic_index: message.topic_index,
+            block_index: message.block_index,
+        }
+    }
+}
+
+impl From<&Message> for NonHumanReadableMessage {
+    fn from(message: &Message) -> Self {
+        Self {
+            hash_addr: message.hash_addr,
+            message: message.message.clone(),
+            topic_name: message.topic_name.clone(),
+            topic_name_hash: message.topic_name_hash,
+            topic_index: message.topic_index,
+            block_index: message.block_index,
+        }
+    }
+}
+
+impl From<NonHumanReadableMessage> for Message {
+    fn from(message: NonHumanReadableMessage) -> Self {
+        Self {
+            hash_addr: message.hash_addr,
+            message: message.message,
+            topic_name: message.topic_name,
+            topic_name_hash: message.topic_name_hash,
+            topic_index: message.topic_index,
+            block_index: message.block_index,
+        }
+    }
+}
+
+#[cfg(any(feature = "std", test))]
+#[derive(Error, Debug)]
+enum MessageDeserializationError {
+    #[error("{0}")]
+    Base16(String),
+}
+
+impl TryFrom<HumanReadableMessage> for Message {
+    type Error = MessageDeserializationError;
+    fn try_from(message: HumanReadableMessage) -> Result<Self, Self::Error> {
+        let decoded = checksummed_hex::decode(message.hash_addr).map_err(|e| {
+            MessageDeserializationError::Base16(format!(
+                "Failed to decode hash addr checksummed: {}",
+                e
+            ))
+        })?;
+        let hash_addr = HashAddr::try_from(decoded.as_ref()).map_err(|e| {
+            MessageDeserializationError::Base16(format!("Failed to decode hash address: {}", e))
+        })?;
+        Ok(Self {
+            hash_addr,
+            message: message.message,
+            topic_name: message.topic_name,
+            topic_name_hash: message.topic_name_hash,
+            topic_index: message.topic_index,
+            block_index: message.block_index,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct NonHumanReadableMessage {
+    hash_addr: HashAddr,
+    message: MessagePayload,
+    topic_name: String,
+    topic_name_hash: TopicNameHash,
+    topic_index: u32,
+    block_index: u64,
+}
+
+impl Serialize for Message {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            HumanReadableMessage::from(self).serialize(serializer)
+        } else {
+            NonHumanReadableMessage::from(self).serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Message {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let human_readable = HumanReadableMessage::deserialize(deserializer)?;
+            Message::try_from(human_readable)
+                .map_err(|error| de::Error::custom(format!("{:?}", error)))
+        } else {
+            let non_human_readable = NonHumanReadableMessage::deserialize(deserializer)?;
+            Ok(Message::from(non_human_readable))
+        }
+    }
 }
 
 impl Message {
@@ -401,5 +518,15 @@ mod tests {
         let json_string = serde_json::to_string_pretty(&message_payload).unwrap();
         let decoded: MessagePayload = serde_json::from_str(&json_string).unwrap();
         assert_eq!(decoded, message_payload);
+    }
+
+    #[test]
+    fn message_json_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let message = Message::random(rng);
+        let json_string = serde_json::to_string_pretty(&message).unwrap();
+        let decoded: Message = serde_json::from_str(&json_string).unwrap();
+        assert_eq!(decoded, message);
     }
 }

--- a/types/src/contract_messages/messages.rs
+++ b/types/src/contract_messages/messages.rs
@@ -5,6 +5,7 @@ use crate::{
 
 use alloc::{string::String, vec::Vec};
 use core::{convert::TryFrom, fmt::Debug};
+#[cfg(any(feature = "std", test))]
 use thiserror::Error;
 
 #[cfg(feature = "datasize")]
@@ -16,10 +17,7 @@ use rand::{
 };
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
-use serde::{
-    de::{self, Error as SerdeError},
-    Deserialize, Deserializer, Serialize, Serializer,
-};
+use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(any(feature = "testing", test))]
 use crate::testing::TestRng;
@@ -230,6 +228,7 @@ pub struct Message {
     block_index: u64,
 }
 
+#[cfg(any(feature = "std", test))]
 #[derive(Serialize, Deserialize)]
 struct HumanReadableMessage {
     hash_addr: String,
@@ -240,6 +239,7 @@ struct HumanReadableMessage {
     block_index: u64,
 }
 
+#[cfg(any(feature = "std", test))]
 impl From<&Message> for HumanReadableMessage {
     fn from(message: &Message) -> Self {
         Self {
@@ -253,6 +253,7 @@ impl From<&Message> for HumanReadableMessage {
     }
 }
 
+#[cfg(any(feature = "std", test))]
 impl From<&Message> for NonHumanReadableMessage {
     fn from(message: &Message) -> Self {
         Self {
@@ -266,6 +267,7 @@ impl From<&Message> for NonHumanReadableMessage {
     }
 }
 
+#[cfg(any(feature = "std", test))]
 impl From<NonHumanReadableMessage> for Message {
     fn from(message: NonHumanReadableMessage) -> Self {
         Self {
@@ -286,6 +288,7 @@ enum MessageDeserializationError {
     Base16(String),
 }
 
+#[cfg(any(feature = "std", test))]
 impl TryFrom<HumanReadableMessage> for Message {
     type Error = MessageDeserializationError;
     fn try_from(message: HumanReadableMessage) -> Result<Self, Self::Error> {
@@ -309,6 +312,7 @@ impl TryFrom<HumanReadableMessage> for Message {
     }
 }
 
+#[cfg(any(feature = "std", test))]
 #[derive(Serialize, Deserialize)]
 struct NonHumanReadableMessage {
     hash_addr: HashAddr,
@@ -319,6 +323,7 @@ struct NonHumanReadableMessage {
     block_index: u64,
 }
 
+#[cfg(any(feature = "std", test))]
 impl Serialize for Message {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         if serializer.is_human_readable() {
@@ -329,12 +334,13 @@ impl Serialize for Message {
     }
 }
 
+#[cfg(any(feature = "std", test))]
 impl<'de> Deserialize<'de> for Message {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         if deserializer.is_human_readable() {
             let human_readable = HumanReadableMessage::deserialize(deserializer)?;
             Message::try_from(human_readable)
-                .map_err(|error| de::Error::custom(format!("{:?}", error)))
+                .map_err(|error| SerdeError::custom(format!("{:?}", error)))
         } else {
             let non_human_readable = NonHumanReadableMessage::deserialize(deserializer)?;
             Ok(Message::from(non_human_readable))


### PR DESCRIPTION
`hash_addr` field of `Message` struct json-serialized as an array of bytes, while it should serialize to a base16 encoded string