### PR TITLE
Tweak tx sizes

### DIFF
--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -204,12 +204,12 @@ vm_casper_v2 = false
 # [3] -> Transaction gas limit size in bytes for a given transaction in a certain lane
 # [4] -> The maximum number of transactions the lane can contain
 native_mint_lane = [0, 2048, 1024, 2_500_000_000, 650]
-native_auction_lane = [1, 3096, 2048, 2_500_000_000, 145]
-install_upgrade_lane = [2, 1_048_576, 2048, 100_000_000_000, 1]
+native_auction_lane = [1, 3096, 2048, 2_500_000_000, 650]
+install_upgrade_lane = [2, 750_000, 2048, 100_000_000_000, 1]
 wasm_lanes = [
-    [3, 344_064, 1024, 100_000_000_000, 1],
-    [4, 172_032, 1024, 50_000_000_000, 2],
-    [5, 12_288, 512, 2_500_000_000, 80]]
+    [3, 262_144, 1024, 100_000_000_000, 1],
+    [4, 131_072, 1024, 50_000_000_000, 2],
+    [5, 16_384, 512, 2_500_000_000, 80]]
 
 [transactions.deploy]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -213,11 +213,11 @@ vm_casper_v2 = false
 # [4] -> The maximum number of transactions the lane can contain
 native_mint_lane = [0, 2048, 1024, 2_500_000_000, 650]
 native_auction_lane = [1, 3096, 2048, 2_500_000_000, 650]
-install_upgrade_lane = [2, 1_048_576, 2048, 100_000_000_000, 1]
+install_upgrade_lane = [2, 750_000, 2048, 100_000_000_000, 1]
 wasm_lanes = [
-    [3, 344_064, 1024, 100_000_000_000, 1],
-    [4, 172_032, 1024, 50_000_000_000, 2],
-    [5, 12_288, 512, 2_500_000_000, 80]]
+    [3, 262_144, 1024, 100_000_000_000, 1],
+    [4, 131_072, 1024, 50_000_000_000, 2],
+    [5, 16_384, 512, 2_500_000_000, 80]]
 
 [transactions.deploy]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.


### PR DESCRIPTION
This PR tweaks tx sizes in lanes configuration based on the mainnet Wasm data analysis

For analysis every wasm was processed through `wasm-strip`, and whether it's install/upgrade was based on either `casper_create_contract_package_at_hash` or `casper_add_contract_version` being present in the binary. Otherwise, a wasm is considered a session. 

1. The install or upgrade lane tx size was decreased by 75% from 1MiB to 750kB. Based on the heuristics above, this lane should cover all existing Wasm installers/upgraders and encourage the use of a `wasm-strip` tool or similar to minimize the Wasm binary to fit within it. The current max size of a stripped installer is 618kB, so with 750kB, there's still margin for more complex Wasms. 
2. Wasm lane 3 is decreased to 2^18 (262144 bytes), which should fit Wasm sessions that need extra size above lane 4. No Wasm was observed to date that needs more space and is not an installer.
3. Wasm lane 4 is decreased to a previous power of two (2^17). This should cover any Wasm session and encourage the use of `wasm-strip` etc. 
4. Wasm lane 5 is bumped to a next power of two (2^14) which should cover about 10% of all Wasms observed to-date. Ideal for multi-sig key management, contract calls, etc.

The maximum size of a session Wasm observed to date was 116952 (assuming each one was Wasm-stripped), so lane 3-4 should cover all use cases. 

The dataset is available here with the analysis script https://gist.github.com/mpapierski/1b7a603bde1d4fe99c836ef9b68b3d0e