### PR TITLE
Added json-deserialization code to other variants of Key::BidAddr. Al…

### DIFF
--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -290,10 +290,10 @@ pub enum ErrorCode {
     #[error("invalid transaction runtime")]
     InvalidTransactionRuntime = 90,
     /// Key in transfer request malformed
-    #[error("transfer record malformed key")]
+    #[error("malformed transfer record key")]
     TransferRecordMalformedKey = 91,
     /// Malformed information request
-    #[error("transfer record malformed key")]
+    #[error("malformed information request")]
     MalformedInformationRequest = 92,
     /// Malformed binary version
     #[error("malformed version bytes in header of binary request")]

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -289,6 +289,24 @@ pub enum ErrorCode {
     /// Invalid transaction runtime.
     #[error("invalid transaction runtime")]
     InvalidTransactionRuntime = 90,
+    /// Key in transfer request malformed
+    #[error("transfer record malformed key")]
+    TransferRecordMalformedKey = 91,
+    /// Malformed information request
+    #[error("transfer record malformed key")]
+    MalformedInformationRequest = 92,
+    /// Malformed binary version
+    #[error("malformed version bytes in header of binary request")]
+    MalformedBinaryVersion = 93,
+    /// Malformed binary protocolVersion
+    #[error("malformed protocol version")]
+    MalformedProtocolVersion = 94,
+    /// Malformed header
+    #[error("malformed header of binary request")]
+    MalformedBinaryRequestHeader = 95,
+    /// Malformed binary request
+    #[error("malformed binary request")]
+    MalformedBinaryRequest = 96,
 }
 
 impl TryFrom<u16> for ErrorCode {
@@ -387,6 +405,12 @@ impl TryFrom<u16> for ErrorCode {
             88 => Ok(ErrorCode::RequestThrottled),
             89 => Ok(ErrorCode::ExpectedNamedArguments),
             90 => Ok(ErrorCode::InvalidTransactionRuntime),
+            91 => Ok(ErrorCode::TransferRecordMalformedKey),
+            92 => Ok(ErrorCode::MalformedInformationRequest),
+            93 => Ok(ErrorCode::MalformedBinaryVersion),
+            94 => Ok(ErrorCode::MalformedProtocolVersion),
+            95 => Ok(ErrorCode::MalformedBinaryRequestHeader),
+            96 => Ok(ErrorCode::MalformedBinaryRequest),
             _ => Err(UnknownErrorCode),
         }
     }

--- a/node/src/components/block_validator/tests.rs
+++ b/node/src/components/block_validator/tests.rs
@@ -212,7 +212,7 @@ pub(super) fn new_deploy(rng: &mut TestRng, timestamp: Timestamp, ttl: TimeDiff)
     let dependencies = vec![];
     let gas_price = 1;
 
-    Deploy::new(
+    Deploy::new_signed(
         timestamp,
         ttl,
         gas_price,
@@ -247,7 +247,7 @@ pub(super) fn new_transfer(rng: &mut TestRng, timestamp: Timestamp, ttl: TimeDif
     let dependencies = vec![];
     let gas_price = 1;
 
-    Deploy::new(
+    Deploy::new_signed(
         timestamp,
         ttl,
         gas_price,

--- a/node/src/components/contract_runtime/tests.rs
+++ b/node/src/components/contract_runtime/tests.rs
@@ -315,7 +315,7 @@ async fn should_not_set_shared_pre_state_to_lower_block_height() {
               "id" => Some(9_u64),
             },
         };
-        Transaction::Deploy(Deploy::new(
+        Transaction::Deploy(Deploy::new_signed(
             timestamp,
             ttl,
             gas_price,

--- a/node/src/utils/specimen.rs
+++ b/node/src/utils/specimen.rs
@@ -964,7 +964,7 @@ impl LargestSpecimen for Deploy {
         //       being this maximum size already (see the [`LargestSpecimen`] implementation of
         //       [`ExecutableDeployItem`]). For this reason, we leave `dependencies` and `payment`
         //       small.
-        Deploy::new(
+        Deploy::new_signed(
             LargestSpecimen::largest_specimen(estimator, cache),
             LargestSpecimen::largest_specimen(estimator, cache),
             LargestSpecimen::largest_specimen(estimator, cache),

--- a/storage/src/global_state/trie/tests.rs
+++ b/storage/src/global_state/trie/tests.rs
@@ -98,7 +98,7 @@ mod proptests {
 
     use casper_types::{
         bytesrepr::{self, deserialize_from_slice, FromBytes, ToBytes},
-        gens::{blake2b_hash_arb, key_arb, trie_pointer_arb},
+        gens::{all_keys_arb, blake2b_hash_arb, trie_pointer_arb},
         Digest, Key, StoredValue,
     };
 
@@ -198,7 +198,7 @@ mod proptests {
         }
 
         #[test]
-        fn roundtrip_key(key in key_arb()) {
+        fn roundtrip_key(key in all_keys_arb()) {
             bytesrepr::test_serialization_roundtrip(&key);
         }
 
@@ -259,14 +259,14 @@ mod proptests {
         }
 
         #[test]
-        fn bincode_roundtrip_key(key in key_arb()) {
+        fn bincode_roundtrip_key(key in all_keys_arb()) {
              let bincode_bytes = bincode::serialize(&key)?;
              let deserialized_key = bincode::deserialize(&bincode_bytes)?;
              prop_assert_eq!(key, deserialized_key)
         }
 
         #[test]
-        fn serde_roundtrip_key(key in key_arb()) {
+        fn serde_roundtrip_key(key in all_keys_arb()) {
              let json_str = serde_json::to_string(&key)?;
              let deserialized_key = serde_json::from_str(&json_str)?;
              assert_eq!(key, deserialized_key)

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -163,6 +163,24 @@ pub fn key_arb() -> impl Strategy<Value = Key> {
         deploy_hash_arb().prop_map(Key::DeployInfo),
         era_id_arb().prop_map(Key::EraInfo),
         uref_arb().prop_map(|uref| Key::Balance(uref.addr())),
+        bid_addr_validator_arb().prop_map(Key::BidAddr),
+        bid_addr_delegator_arb().prop_map(Key::BidAddr),
+        account_hash_arb().prop_map(Key::Withdraw),
+        u8_slice_32().prop_map(Key::Dictionary),
+        balance_hold_addr_arb().prop_map(Key::BalanceHold),
+        Just(Key::EraSummary)
+    ]
+}
+
+pub fn all_keys_arb() -> impl Strategy<Value = Key> {
+    prop_oneof![
+        account_hash_arb().prop_map(Key::Account),
+        u8_slice_32().prop_map(Key::Hash),
+        uref_arb().prop_map(Key::URef),
+        transfer_v1_addr_arb().prop_map(Key::Transfer),
+        deploy_hash_arb().prop_map(Key::DeployInfo),
+        era_id_arb().prop_map(Key::EraInfo),
+        uref_arb().prop_map(|uref| Key::Balance(uref.addr())),
         account_hash_arb().prop_map(Key::Withdraw),
         u8_slice_32().prop_map(Key::Dictionary),
         balance_hold_addr_arb().prop_map(Key::BalanceHold),
@@ -176,9 +194,9 @@ pub fn key_arb() -> impl Strategy<Value = Key> {
         u8_slice_32().prop_map(Key::SmartContract),
         byte_code_addr_arb().prop_map(Key::ByteCode),
         entity_addr_arb().prop_map(Key::AddressableEntity),
+        block_global_addr_arb().prop_map(Key::BlockGlobal),
         message_addr_arb().prop_map(Key::Message),
         named_key_addr_arb().prop_map(Key::NamedKey),
-        block_global_addr_arb().prop_map(Key::BlockGlobal),
         balance_hold_addr_arb().prop_map(Key::BalanceHold),
         entry_point_addr_arb().prop_map(Key::EntryPoint),
         entity_addr_arb().prop_map(Key::State),
@@ -222,8 +240,7 @@ pub fn bid_addr_delegator_arb() -> impl Strategy<Value = BidAddr> {
 }
 
 pub fn bid_legacy_arb() -> impl Strategy<Value = BidAddr> {
-    let x = u8_slice_32();
-    (x).prop_map(BidAddr::legacy)
+    u8_slice_32().prop_map(BidAddr::legacy)
 }
 
 pub fn bid_addr_delegated_arb() -> impl Strategy<Value = BidAddr> {

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -2,6 +2,8 @@
 //! [`Proptest`](https://crates.io/crates/proptest).
 #![allow(missing_docs)]
 
+use core::u32;
+
 use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
@@ -16,12 +18,12 @@ use crate::{
     },
     addressable_entity::{
         action_thresholds::gens::action_thresholds_arb, associated_keys::gens::associated_keys_arb,
-        MessageTopics, NamedKeyValue, Parameters, Weight,
+        MessageTopics, NamedKeyAddr, NamedKeyValue, Parameters, Weight,
     },
     block::BlockGlobalAddr,
     byte_code::ByteCodeKind,
     bytesrepr::Bytes,
-    contract_messages::{MessageChecksum, MessageTopicSummary, TopicNameHash},
+    contract_messages::{MessageAddr, MessageChecksum, MessageTopicSummary, TopicNameHash},
     contracts::{
         Contract, ContractHash, ContractPackage, ContractPackageStatus, ContractVersionKey,
         ContractVersions, EntryPoint as ContractEntryPoint, EntryPoints as ContractEntryPoints,
@@ -51,12 +53,13 @@ use crate::{
         gens::{transfer_v1_addr_arb, transfer_v1_arb},
         TransferAddr,
     },
-    AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, ByteCode, CLType, CLValue,
-    Digest, EntityAddr, EntityKind, EntryPoint, EntryPointAccess, EntryPointPayment,
-    EntryPointType, EntryPoints, EraId, Group, InitiatorAddr, Key, NamedArg, Package, Parameter,
-    Phase, PricingMode, ProtocolVersion, PublicKey, RuntimeArgs, SemVer, StoredValue, TimeDiff,
-    Timestamp, Transaction, TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntime,
-    TransactionScheduling, TransactionTarget, TransactionV1, URef, U128, U256, U512,
+    AccessRights, AddressableEntity, AddressableEntityHash, BlockTime, ByteCode, ByteCodeAddr,
+    CLType, CLValue, Digest, EntityAddr, EntityKind, EntryPoint, EntryPointAccess, EntryPointAddr,
+    EntryPointPayment, EntryPointType, EntryPoints, EraId, Group, InitiatorAddr, Key, NamedArg,
+    Package, Parameter, Phase, PricingMode, ProtocolVersion, PublicKey, RuntimeArgs, SemVer,
+    StoredValue, TimeDiff, Timestamp, Transaction, TransactionEntryPoint,
+    TransactionInvocationTarget, TransactionRuntime, TransactionScheduling, TransactionTarget,
+    TransactionV1, URef, U128, U256, U512,
 };
 use proptest::{
     array, bits, bool,
@@ -117,6 +120,40 @@ pub fn era_id_arb() -> impl Strategy<Value = EraId> {
     any::<u64>().prop_map(EraId::from)
 }
 
+pub fn named_key_addr_arb() -> impl Strategy<Value = NamedKeyAddr> {
+    (entity_addr_arb(), u8_slice_32())
+        .prop_map(|(entity_addr, b)| NamedKeyAddr::new_named_key_entry(entity_addr, b))
+}
+
+pub fn message_addr_arb() -> impl Strategy<Value = MessageAddr> {
+    prop_oneof![
+        (u8_slice_32(), u8_slice_32()).prop_map(|(hash_addr, topic_name_hash)| {
+            MessageAddr::new_topic_addr(hash_addr, TopicNameHash::new(topic_name_hash))
+        }),
+        (u8_slice_32(), u8_slice_32(), example_u32_arb()).prop_map(
+            |(hash_addr, topic_name_hash, index)| MessageAddr::new_message_addr(
+                hash_addr,
+                TopicNameHash::new(topic_name_hash),
+                index
+            )
+        ),
+    ]
+}
+
+pub fn entry_point_addr_arb() -> impl Strategy<Value = EntryPointAddr> {
+    (entity_addr_arb(), any::<String>()).prop_map(|(entity_addr, b)| {
+        EntryPointAddr::new_v1_entry_point_addr(entity_addr, &b).unwrap()
+    })
+}
+
+pub fn byte_code_addr_arb() -> impl Strategy<Value = ByteCodeAddr> {
+    prop_oneof![
+        Just(ByteCodeAddr::Empty),
+        u8_slice_32().prop_map(ByteCodeAddr::V1CasperWasm),
+        u8_slice_32().prop_map(ByteCodeAddr::V2CasperWasm),
+    ]
+}
+
 pub fn key_arb() -> impl Strategy<Value = Key> {
     prop_oneof![
         account_hash_arb().prop_map(Key::Account),
@@ -126,12 +163,25 @@ pub fn key_arb() -> impl Strategy<Value = Key> {
         deploy_hash_arb().prop_map(Key::DeployInfo),
         era_id_arb().prop_map(Key::EraInfo),
         uref_arb().prop_map(|uref| Key::Balance(uref.addr())),
-        bid_addr_validator_arb().prop_map(Key::BidAddr),
-        bid_addr_delegator_arb().prop_map(Key::BidAddr),
         account_hash_arb().prop_map(Key::Withdraw),
         u8_slice_32().prop_map(Key::Dictionary),
         balance_hold_addr_arb().prop_map(Key::BalanceHold),
         Just(Key::EraSummary),
+        Just(Key::SystemEntityRegistry),
+        Just(Key::ChainspecRegistry),
+        Just(Key::ChecksumRegistry),
+        bid_addr_arb().prop_map(Key::BidAddr),
+        account_hash_arb().prop_map(Key::Bid),
+        account_hash_arb().prop_map(Key::Unbond),
+        u8_slice_32().prop_map(Key::SmartContract),
+        byte_code_addr_arb().prop_map(Key::ByteCode),
+        entity_addr_arb().prop_map(Key::AddressableEntity),
+        message_addr_arb().prop_map(Key::Message),
+        named_key_addr_arb().prop_map(Key::NamedKey),
+        block_global_addr_arb().prop_map(Key::BlockGlobal),
+        balance_hold_addr_arb().prop_map(Key::BalanceHold),
+        entry_point_addr_arb().prop_map(Key::EntryPoint),
+        entity_addr_arb().prop_map(Key::State),
     ]
 }
 
@@ -169,6 +219,50 @@ pub fn bid_addr_delegator_arb() -> impl Strategy<Value = BidAddr> {
     let x = u8_slice_32();
     let y = u8_slice_32();
     (x, y).prop_map(BidAddr::new_delegator_account_addr)
+}
+
+pub fn bid_legacy_arb() -> impl Strategy<Value = BidAddr> {
+    let x = u8_slice_32();
+    (x).prop_map(BidAddr::legacy)
+}
+
+pub fn bid_addr_delegated_arb() -> impl Strategy<Value = BidAddr> {
+    (public_key_arb_no_system(), delegator_kind_arb()).prop_map(|(validator, delegator_kind)| {
+        BidAddr::new_delegator_kind(&validator, &delegator_kind)
+    })
+}
+
+pub fn bid_addr_credit_arb() -> impl Strategy<Value = BidAddr> {
+    (public_key_arb_no_system(), era_id_arb())
+        .prop_map(|(validator, era_id)| BidAddr::new_credit(&validator, era_id))
+}
+
+pub fn bid_addr_reservation_account_arb() -> impl Strategy<Value = BidAddr> {
+    (public_key_arb_no_system(), public_key_arb_no_system())
+        .prop_map(|(validator, delegator)| BidAddr::new_reservation_account(&validator, &delegator))
+}
+
+pub fn bid_addr_reservation_purse_arb() -> impl Strategy<Value = BidAddr> {
+    (public_key_arb_no_system(), u8_slice_32())
+        .prop_map(|(validator, uref)| BidAddr::new_reservation_purse(&validator, uref))
+}
+
+pub fn bid_addr_new_unbond_account_arb() -> impl Strategy<Value = BidAddr> {
+    (public_key_arb_no_system(), public_key_arb_no_system())
+        .prop_map(|(validator, unbonder)| BidAddr::new_unbond_account(validator, unbonder))
+}
+
+pub fn bid_addr_arb() -> impl Strategy<Value = BidAddr> {
+    prop_oneof![
+        bid_addr_validator_arb(),
+        bid_addr_delegator_arb(),
+        bid_legacy_arb(),
+        bid_addr_delegated_arb(),
+        bid_addr_credit_arb(),
+        bid_addr_reservation_account_arb(),
+        bid_addr_reservation_purse_arb(),
+        bid_addr_new_unbond_account_arb(),
+    ]
 }
 
 pub fn balance_hold_addr_arb() -> impl Strategy<Value = BalanceHoldAddr> {

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -35,9 +35,8 @@ use tracing::{error, warn};
 
 use crate::{
     account::{AccountHash, ACCOUNT_HASH_LENGTH},
-    addressable_entity,
     addressable_entity::{
-        AddressableEntityHash, EntityAddr, EntityKindTag, EntryPointAddr, NamedKeyAddr,
+        self, AddressableEntityHash, EntityAddr, EntityKindTag, EntryPointAddr, NamedKeyAddr,
     },
     block::BlockGlobalAddr,
     byte_code,
@@ -758,6 +757,15 @@ impl Key {
                     )
                     .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
                     BidAddr::new_delegator_account_addr((validator_bytes, delegator_bytes))
+                } else if tag == BidAddrTag::DelegatedPurse {
+                    let uref = <[u8; UREF_ADDR_LENGTH]>::try_from(
+                        bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
+                    )
+                    .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
+                    BidAddr::DelegatedPurse {
+                        validator: AccountHash::new(validator_bytes),
+                        delegator: uref,
+                    }
                 } else if tag == BidAddrTag::Credit {
                     let era_id = bytesrepr::deserialize_from_slice(
                         &bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..],
@@ -766,6 +774,39 @@ impl Key {
                     BidAddr::Credit {
                         validator: AccountHash::new(validator_bytes),
                         era_id,
+                    }
+                } else if tag == BidAddrTag::ReservedDelegationAccount {
+                    let delegator_bytes = <[u8; ACCOUNT_HASH_LENGTH]>::try_from(
+                        bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
+                    )
+                    .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
+                    BidAddr::new_reservation_account_addr((validator_bytes, delegator_bytes))
+                } else if tag == BidAddrTag::ReservedDelegationPurse {
+                    let uref = <[u8; UREF_ADDR_LENGTH]>::try_from(
+                        bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
+                    )
+                    .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
+                    BidAddr::ReservedDelegationPurse {
+                        validator: AccountHash::new(validator_bytes),
+                        delegator: uref,
+                    }
+                } else if tag == BidAddrTag::UnbondAccount {
+                    let unbonder_bytes = <[u8; ACCOUNT_HASH_LENGTH]>::try_from(
+                        bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
+                    )
+                    .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
+                    BidAddr::UnbondAccount {
+                        validator: AccountHash::new(validator_bytes),
+                        unbonder: AccountHash::new(unbonder_bytes),
+                    }
+                } else if tag == BidAddrTag::UnbondPurse {
+                    let uref = <[u8; UREF_ADDR_LENGTH]>::try_from(
+                        bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
+                    )
+                    .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
+                    BidAddr::UnbondPurse {
+                        validator: AccountHash::new(validator_bytes),
+                        unbonder: uref,
                     }
                 } else {
                     return Err(FromStrError::BidAddr("invalid tag".to_string()));
@@ -2724,5 +2765,20 @@ mod tests {
         let decoded = serde_json::from_value(encoded.clone())
             .unwrap_or_else(|_| panic!("{} {}", key, encoded));
         assert_eq!(key, &decoded);
+    }
+}
+
+#[cfg(test)]
+mod proptest {
+    use crate::gens;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_json_roundtrip_for_bidaddr_key(key in gens::key_arb()) {
+            let json_string = serde_json::to_string_pretty(&key).unwrap();
+            let decoded = serde_json::from_str(&json_string).unwrap();
+            assert_eq!(key, decoded);
+        }
     }
 }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -746,18 +746,17 @@ impl Key {
             )
             .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
 
-            let bid_addr = {
-                if tag == BidAddrTag::Unified {
-                    BidAddr::legacy(validator_bytes)
-                } else if tag == BidAddrTag::Validator {
-                    BidAddr::new_validator_addr(validator_bytes)
-                } else if tag == BidAddrTag::DelegatedAccount {
+            let bid_addr = match tag {
+                BidAddrTag::Unified => BidAddr::legacy(validator_bytes),
+                BidAddrTag::Validator => BidAddr::new_validator_addr(validator_bytes),
+                BidAddrTag::DelegatedAccount => {
                     let delegator_bytes = <[u8; ACCOUNT_HASH_LENGTH]>::try_from(
                         bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
                     )
                     .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
                     BidAddr::new_delegator_account_addr((validator_bytes, delegator_bytes))
-                } else if tag == BidAddrTag::DelegatedPurse {
+                }
+                BidAddrTag::DelegatedPurse => {
                     let uref = <[u8; UREF_ADDR_LENGTH]>::try_from(
                         bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
                     )
@@ -766,7 +765,8 @@ impl Key {
                         validator: AccountHash::new(validator_bytes),
                         delegator: uref,
                     }
-                } else if tag == BidAddrTag::Credit {
+                }
+                BidAddrTag::Credit => {
                     let era_id = bytesrepr::deserialize_from_slice(
                         &bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..],
                     )
@@ -775,13 +775,15 @@ impl Key {
                         validator: AccountHash::new(validator_bytes),
                         era_id,
                     }
-                } else if tag == BidAddrTag::ReservedDelegationAccount {
+                }
+                BidAddrTag::ReservedDelegationAccount => {
                     let delegator_bytes = <[u8; ACCOUNT_HASH_LENGTH]>::try_from(
                         bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
                     )
                     .map_err(|err| FromStrError::BidAddr(err.to_string()))?;
                     BidAddr::new_reservation_account_addr((validator_bytes, delegator_bytes))
-                } else if tag == BidAddrTag::ReservedDelegationPurse {
+                }
+                BidAddrTag::ReservedDelegationPurse => {
                     let uref = <[u8; UREF_ADDR_LENGTH]>::try_from(
                         bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
                     )
@@ -790,7 +792,8 @@ impl Key {
                         validator: AccountHash::new(validator_bytes),
                         delegator: uref,
                     }
-                } else if tag == BidAddrTag::UnbondAccount {
+                }
+                BidAddrTag::UnbondAccount => {
                     let unbonder_bytes = <[u8; ACCOUNT_HASH_LENGTH]>::try_from(
                         bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
                     )
@@ -799,7 +802,8 @@ impl Key {
                         validator: AccountHash::new(validator_bytes),
                         unbonder: AccountHash::new(unbonder_bytes),
                     }
-                } else if tag == BidAddrTag::UnbondPurse {
+                }
+                BidAddrTag::UnbondPurse => {
                     let uref = <[u8; UREF_ADDR_LENGTH]>::try_from(
                         bytes[BidAddr::VALIDATOR_BID_ADDR_LENGTH..].as_ref(),
                     )
@@ -808,8 +812,6 @@ impl Key {
                         validator: AccountHash::new(validator_bytes),
                         unbonder: uref,
                     }
-                } else {
-                    return Err(FromStrError::BidAddr("invalid tag".to_string()));
                 }
             };
             return Ok(Key::BidAddr(bid_addr));
@@ -2775,7 +2777,7 @@ mod proptest {
 
     proptest! {
         #[test]
-        fn test_json_roundtrip_for_bidaddr_key(key in gens::key_arb()) {
+        fn test_json_roundtrip_for_bidaddr_key(key in gens::all_keys_arb()) {
             let json_string = serde_json::to_string_pretty(&key).unwrap();
             let decoded = serde_json::from_str(&json_string).unwrap();
             assert_eq!(key, decoded);

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -199,7 +199,7 @@ pub use transaction::{
     TransactionEntryPoint, TransactionHash, TransactionId, TransactionInvocationTarget,
     TransactionRuntime, TransactionScheduling, TransactionTarget, TransactionV1,
     TransactionV1DecodeFromJsonError, TransactionV1Error, TransactionV1ExcessiveSizeError,
-    TransactionV1Hash, TransferTarget,
+    TransactionV1Hash, TransactionV1Payload, TransferTarget,
 };
 #[cfg(any(feature = "std", test))]
 pub use transaction::{

--- a/types/src/system/auction/bid_addr.rs
+++ b/types/src/system/auction/bid_addr.rs
@@ -735,29 +735,15 @@ mod tests {
 }
 
 #[cfg(test)]
-mod prop_test_validator_addr {
+mod proptest {
     use proptest::prelude::*;
 
     use crate::{bytesrepr, gens};
 
     proptest! {
         #[test]
-        fn test_value_bid_addr_validator(validator_bid_addr in gens::bid_addr_validator_arb()) {
-            bytesrepr::test_serialization_roundtrip(&validator_bid_addr);
-        }
-    }
-}
-
-#[cfg(test)]
-mod prop_test_delegator_addr {
-    use proptest::prelude::*;
-
-    use crate::{bytesrepr, gens};
-
-    proptest! {
-        #[test]
-        fn test_value_bid_addr_delegator(delegator_bid_addr in gens::bid_addr_delegator_arb()) {
-            bytesrepr::test_serialization_roundtrip(&delegator_bid_addr);
+        fn test_value_bid_addr_validator(bid_addr in gens::bid_addr_arb()) {
+            bytesrepr::test_serialization_roundtrip(&bid_addr);
         }
     }
 }

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -87,12 +87,10 @@ pub use transaction_scheduling::TransactionScheduling;
 pub use transaction_target::TransactionTarget;
 #[cfg(any(feature = "std", feature = "testing", feature = "gens", test))]
 pub(crate) use transaction_v1::fields_container::FieldsContainer;
-#[cfg(any(feature = "testing", feature = "gens", test))]
-pub use transaction_v1::TransactionV1Payload;
 pub use transaction_v1::{
     arg_handling, InvalidTransactionV1, TransactionArgs, TransactionV1,
     TransactionV1DecodeFromJsonError, TransactionV1Error, TransactionV1ExcessiveSizeError,
-    TransactionV1Hash,
+    TransactionV1Hash, TransactionV1Payload,
 };
 #[cfg(any(feature = "std", test))]
 pub use transaction_v1::{TransactionV1Builder, TransactionV1BuilderError};
@@ -142,6 +140,16 @@ pub enum Transaction {
 }
 
 impl Transaction {
+    // Deploy variant ctor
+    pub fn from_deploy(deploy: Deploy) -> Self {
+        Transaction::Deploy(deploy)
+    }
+
+    // V1 variant ctor
+    pub fn from_v1(v1: TransactionV1) -> Self {
+        Transaction::V1(v1)
+    }
+
     /// Returns the `TransactionHash` identifying this transaction.
     pub fn hash(&self) -> TransactionHash {
         match self {

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -152,10 +152,27 @@ pub struct Deploy {
 }
 
 impl Deploy {
+    /// Constructs a new `Deploy`.
+    pub fn new(
+        hash: DeployHash,
+        header: DeployHeader,
+        payment: ExecutableDeployItem,
+        session: ExecutableDeployItem,
+    ) -> Deploy {
+        Deploy {
+            hash,
+            header,
+            payment,
+            session,
+            approvals: BTreeSet::new(),
+            #[cfg(any(feature = "once_cell", test))]
+            is_valid: OnceCell::new(),
+        }
+    }
     /// Constructs a new signed `Deploy`.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_signed(
         timestamp: Timestamp,
         ttl: TimeDiff,
         gas_price: u64,
@@ -581,7 +598,7 @@ impl Deploy {
 
         let secret_key = SecretKey::random(rng);
 
-        Deploy::new(
+        Deploy::new_signed(
             timestamp,
             ttl,
             gas_price,
@@ -633,7 +650,7 @@ impl Deploy {
             args: payment_args,
         };
         let secret_key = SecretKey::random(rng);
-        Deploy::new(
+        Deploy::new_signed(
             timestamp,
             ttl,
             deploy.header.gas_price(),
@@ -666,7 +683,7 @@ impl Deploy {
             args: payment_args,
         };
         let secret_key = SecretKey::random(rng);
-        Deploy::new(
+        Deploy::new_signed(
             Timestamp::now(),
             deploy.header.ttl(),
             deploy.header.gas_price(),
@@ -868,7 +885,7 @@ impl Deploy {
             None => TimeDiff::from_seconds(rng.gen_range(60..3600)),
             Some(ttl) => ttl,
         };
-        Deploy::new(
+        Deploy::new_signed(
             timestamp,
             ttl,
             1,
@@ -963,7 +980,7 @@ impl Deploy {
         let deploy = Self::random_valid_native_transfer(rng);
         let secret_key = SecretKey::random(rng);
 
-        Deploy::new(
+        Deploy::new_signed(
             Timestamp::zero(),
             TimeDiff::from_seconds(1u32),
             deploy.header.gas_price(),
@@ -995,7 +1012,7 @@ impl Deploy {
         let deploy = Self::random_valid_native_transfer(rng);
         let secret_key = SecretKey::random(rng);
 
-        Deploy::new(
+        Deploy::new_signed(
             deploy.header.timestamp(),
             deploy.header.ttl(),
             deploy.header.gas_price(),
@@ -1013,7 +1030,7 @@ impl Deploy {
         let deploy = Self::random_valid_native_transfer(rng);
         let secret_key = SecretKey::random(rng);
 
-        Deploy::new(
+        Deploy::new_signed(
             deploy.header.timestamp(),
             deploy.header.ttl(),
             deploy.header.gas_price(),
@@ -1032,7 +1049,7 @@ impl Deploy {
         let deploy = Self::random(rng);
         let secret_key = SecretKey::random(rng);
 
-        Deploy::new(
+        Deploy::new_signed(
             deploy.header.timestamp(),
             deploy.header.ttl(),
             gas_price,
@@ -1579,7 +1596,7 @@ mod tests {
             transfer_args.insert_cl_value("amount", value);
             transfer_args
         };
-        Deploy::new(
+        Deploy::new_signed(
             Timestamp::now(),
             ttl,
             gas_price,
@@ -2112,7 +2129,7 @@ mod tests {
             transfer_args
         };
 
-        let deploy = Deploy::new(
+        let deploy = Deploy::new_signed(
             Timestamp::now(),
             config.max_ttl,
             GAS_PRICE_TOLERANCE as u64,

--- a/types/src/transaction/deploy/deploy_header.rs
+++ b/types/src/transaction/deploy/deploy_header.rs
@@ -41,7 +41,7 @@ pub struct DeployHeader {
 
 impl DeployHeader {
     #[cfg(any(feature = "std", feature = "json-schema", test))]
-    pub(super) fn new(
+    pub fn new(
         account: PublicKey,
         timestamp: Timestamp,
         ttl: TimeDiff,

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -153,7 +153,7 @@ impl TryFrom<TransactionV1> for TransactionV1Json {
 }
 
 impl TransactionV1 {
-    // ctor
+    /// ctor
     pub fn new(
         hash: TransactionV1Hash,
         payload: TransactionV1Payload,

--- a/types/src/transaction/transaction_v1/transaction_v1_payload.rs
+++ b/types/src/transaction/transaction_v1/transaction_v1_payload.rs
@@ -53,6 +53,7 @@ const EXPECTED_FIELD_KEYS: [u16; 4] = [
     SCHEDULING_MAP_KEY,
 ];
 
+/// Structure aggregating internal data of V1 transaction.
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[cfg_attr(
@@ -75,6 +76,7 @@ pub struct TransactionV1Payload {
 }
 
 impl TransactionV1Payload {
+    // ctor
     pub fn new(
         chain_name: String,
         timestamp: Timestamp,
@@ -104,26 +106,32 @@ impl TransactionV1Payload {
         ]
     }
 
+    /// Returns the chain name of the transaction.
     pub fn chain_name(&self) -> &str {
         &self.chain_name
     }
 
+    /// Returns the timestamp of the transaction.
     pub fn timestamp(&self) -> Timestamp {
         self.timestamp
     }
 
+    /// Returns the time-to-live of the transaction.
     pub fn ttl(&self) -> TimeDiff {
         self.ttl
     }
 
+    /// Returns the pricing mode of the transaction.
     pub fn pricing_mode(&self) -> &PricingMode {
         &self.pricing_mode
     }
 
+    /// Returns the initiator address of the transaction.
     pub fn initiator_addr(&self) -> &InitiatorAddr {
         &self.initiator_addr
     }
 
+    /// Returns the fields of the transaction.
     pub fn fields(&self) -> &BTreeMap<u16, Bytes> {
         &self.fields
     }
@@ -138,6 +146,8 @@ impl TransactionV1Payload {
         self.expires() < current_instant
     }
 
+    /// Fetches field from the amorphic `field` map and attempts to deserialize it into a type `T`.
+    /// The deserialization is done using the `FromBytes` trait.
     pub fn deserialize_field<T: FromBytes>(
         &self,
         index: u16,
@@ -154,10 +164,12 @@ impl TransactionV1Payload {
         Ok(value)
     }
 
+    /// Helper method to return size of `fields`.
     pub fn number_of_fields(&self) -> usize {
         self.fields.len()
     }
 
+    /// Makes transaction payload invalid.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn invalidate(&mut self) {
         self.chain_name.clear();


### PR DESCRIPTION
…so split `BadRequest` error into targeted ones that convey more info about what actually went wrong. 
Added tests to cover all Key variants in both json and byt serialization. 
Changed TransactionV1 to publish it's constructor
Pub-used TransactionV1Payload (it was a bug that it wasn't pub-used)

This will have effect on sidecar and casper-client-rs.
