### PR TITLE
Update chainspec gas fees related to bids

### DIFF
--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -78,7 +78,7 @@ minimum_delegation_amount = 500_000_000_000
 maximum_delegation_amount = 1_000_000_000_000_000_000
 # Minimum bid amount allowed in motes. Withdrawing one's bid to an amount strictly less than
 # the value specified will be treated as a full unbond of a validator and their associated delegators
-minimum_bid_amount = 10_000_000_000_000
+minimum_bid_amount = 100_000_000_000_000
 # Global state prune batch size (0 = this feature is off)
 prune_batch_size = 0
 # Enables strict arguments checking when calling a contract; i.e. that all non-optional args are provided and of the correct `CLType`.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -85,7 +85,7 @@ minimum_delegation_amount = 500_000_000_000
 maximum_delegation_amount = 1_000_000_000_000_000_000
 # Minimum bid amount allowed in motes. Withdrawing one's bid to an amount strictly less than
 # the value specified will be treated as a full unbond of a validator and their associated delegators
-minimum_bid_amount = 10_000_000_000_000
+minimum_bid_amount = 100_000_000_000_000
 # Global state prune batch size (0 = this feature is off)
 prune_batch_size = 0
 # Enables strict arguments checking when calling a contract; i.e. that all non-optional args are provided and of the correct `CLType`.
@@ -355,7 +355,7 @@ max_message_size = 1_024
 [system_costs.auction_costs]
 get_era_validators = 10_000
 read_seigniorage_recipients = 10_000
-add_bid = 5_000_000_000_000
+add_bid = 2_500_000_000
 withdraw_bid = 2_500_000_000
 delegate = 2_500_000_000
 undelegate = 2_500_000_000


### PR DESCRIPTION
Update chainspec gas fees related to bids

- `add_bid` gas fee lowered back to to 2.5 CSPR
- `minimum_bid_amount` increased to 100k CSPR (~1500 USD at current market prices)

Closes #4968 