### PR TITLE
Some types and enum variants were not properly json-serializing

### DIFF
--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -26,6 +26,7 @@ use derive_more::From;
 use futures::channel::oneshot;
 use once_cell::sync::Lazy;
 use rand::Rng;
+use regex::Regex;
 use serde_json::Value;
 use tempfile::TempDir;
 use tokio::runtime::{self, Runtime};
@@ -424,6 +425,33 @@ pub fn assert_schema(schema_path: String, actual_schema: String) {
         temp_file_path.display()
     );
     assert_json_eq!(actual_schema, expected_schema);
+
+    // Check for the following pattern in the JSON as this points to a byte array or vec (e.g.
+    // a hash digest) not being represented as a hex-encoded string:
+    //
+    // ```json
+    // "type": "array",
+    // "items": {
+    //   "type": "integer",
+    //   "format": "uint8",
+    //   "minimum": 0.0
+    // },
+    // ```
+    //
+    // The type/variant in question (most easily identified from the git diff) might be easily
+    // fixed via application of a serde attribute, e.g.
+    // `#[serde(with = "serde_helpers::raw_32_byte_array")]`.  It will likely require a
+    // schemars attribute too, indicating it is a hex-encoded string.  See for example
+    // `TransactionInvocationTarget::Package::addr`.
+    let schema = fs::read_to_string(&schema_path).unwrap();
+    let regex = Regex::new(
+            r#"\s*"type":\s*"array",\s*"items":\s*\{\s*"type":\s*"integer",\s*"format":\s*"uint8",\s*"minimum":\s*0\.0\s*\},"#
+        ).unwrap();
+    assert!(
+        !regex.is_match(&schema),
+        "seems like a byte array is not hex-encoded - see comment in `json_schema_check` for \
+            further info"
+    );
 }
 
 #[cfg(test)]

--- a/node/src/testing.rs
+++ b/node/src/testing.rs
@@ -26,7 +26,6 @@ use derive_more::From;
 use futures::channel::oneshot;
 use once_cell::sync::Lazy;
 use rand::Rng;
-use regex::Regex;
 use serde_json::Value;
 use tempfile::TempDir;
 use tokio::runtime::{self, Runtime};
@@ -425,33 +424,6 @@ pub fn assert_schema(schema_path: String, actual_schema: String) {
         temp_file_path.display()
     );
     assert_json_eq!(actual_schema, expected_schema);
-
-    // Check for the following pattern in the JSON as this points to a byte array or vec (e.g.
-    // a hash digest) not being represented as a hex-encoded string:
-    //
-    // ```json
-    // "type": "array",
-    // "items": {
-    //   "type": "integer",
-    //   "format": "uint8",
-    //   "minimum": 0.0
-    // },
-    // ```
-    //
-    // The type/variant in question (most easily identified from the git diff) might be easily
-    // fixed via application of a serde attribute, e.g.
-    // `#[serde(with = "serde_helpers::raw_32_byte_array")]`.  It will likely require a
-    // schemars attribute too, indicating it is a hex-encoded string.  See for example
-    // `TransactionInvocationTarget::Package::addr`.
-    let schema = fs::read_to_string(&schema_path).unwrap();
-    let regex = Regex::new(
-            r#"\s*"type":\s*"array",\s*"items":\s*\{\s*"type":\s*"integer",\s*"format":\s*"uint8",\s*"minimum":\s*0\.0\s*\},"#
-        ).unwrap();
-    assert!(
-        !regex.is_match(&schema),
-        "seems like a byte array is not hex-encoded - see comment in `json_schema_check` for \
-            further info"
-    );
 }
 
 #[cfg(test)]

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -2449,14 +2449,7 @@
           ],
           "properties": {
             "Purse": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 32,
-              "minItems": 32
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -3245,14 +3238,7 @@
           ],
           "properties": {
             "DelegatedPurse": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 32,
-              "minItems": 32
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -3937,12 +3923,7 @@
           ],
           "properties": {
             "RawBytes": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              }
+              "type": "string"
             }
           },
           "additionalProperties": false

--- a/types/src/system/auction/unbond.rs
+++ b/types/src/system/auction/unbond.rs
@@ -1,17 +1,23 @@
+#[cfg(any(feature = "std", test))]
+use crate::checksummed_hex;
 use alloc::vec::Vec;
-
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::{BidAddr, DelegatorKind, UnbondingPurse, WithdrawPurse};
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     CLType, CLTyped, EraId, PublicKey, URef, URefAddr, U512,
 };
