### PR TITLE
Improve transactor acceptor logic.

### DIFF
--- a/node/src/types/transaction/transaction_v1_builder.rs
+++ b/node/src/types/transaction/transaction_v1_builder.rs
@@ -502,6 +502,15 @@ impl<'a> TransactionV1Builder<'a> {
         self
     }
 
+    /// Sets the transaction args in the transaction.
+    ///
+    /// NOTE: this overwrites any existing transaction_args args.
+    #[cfg(test)]
+    pub fn with_transaction_args(mut self, args: TransactionArgs) -> Self {
+        self.args = args;
+        self
+    }
+
     /// Returns the new transaction, or an error if non-defaulted fields were not set.
     ///
     /// For more info, see [the `TransactionBuilder` documentation](TransactionV1Builder).

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -193,6 +193,8 @@ pub enum InvalidTransaction {
     UnexpectedTransactionFieldEntries,
     /// The transaction requires named arguments.
     ExpectedNamedArguments,
+    /// The transaction required bytes arguments.
+    ExpectedBytesArguments,
     /// The transaction runtime is invalid.
     InvalidTransactionRuntime {
         /// The expected runtime as specified by the chainspec.
@@ -380,6 +382,9 @@ impl Display for InvalidTransaction {
             InvalidTransaction::ExpectedNamedArguments => {
                 write!(formatter, "transaction requires named arguments")
             }
+            InvalidTransaction::ExpectedBytesArguments => {
+                write!(formatter, "transaction requires bytes arguments")
+            }
             InvalidTransaction::InvalidTransactionRuntime { expected } => {
                 write!(
                     formatter,
@@ -389,6 +394,8 @@ impl Display for InvalidTransaction {
             InvalidTransaction::MissingSeed => {
                 write!(formatter, "missing seed for install or upgrade")
             }
+
+
         }
     }
 }
@@ -438,6 +445,7 @@ impl StdError for InvalidTransaction {
                 FieldDeserializationError::FromBytesError { error, .. } => Some(error),
             },
             InvalidTransaction::ExpectedNamedArguments
+            | InvalidTransaction::ExpectedBytesArguments
             | InvalidTransaction::InvalidTransactionRuntime { .. }
             | InvalidTransaction::MissingSeed => None,
         }

--- a/types/src/transaction/transaction_v1/transaction_args.rs
+++ b/types/src/transaction/transaction_v1/transaction_args.rs
@@ -80,6 +80,22 @@ impl TransactionArgs {
             }
         }
     }
+
+    /// Returns `true` if the transaction args is [`Named`].
+    ///
+    /// [`Named`]: TransactionArgs::Named
+    #[must_use]
+    pub fn is_named(&self) -> bool {
+        matches!(self, Self::Named(..))
+    }
+
+    /// Returns `true` if the transaction args is [`Bytesrepr`].
+    ///
+    /// [`Bytesrepr`]: TransactionArgs::Bytesrepr
+    #[must_use]
+    pub fn is_bytesrepr(&self) -> bool {
+        matches!(self, Self::Bytesrepr(..))
+    }
 }
 
 impl FromBytes for TransactionArgs {


### PR DESCRIPTION
This PR ensures that Vm1 runtime won't allow args of bytes that only make sense in Vm2 runtime.