### PR TITLE
Fix visibility for transaction builder methods

### DIFF
--- a/types/src/transaction/transaction_v1/arg_handling.rs
+++ b/types/src/transaction/transaction_v1/arg_handling.rs
@@ -378,6 +378,13 @@ pub fn has_valid_redelegate_args(args: &TransactionArgs) -> Result<(), InvalidTr
     Ok(())
 }
 
+/// Creates a `RuntimeArgs` suitable for use in a activate bid transaction.
+pub fn new_activate_bid_args(validator: PublicKey) -> Result<RuntimeArgs, CLValueError> {
+    let mut args = RuntimeArgs::new();
+    ACTIVATE_BID_ARG_VALIDATOR.insert(&mut args, validator)?;
+    Ok(args)
+}
+
 /// Checks the given `RuntimeArgs` are suitable for use in an activate bid transaction.
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub fn has_valid_activate_bid_args(args: &TransactionArgs) -> Result<(), InvalidTransactionV1> {

--- a/types/src/transaction/transaction_v1/arg_handling.rs
+++ b/types/src/transaction/transaction_v1/arg_handling.rs
@@ -7,12 +7,13 @@ use tracing::debug;
 
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::{
-    account::AccountHash, bytesrepr::FromBytes, system::auction::ARG_VALIDATOR, CLType, CLValue,
-    InvalidTransactionV1, TransactionArgs,
+    account::AccountHash, bytesrepr::FromBytes, CLType, CLValue, InvalidTransactionV1,
+    TransactionArgs,
 };
 use crate::{
-    bytesrepr::ToBytes, system::auction::Reservation, CLTyped, CLValueError, PublicKey,
-    RuntimeArgs, TransferTarget, URef, U512,
+    bytesrepr::ToBytes,
+    system::auction::{Reservation, ARG_VALIDATOR},
+    CLTyped, CLValueError, PublicKey, RuntimeArgs, TransferTarget, URef, U512,
 };
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use alloc::string::ToString;
@@ -47,7 +48,6 @@ const REDELEGATE_ARG_VALIDATOR: RequiredArg<PublicKey> = RequiredArg::new("valid
 const REDELEGATE_ARG_AMOUNT: RequiredArg<U512> = RequiredArg::new("amount");
 const REDELEGATE_ARG_NEW_VALIDATOR: RequiredArg<PublicKey> = RequiredArg::new("new_validator");
 
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
 const ACTIVATE_BID_ARG_VALIDATOR: RequiredArg<PublicKey> = RequiredArg::new(ARG_VALIDATOR);
 
 const CHANGE_BID_PUBLIC_KEY_ARG_PUBLIC_KEY: RequiredArg<PublicKey> = RequiredArg::new("public_key");

--- a/types/src/transaction/transaction_v1/arg_handling.rs
+++ b/types/src/transaction/transaction_v1/arg_handling.rs
@@ -1,4 +1,5 @@
 //! Collection of helper functions and structures to reason about amorphic RuntimeArgs.
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
@@ -416,7 +417,6 @@ pub fn has_valid_change_bid_public_key_args(
 }
 
 /// Creates a `RuntimeArgs` suitable for use in a add resrvations transaction.
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub fn new_add_reservations_args(
     reservations: Vec<Reservation>,
 ) -> Result<RuntimeArgs, CLValueError> {
@@ -436,7 +436,6 @@ pub fn has_valid_add_reservations_args(args: &TransactionArgs) -> Result<(), Inv
 }
 
 /// Creates a `RuntimeArgs` suitable for use in a cancel reservations transaction.
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub fn new_cancel_reservations_args(
     validator: PublicKey,
     delegators: Vec<PublicKey>,

--- a/types/src/transaction/transaction_v1/arg_handling.rs
+++ b/types/src/transaction/transaction_v1/arg_handling.rs
@@ -7,13 +7,12 @@ use tracing::debug;
 
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use crate::{
-    account::AccountHash,
-    bytesrepr::FromBytes,
-    system::auction::{Reservation, ARG_VALIDATOR},
-    CLType, CLValue, InvalidTransactionV1, TransactionArgs,
+    account::AccountHash, bytesrepr::FromBytes, system::auction::ARG_VALIDATOR, CLType, CLValue,
+    InvalidTransactionV1, TransactionArgs,
 };
 use crate::{
-    bytesrepr::ToBytes, CLTyped, CLValueError, PublicKey, RuntimeArgs, TransferTarget, URef, U512,
+    bytesrepr::ToBytes, system::auction::Reservation, CLTyped, CLValueError, PublicKey,
+    RuntimeArgs, TransferTarget, URef, U512,
 };
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 use alloc::string::ToString;
@@ -55,13 +54,10 @@ const CHANGE_BID_PUBLIC_KEY_ARG_PUBLIC_KEY: RequiredArg<PublicKey> = RequiredArg
 const CHANGE_BID_PUBLIC_KEY_ARG_NEW_PUBLIC_KEY: RequiredArg<PublicKey> =
     RequiredArg::new("new_public_key");
 
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
 const ADD_RESERVATIONS_ARG_RESERVATIONS: RequiredArg<Vec<Reservation>> =
     RequiredArg::new("reservations");
 
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
 const CANCEL_RESERVATIONS_ARG_VALIDATOR: RequiredArg<PublicKey> = RequiredArg::new("validator");
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
 const CANCEL_RESERVATIONS_ARG_DELEGATORS: RequiredArg<Vec<PublicKey>> =
     RequiredArg::new("delegators");
 

--- a/types/src/transaction/transaction_v1/transaction_v1_builder.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_builder.rs
@@ -1,4 +1,5 @@
 pub mod error;
+use alloc::vec::Vec;
 
 use core::marker::PhantomData;
 
@@ -8,12 +9,11 @@ use super::{
     fields_container::FieldsContainerError,
     InitiatorAddrAndSecretKey, PricingMode, TransactionArgs, TransactionV1,
 };
-#[cfg(any(all(feature = "std", feature = "testing"), test))]
-use crate::system::auction::Reservation;
 use crate::{
-    bytesrepr::Bytes, transaction::FieldsContainer, AddressableEntityHash, CLValue, CLValueError,
-    EntityVersion, PackageHash, PublicKey, RuntimeArgs, SecretKey, TimeDiff, Timestamp,
-    TransactionEntryPoint, TransactionInvocationTarget, TransferTarget, URef, U512,
+    bytesrepr::Bytes, system::auction::Reservation, transaction::FieldsContainer,
+    AddressableEntityHash, CLValue, CLValueError, EntityVersion, PackageHash, PublicKey,
+    RuntimeArgs, SecretKey, TimeDiff, Timestamp, TransactionEntryPoint,
+    TransactionInvocationTarget, TransferTarget, URef, U512,
 };
 #[cfg(any(feature = "testing", test))]
 use crate::{testing::TestRng, transaction::Approval, TransactionConfig, TransactionV1Hash};
@@ -298,7 +298,6 @@ impl<'a> TransactionV1Builder<'a> {
 
     /// Returns a new `TransactionV1Builder` suitable for building a native add_reservations
     /// transaction.
-    #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn new_add_reservations(reservations: Vec<Reservation>) -> Result<Self, CLValueError> {
         let args = arg_handling::new_add_reservations_args(reservations)?;
         let mut builder = TransactionV1Builder::new();
@@ -311,7 +310,6 @@ impl<'a> TransactionV1Builder<'a> {
 
     /// Returns a new `TransactionV1Builder` suitable for building a native cancel_reservations
     /// transaction.
-    #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn new_cancel_reservations(
         validator: PublicKey,
         delegators: Vec<PublicKey>,

--- a/types/src/transaction/transaction_v1/transaction_v1_builder.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_builder.rs
@@ -281,6 +281,18 @@ impl<'a> TransactionV1Builder<'a> {
         Ok(builder)
     }
 
+    /// Returns a new `TransactionV1Builder` suitable for building a native activate_bid
+    /// transaction.
+    pub fn new_activate_bid(validator: PublicKey) -> Result<Self, CLValueError> {
+        let args = arg_handling::new_activate_bid_args(validator)?;
+        let mut builder = TransactionV1Builder::new();
+        builder.args = TransactionArgs::Named(args);
+        builder.target = TransactionTarget::Native;
+        builder.entry_point = TransactionEntryPoint::ActivateBid;
+        builder.scheduling = Self::DEFAULT_SCHEDULING;
+        Ok(builder)
+    }
+
     /// Returns a new `TransactionV1Builder` suitable for building a native change_bid_public_key
     /// transaction.
     pub fn new_change_bid_public_key(


### PR DESCRIPTION
Fix visibility for methods related to delegator reservations. Also add support for activate_bid transactions.