-
-use super::{BidAddr, DelegatorKind, UnbondingPurse, WithdrawPurse};
+#[cfg(any(feature = "std", test))]
+use serde::{de::Error as SerdeError, Deserializer, Serializer};
+#[cfg(any(feature = "std", test))]
+use serde_helpers::{HumanReadableUnbondKind, NonHumanReadableUnbondKind};
+#[cfg(any(feature = "std", test))]
+use thiserror::Error;
 
 /// UnbondKindTag variants.
 #[allow(clippy::large_enum_variant)]
@@ -27,13 +33,13 @@ pub enum UnbondKindTag {
 }
 
 /// Unbond variants.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Clone, Ord, PartialOrd)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub enum UnbondKind {
     Validator(PublicKey),
     DelegatedPublicKey(PublicKey),
-    DelegatedPurse(URefAddr),
+    DelegatedPurse(#[cfg_attr(feature = "json-schema", schemars(with = "String"))] URefAddr),
 }
 
 impl UnbondKind {
@@ -141,6 +147,80 @@ impl From<DelegatorKind> for UnbondKind {
         match value {
             DelegatorKind::PublicKey(pk) => UnbondKind::DelegatedPublicKey(pk),
             DelegatorKind::Purse(addr) => UnbondKind::DelegatedPurse(addr),
+        }
+    }
+}
+
+#[cfg(any(feature = "std", test))]
+impl Serialize for UnbondKind {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            HumanReadableUnbondKind::from(self).serialize(serializer)
+        } else {
+            NonHumanReadableUnbondKind::from(self).serialize(serializer)
+        }
+    }
+}
+
+#[cfg(any(feature = "std", test))]
+#[derive(Error, Debug)]
+enum UnbondKindError {
+    #[error("Error when deserializing UnbondKind: {0}")]
+    DeserializationError(String),
+}
+
+#[cfg(any(feature = "std", test))]
+impl TryFrom<HumanReadableUnbondKind> for UnbondKind {
+    type Error = UnbondKindError;
+
+    fn try_from(value: HumanReadableUnbondKind) -> Result<Self, Self::Error> {
+        match value {
+            HumanReadableUnbondKind::Validator(public_key) => Ok(UnbondKind::Validator(public_key)),
+            HumanReadableUnbondKind::DelegatedPublicKey(public_key) => {
+                Ok(UnbondKind::DelegatedPublicKey(public_key))
+            }
+            HumanReadableUnbondKind::DelegatedPurse(encoded) => {
+                let decoded = checksummed_hex::decode(&encoded).map_err(|e| {
+                    UnbondKindError::DeserializationError(format!(
+                        "Failed to decode encoded URefAddr: {}",
+                        e
+                    ))
+                })?;
+                let uref_addr = URefAddr::try_from(decoded.as_ref()).map_err(|e| {
+                    UnbondKindError::DeserializationError(format!(
+                        "Failed to build uref address: {}",
+                        e
+                    ))
+                })?;
+                Ok(UnbondKind::DelegatedPurse(uref_addr))
+            }
+        }
+    }
+}
+
+impl From<NonHumanReadableUnbondKind> for UnbondKind {
+    fn from(value: NonHumanReadableUnbondKind) -> Self {
+        match value {
+            NonHumanReadableUnbondKind::Validator(public_key) => UnbondKind::Validator(public_key),
+            NonHumanReadableUnbondKind::DelegatedPublicKey(public_key) => {
+                UnbondKind::DelegatedPublicKey(public_key)
+            }
+            NonHumanReadableUnbondKind::DelegatedPurse(uref_addr) => {
+                UnbondKind::DelegatedPurse(uref_addr)
+            }
+        }
+    }
+}
+#[cfg(any(feature = "std", test))]
+impl<'de> Deserialize<'de> for UnbondKind {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        if deserializer.is_human_readable() {
+            let human_readable = HumanReadableUnbondKind::deserialize(deserializer)?;
+            UnbondKind::try_from(human_readable)
+                .map_err(|error| SerdeError::custom(format!("{:?}", error)))
+        } else {
+            let non_human_readable = NonHumanReadableUnbondKind::deserialize(deserializer)?;
+            Ok(UnbondKind::from(non_human_readable))
         }
     }
 }
@@ -472,14 +552,70 @@ impl CLTyped for UnbondEra {
     }
 }
 
+#[cfg(any(feature = "std", test))]
+mod serde_helpers {
+    use super::UnbondKind;
+    use crate::{PublicKey, URefAddr};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    pub(super) enum HumanReadableUnbondKind {
+        Validator(PublicKey),
+        DelegatedPublicKey(PublicKey),
+        DelegatedPurse(String),
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub(super) enum NonHumanReadableUnbondKind {
+        Validator(PublicKey),
+        DelegatedPublicKey(PublicKey),
+        DelegatedPurse(URefAddr),
+    }
+
+    impl From<&UnbondKind> for HumanReadableUnbondKind {
+        fn from(unbond_source: &UnbondKind) -> Self {
+            match unbond_source {
+                UnbondKind::Validator(public_key) => {
+                    HumanReadableUnbondKind::Validator(public_key.clone())
+                }
+                UnbondKind::DelegatedPublicKey(public_key) => {
+                    HumanReadableUnbondKind::DelegatedPublicKey(public_key.clone())
+                }
+                UnbondKind::DelegatedPurse(uref_addr) => {
+                    HumanReadableUnbondKind::DelegatedPurse(base16::encode_lower(uref_addr))
+                }
+            }
+        }
+    }
+
+    impl From<&UnbondKind> for NonHumanReadableUnbondKind {
+        fn from(unbond_kind: &UnbondKind) -> Self {
+            match unbond_kind {
+                UnbondKind::Validator(public_key) => {
+                    NonHumanReadableUnbondKind::Validator(public_key.clone())
+                }
+                UnbondKind::DelegatedPublicKey(public_key) => {
+                    NonHumanReadableUnbondKind::DelegatedPublicKey(public_key.clone())
+                }
+                UnbondKind::DelegatedPurse(uref_addr) => {
+                    NonHumanReadableUnbondKind::DelegatedPurse(uref_addr.clone())
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use rand::Rng;
+
     use crate::{
         bytesrepr,
         system::auction::{
             unbond::{Unbond, UnbondKind},
             UnbondEra,
         },
+        testing::TestRng,
         AccessRights, EraId, PublicKey, SecretKey, URef, U512,
     };
 
@@ -537,5 +673,47 @@ mod tests {
             vec![],
         );
         assert!(!delegator_unbond.is_validator());
+    }
+
+    #[test]
+    fn purse_serialized_as_string() {
+        let delegator_kind_payload = UnbondKind::DelegatedPurse([1; 32]);
+        let serialized = serde_json::to_string(&delegator_kind_payload).unwrap();
+        assert_eq!(
+            serialized,
+            "{\"DelegatedPurse\":\"0101010101010101010101010101010101010101010101010101010101010101\"}"
+        );
+    }
+
+    #[test]
+    fn given_broken_address_purse_deserialziation_fails() {
+        let failing =
+            "{\"DelegatedPurse\":\"Z101010101010101010101010101010101010101010101010101010101010101\"}";
+        let ret = serde_json::from_str::<UnbondKind>(failing);
+        assert!(ret.is_err());
+        let failing =
+            "{\"DelegatedPurse\":\"01010101010101010101010101010101010101010101010101010101\"}";
+        let ret = serde_json::from_str::<UnbondKind>(failing);
+        assert!(ret.is_err());
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let rng = &mut TestRng::new();
+
+        let entity = UnbondKind::Validator(PublicKey::random(rng));
+        let json_string = serde_json::to_string_pretty(&entity).unwrap();
+        let decoded: UnbondKind = serde_json::from_str(&json_string).unwrap();
+        assert_eq!(decoded, entity);
+
+        let entity = UnbondKind::DelegatedPublicKey(PublicKey::random(rng));
+        let json_string = serde_json::to_string_pretty(&entity).unwrap();
+        let decoded: UnbondKind = serde_json::from_str(&json_string).unwrap();
+        assert_eq!(decoded, entity);
+
+        let entity = UnbondKind::DelegatedPurse(rng.gen());
+        let json_string = serde_json::to_string_pretty(&entity).unwrap();
+        let decoded: UnbondKind = serde_json::from_str(&json_string).unwrap();
+        assert_eq!(decoded, entity);
     }
 }

--- a/types/src/transaction/transaction_v1/transaction_v1_builder.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_builder.rs
@@ -283,7 +283,7 @@ impl<'a> TransactionV1Builder<'a> {
 
     /// Returns a new `TransactionV1Builder` suitable for building a native change_bid_public_key
     /// transaction.
-    pub fn new_change_bid_public_key<A: Into<U512>>(
+    pub fn new_change_bid_public_key(
         public_key: PublicKey,
         new_public_key: PublicKey,
     ) -> Result<Self, CLValueError> {


### PR DESCRIPTION
The types/enum variants that changed:
* DelegatorKind::Purse(uref_addr) (uref_addr used to json-serialize as array of u8, now it json-serializes as a base16 encoded string of that vec)
* UnbondKind::DelegatedPurse (uref_addr) (uref_addr used to json-serialize as array of u8, now it json-serializes as a base16 encoded string of that vec)
* StoredValue::RawBytes(raw_bytes_vec) -> raw_bytes_vec serialized as an array of u8, but based on how we serialize Bytes in StoredValue::ContractWasm::bytes I changed it that it serializes as a string (to be consistent with serialization of Bytes type)

This will affect casper-client-rs and sidecar.