### PR TITLE
GH-5039: Tweak costs and chainspec settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6075,11 +6075,23 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6093,6 +6105,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.7.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.40",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
  "tokio-serde",
  "tokio-stream",
  "tokio-util 0.6.10",
- "toml 0.7.8",
+ "toml 0.8.19",
  "tower",
  "tracing",
  "tracing-futures",
@@ -6075,23 +6075,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "indexmap 2.7.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6105,19 +6093,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.7.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.5.40",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -83,7 +83,7 @@ tokio-serde = { version = "0.8.0", features = ["bincode"] }
 tokio-stream = { version = "0.1.4", features = ["sync"] }
 tokio-util = { version = "0.6.4", features = ["codec"] }
 mio = "0.8.11"
-toml = { version = "0.7.8", features = ["preserve_order"] }
+toml = { version = "0.8.19", features = ["preserve_order"] }
 tower = { version = "0.4.6", features = ["limit"] }
 tracing = "0.1.18"
 tracing-futures = "0.2.5"

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -3283,8 +3283,14 @@ async fn run_gas_price_scenario(gas_price_scenario: GasPriceScenario) {
         .highest_complete_block()
         .maybe_current_gas_price()
         .expect("must have gas price");
-    let cost =
-        fixture.chainspec.system_costs_config.mint_costs().transfer * (current_gas_price as u32);
+
+    let cost = match fixture.chainspec.core_config.pricing_handling {
+        PricingHandling::Classic => 0,
+        PricingHandling::Fixed => {
+            fixture.chainspec.system_costs_config.mint_costs().transfer * (current_gas_price as u32)
+        }
+    };
+
     assert_eq!(holds_after, holds_before + U512::from(cost));
 
     // Run the network at zero load and ensure the value falls back to the floor.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -106,7 +106,7 @@ compute_rewards = true
 # This causes excess payment amounts to be sent to either a
 # pre-defined purse, or back to the sender.  The refunded amount is calculated as the given ratio of the payment amount
 # minus the execution costs.
-refund_handling = { type = 'no_refund' }
+refund_handling = { type = 'refund', refund_ratio = [99, 100] }
 # Defines how fees are handled.
 #
 # Valid options are:
@@ -115,7 +115,7 @@ refund_handling = { type = 'no_refund' }
 #   'accumulate': fees are accumulated in a special purse and distributed at the end of each era evenly among all
 #                 administrator accounts
 #   'burn': fees are burned
-fee_handling = { type = 'no_fee' }
+fee_handling = { type = 'pay_to_proposer' }
 # If a validator would recieve a validator credit, it cannot exceed this percentage of their total stake.
 validator_credit_cap = [1, 5]
 # Defines how pricing is handled.
@@ -205,7 +205,7 @@ vm_casper_v2 = false
 # [2] -> Max args length size in bytes for a given transaction in a certain lane
 # [3] -> Transaction gas limit size in bytes for a given transaction in a certain lane
 # [4] -> The maximum number of transactions the lane can contain
-native_mint_lane = [0, 2048, 1024, 2_500_000_000, 650]
+native_mint_lane = [0, 2048, 1024, 100_000_000, 650]
 native_auction_lane = [1, 3096, 2048, 2_500_000_000, 650]
 install_upgrade_lane = [2, 750_000, 2048, 100_000_000_000, 1]
 wasm_lanes = [
@@ -348,19 +348,21 @@ max_topics_per_contract = 128
 max_message_size = 1_024
 
 [system_costs]
+# Penalty charge for calling invalid entry point in a system contract.
+no_such_entrypoint = 2_500_000_000
 
 [system_costs.auction_costs]
-get_era_validators = 10_000
-read_seigniorage_recipients = 10_000
+get_era_validators = 2_500_000_000
+read_seigniorage_recipients = 5_000_000_000
 add_bid = 2_500_000_000
 withdraw_bid = 2_500_000_000
 delegate = 2_500_000_000
 undelegate = 2_500_000_000
-run_auction = 10_000
-slash = 10_000
-distribute = 10_000
-withdraw_delegator_reward = 10_000
-withdraw_validator_reward = 10_000
+run_auction = 2_500_000_000
+slash = 2_500_000_000
+distribute = 2_500_000_000
+withdraw_delegator_reward = 5_000_000_000
+withdraw_validator_reward = 5_000_000_000
 read_era_id = 10_000
 activate_bid = 10_000
 redelegate = 2_500_000_000
@@ -370,23 +372,22 @@ cancel_reservations = 2_500_000_000
 
 [system_costs.mint_costs]
 mint = 2_500_000_000
-reduce_total_supply = 10_000
+reduce_total_supply = 2_500_000_000
 create = 2_500_000_000
 balance = 10_000
 burn = 10_000
 transfer = 100_000_000
-read_base_round_reward = 10_000
+read_base_round_reward = 2_500_000_000
 mint_into_existing_purse = 2_500_000_000
 
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
 get_refund_purse = 10_000
-finalize_payment = 10_000
+finalize_payment = 2_500_000_000
 
 [system_costs.standard_payment_costs]
 pay = 10_000
-
 
 [vacancy]
 # The cost of a transaction is based on a multiplier. This allows for economic disincentives for misuse of the network.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -112,7 +112,7 @@ compute_rewards = true
 # This causes excess payment amounts to be sent to either a
 # pre-defined purse, or back to the sender.  The refunded amount is calculated as the given ratio of the payment amount
 # minus the execution costs.
-refund_handling = { type = 'no_refund' }
+refund_handling = { type = 'refund', refund_ratio = [99, 100] }
 # Defines how fees are handled.
 #
 # Valid options are:
@@ -121,7 +121,7 @@ refund_handling = { type = 'no_refund' }
 #   'accumulate': fees are accumulated in a special purse and distributed at the end of each era evenly among all
 #                 administrator accounts
 #   'burn': fees are burned
-fee_handling = { type = 'no_fee' }
+fee_handling = { type = 'pay_to_proposer' }
 # If a validator would recieve a validator credit, it cannot exceed this percentage of their total stake.
 validator_credit_cap = [1, 5]
 # Defines how pricing is handled.
@@ -212,7 +212,7 @@ vm_casper_v2 = false
 # [2] -> Max args length size in bytes for a given transaction in a certain lane
 # [3] -> Transaction gas limit size in bytes for a given transaction in a certain lane
 # [4] -> The maximum number of transactions the lane can contain
-native_mint_lane = [0, 2048, 1024, 2_500_000_000, 650]
+native_mint_lane = [0, 2048, 1024, 100_000_000, 650]
 native_auction_lane = [1, 3096, 2048, 2_500_000_000, 650]
 install_upgrade_lane = [2, 750_000, 2048, 100_000_000_000, 1]
 wasm_lanes = [
@@ -355,19 +355,21 @@ max_topics_per_contract = 128
 max_message_size = 1_024
 
 [system_costs]
+# Penalty charge for calling invalid entry point in a system contract.
+no_such_entrypoint = 2_500_000_000
 
 [system_costs.auction_costs]
-get_era_validators = 10_000
-read_seigniorage_recipients = 10_000
+get_era_validators = 2_500_000_000
+read_seigniorage_recipients = 5_000_000_000
 add_bid = 2_500_000_000
 withdraw_bid = 2_500_000_000
 delegate = 2_500_000_000
 undelegate = 2_500_000_000
-run_auction = 10_000
-slash = 10_000
-distribute = 10_000
-withdraw_delegator_reward = 10_000
-withdraw_validator_reward = 10_000
+run_auction = 2_500_000_000
+slash = 2_500_000_000
+distribute = 2_500_000_000
+withdraw_delegator_reward = 5_000_000_000
+withdraw_validator_reward = 5_000_000_000
 read_era_id = 10_000
 activate_bid = 10_000
 redelegate = 2_500_000_000
@@ -377,23 +379,22 @@ cancel_reservations = 2_500_000_000
 
 [system_costs.mint_costs]
 mint = 2_500_000_000
-reduce_total_supply = 10_000
+reduce_total_supply = 2_500_000_000
 create = 2_500_000_000
 balance = 10_000
 burn = 10_000
 transfer = 100_000_000
-read_base_round_reward = 10_000
+read_base_round_reward = 2_500_000_000
 mint_into_existing_purse = 2_500_000_000
 
 [system_costs.handle_payment_costs]
 get_payment_purse = 10_000
 set_refund_purse = 10_000
 get_refund_purse = 10_000
-finalize_payment = 10_000
+finalize_payment = 2_500_000_000
 
 [system_costs.standard_payment_costs]
 pay = 10_000
-
 
 [vacancy]
 # The cost of a transaction is based on a multiplier. This allows for economic disincentives for misuse of the network.

--- a/types/src/chainspec/pricing_handling.rs
+++ b/types/src/chainspec/pricing_handling.rs
@@ -18,12 +18,12 @@ const PRICING_HANDLING_FIXED_TAG: u8 = 1;
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 pub enum PricingHandling {
+    #[default]
     /// The transaction sender self-specifies how much token they pay, which becomes their gas
     /// limit.
     Classic,
     /// The costs are fixed, per the cost tables.
     // in 2.0 the default pricing handling is Fixed
-    #[default]
     Fixed,
 }
 

--- a/types/src/chainspec/vm_config/auction_costs.rs
+++ b/types/src/chainspec/vm_config/auction_costs.rs
@@ -11,39 +11,39 @@ use serde::{Deserialize, Serialize};
 use crate::bytesrepr::{self, FromBytes, ToBytes};
 
 /// Default cost of the `get_era_validators` auction entry point.
-pub const DEFAULT_GET_ERA_VALIDATORS_COST: u32 = 10_000;
+pub const DEFAULT_GET_ERA_VALIDATORS_COST: u64 = 2_500_000_000;
 /// Default cost of the `read_seigniorage_recipients` auction entry point.
-pub const DEFAULT_READ_SEIGNIORAGE_RECIPIENTS_COST: u32 = 10_000;
+pub const DEFAULT_READ_SEIGNIORAGE_RECIPIENTS_COST: u64 = 5_000_000_000;
 /// Default cost of the `add_bid` auction entry point.
 pub const DEFAULT_ADD_BID_COST: u64 = 2_500_000_000;
 /// Default cost of the `withdraw_bid` auction entry point.
-pub const DEFAULT_WITHDRAW_BID_COST: u32 = 2_500_000_000;
+pub const DEFAULT_WITHDRAW_BID_COST: u64 = 2_500_000_000;
 /// Default cost of the `delegate` auction entry point.
-pub const DEFAULT_DELEGATE_COST: u32 = DEFAULT_WITHDRAW_BID_COST;
+pub const DEFAULT_DELEGATE_COST: u64 = DEFAULT_WITHDRAW_BID_COST;
 /// Default cost of the `redelegate` auction entry point.
-pub const DEFAULT_REDELEGATE_COST: u32 = DEFAULT_WITHDRAW_BID_COST;
+pub const DEFAULT_REDELEGATE_COST: u64 = DEFAULT_WITHDRAW_BID_COST;
 /// Default cost of the `undelegate` auction entry point.
-pub const DEFAULT_UNDELEGATE_COST: u32 = DEFAULT_WITHDRAW_BID_COST;
+pub const DEFAULT_UNDELEGATE_COST: u64 = DEFAULT_WITHDRAW_BID_COST;
 /// Default cost of the `run_auction` auction entry point.
-pub const DEFAULT_RUN_AUCTION_COST: u32 = 10_000;
+pub const DEFAULT_RUN_AUCTION_COST: u64 = 2_500_000_000;
 /// Default cost of the `slash` auction entry point.
-pub const DEFAULT_SLASH_COST: u32 = 10_000;
+pub const DEFAULT_SLASH_COST: u64 = 2_500_000_000;
 /// Default cost of the `distribute` auction entry point.
-pub const DEFAULT_DISTRIBUTE_COST: u32 = 10_000;
+pub const DEFAULT_DISTRIBUTE_COST: u64 = 2_500_000_000;
 /// Default cost of the `withdraw_delegator_reward` auction entry point.
-pub const DEFAULT_WITHDRAW_DELEGATOR_REWARD_COST: u32 = 10_000;
+pub const DEFAULT_WITHDRAW_DELEGATOR_REWARD_COST: u64 = 5_000_000_000;
 /// Default cost of the `withdraw_validator_reward` auction entry point.
-pub const DEFAULT_WITHDRAW_VALIDATOR_REWARD_COST: u32 = 10_000;
+pub const DEFAULT_WITHDRAW_VALIDATOR_REWARD_COST: u64 = 5_000_000_000;
 /// Default cost of the `read_era_id` auction entry point.
-pub const DEFAULT_READ_ERA_ID_COST: u32 = 10_000;
+pub const DEFAULT_READ_ERA_ID_COST: u64 = 10_000;
 /// Default cost of the `activate_bid` auction entry point.
-pub const DEFAULT_ACTIVATE_BID_COST: u32 = 10_000;
+pub const DEFAULT_ACTIVATE_BID_COST: u64 = 10_000;
 /// Default cost of the `change_bid_public_key` auction entry point.
 pub const DEFAULT_CHANGE_BID_PUBLIC_KEY_COST: u64 = 5_000_000_000;
 /// Default cost of the `add_reservations` auction entry point.
-pub const DEFAULT_ADD_RESERVATIONS_COST: u32 = DEFAULT_WITHDRAW_BID_COST;
+pub const DEFAULT_ADD_RESERVATIONS_COST: u64 = DEFAULT_WITHDRAW_BID_COST;
 /// Default cost of the `cancel_reservations` auction entry point.
-pub const DEFAULT_CANCEL_RESERVATIONS_COST: u32 = DEFAULT_WITHDRAW_BID_COST;
+pub const DEFAULT_CANCEL_RESERVATIONS_COST: u64 = DEFAULT_WITHDRAW_BID_COST;
 
 /// Description of the costs of calling auction entrypoints.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -51,39 +51,39 @@ pub const DEFAULT_CANCEL_RESERVATIONS_COST: u32 = DEFAULT_WITHDRAW_BID_COST;
 #[serde(deny_unknown_fields)]
 pub struct AuctionCosts {
     /// Cost of calling the `get_era_validators` entry point.
-    pub get_era_validators: u32,
+    pub get_era_validators: u64,
     /// Cost of calling the `read_seigniorage_recipients` entry point.
-    pub read_seigniorage_recipients: u32,
+    pub read_seigniorage_recipients: u64,
     /// Cost of calling the `add_bid` entry point.
     pub add_bid: u64,
     /// Cost of calling the `withdraw_bid` entry point.
-    pub withdraw_bid: u32,
+    pub withdraw_bid: u64,
     /// Cost of calling the `delegate` entry point.
-    pub delegate: u32,
+    pub delegate: u64,
     /// Cost of calling the `undelegate` entry point.
-    pub undelegate: u32,
+    pub undelegate: u64,
     /// Cost of calling the `run_auction` entry point.
-    pub run_auction: u32,
+    pub run_auction: u64,
     /// Cost of calling the `slash` entry point.
-    pub slash: u32,
+    pub slash: u64,
     /// Cost of calling the `distribute` entry point.
-    pub distribute: u32,
+    pub distribute: u64,
     /// Cost of calling the `withdraw_delegator_reward` entry point.
-    pub withdraw_delegator_reward: u32,
+    pub withdraw_delegator_reward: u64,
     /// Cost of calling the `withdraw_validator_reward` entry point.
-    pub withdraw_validator_reward: u32,
+    pub withdraw_validator_reward: u64,
     /// Cost of calling the `read_era_id` entry point.
-    pub read_era_id: u32,
+    pub read_era_id: u64,
     /// Cost of calling the `activate_bid` entry point.
-    pub activate_bid: u32,
+    pub activate_bid: u64,
     /// Cost of calling the `redelegate` entry point.
-    pub redelegate: u32,
+    pub redelegate: u64,
     /// Cost of calling the `change_bid_public_key` entry point.
     pub change_bid_public_key: u64,
     /// Cost of calling the `add_reservations` entry point.
-    pub add_reservations: u32,
+    pub add_reservations: u64,
     /// Cost of calling the `cancel_reservations` entry point.
-    pub cancel_reservations: u32,
+    pub cancel_reservations: u64,
 }
 
 impl Default for AuctionCosts {
@@ -243,29 +243,24 @@ impl FromBytes for AuctionCosts {
 #[cfg(any(feature = "testing", test))]
 impl Distribution<AuctionCosts> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> AuctionCosts {
-        // there's a bug in toml...under the hood it uses an i64 when it should use a u64
-        // this causes flaky test failures if the random result exceeds i64::MAX
-        let change_bid_public_key = rng.gen::<u32>() as u64;
-        let add_bid = rng.gen::<u32>() as u64;
-
         AuctionCosts {
-            get_era_validators: rng.gen(),
-            read_seigniorage_recipients: rng.gen(),
-            add_bid,
-            withdraw_bid: rng.gen(),
-            delegate: rng.gen(),
-            undelegate: rng.gen(),
-            run_auction: rng.gen(),
-            slash: rng.gen(),
-            distribute: rng.gen(),
-            withdraw_delegator_reward: rng.gen(),
-            withdraw_validator_reward: rng.gen(),
-            read_era_id: rng.gen(),
-            activate_bid: rng.gen(),
-            redelegate: rng.gen(),
-            change_bid_public_key,
-            add_reservations: rng.gen(),
-            cancel_reservations: rng.gen(),
+            get_era_validators: rng.gen_range(0..i64::MAX) as u64,
+            read_seigniorage_recipients: rng.gen_range(0..i64::MAX) as u64,
+            add_bid: rng.gen_range(0..i64::MAX) as u64,
+            withdraw_bid: rng.gen_range(0..i64::MAX) as u64,
+            delegate: rng.gen_range(0..i64::MAX) as u64,
+            undelegate: rng.gen_range(0..i64::MAX) as u64,
+            run_auction: rng.gen_range(0..i64::MAX) as u64,
+            slash: rng.gen_range(0..i64::MAX) as u64,
+            distribute: rng.gen_range(0..i64::MAX) as u64,
+            withdraw_delegator_reward: rng.gen_range(0..i64::MAX) as u64,
+            withdraw_validator_reward: rng.gen_range(0..i64::MAX) as u64,
+            read_era_id: rng.gen_range(0..i64::MAX) as u64,
+            activate_bid: rng.gen_range(0..i64::MAX) as u64,
+            redelegate: rng.gen_range(0..i64::MAX) as u64,
+            change_bid_public_key: rng.gen_range(0..i64::MAX) as u64,
+            add_reservations: rng.gen_range(0..i64::MAX) as u64,
+            cancel_reservations: rng.gen_range(0..i64::MAX) as u64,
         }
     }
 }
@@ -273,29 +268,29 @@ impl Distribution<AuctionCosts> for Standard {
 #[doc(hidden)]
 #[cfg(any(feature = "gens", test))]
 pub mod gens {
-    use proptest::{num, prop_compose};
+    use proptest::prelude::*;
 
     use super::AuctionCosts;
 
     prop_compose! {
         pub fn auction_costs_arb()(
-            get_era_validators in num::u32::ANY,
-            read_seigniorage_recipients in num::u32::ANY,
-            add_bid in num::u64::ANY,
-            withdraw_bid in num::u32::ANY,
-            delegate in num::u32::ANY,
-            undelegate in num::u32::ANY,
-            run_auction in num::u32::ANY,
-            slash in num::u32::ANY,
-            distribute in num::u32::ANY,
-            withdraw_delegator_reward in num::u32::ANY,
-            withdraw_validator_reward in num::u32::ANY,
-            read_era_id in num::u32::ANY,
-            activate_bid in num::u32::ANY,
-            redelegate in num::u32::ANY,
-            change_bid_public_key in num::u64::ANY,
-            add_reservations in num::u32::ANY,
-            cancel_reservations in num::u32::ANY,
+            get_era_validators in 0..=(i64::MAX as u64),
+            read_seigniorage_recipients in 0..=(i64::MAX as u64),
+            add_bid in 0..=(i64::MAX as u64),
+            withdraw_bid in 0..=(i64::MAX as u64),
+            delegate in 0..=(i64::MAX as u64),
+            undelegate in 0..=(i64::MAX as u64),
+            run_auction in 0..=(i64::MAX as u64),
+            slash in 0..=(i64::MAX as u64),
+            distribute in 0..=(i64::MAX as u64),
+            withdraw_delegator_reward in 0..=(i64::MAX as u64),
+            withdraw_validator_reward in 0..=(i64::MAX as u64),
+            read_era_id in 0..=(i64::MAX as u64),
+            activate_bid in 0..=(i64::MAX as u64),
+            redelegate in 0..=(i64::MAX as u64),
+            change_bid_public_key in 0..=(i64::MAX as u64),
+            add_reservations in 0..=(i64::MAX as u64),
+            cancel_reservations in 0..=(i64::MAX as u64),
         ) -> AuctionCosts {
             AuctionCosts {
                 get_era_validators,

--- a/types/src/chainspec/vm_config/handle_payment_costs.rs
+++ b/types/src/chainspec/vm_config/handle_payment_costs.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_SET_REFUND_PURSE_COST: u32 = 10_000;
 /// Default cost of the `get_refund_purse` `handle_payment` entry point.
 pub const DEFAULT_GET_REFUND_PURSE_COST: u32 = 10_000;
 /// Default cost of the `finalize_payment` `handle_payment` entry point.
-pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 10_000;
+pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 2_500_000_000;
 
 /// Description of the costs of calling `handle_payment` entrypoints.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug)]

--- a/types/src/chainspec/vm_config/mint_costs.rs
+++ b/types/src/chainspec/vm_config/mint_costs.rs
@@ -13,7 +13,7 @@ use crate::bytesrepr::{self, FromBytes, ToBytes};
 /// Default cost of the `mint` mint entry point.
 pub const DEFAULT_MINT_COST: u32 = 2_500_000_000;
 /// Default cost of the `reduce_total_supply` mint entry point.
-pub const DEFAULT_REDUCE_TOTAL_SUPPLY_COST: u32 = 10_000;
+pub const DEFAULT_REDUCE_TOTAL_SUPPLY_COST: u32 = 2_500_000_000;
 /// Default cost of the `burn` mint entry point.
 pub const DEFAULT_BURN_COST: u32 = 10_000;
 /// Default cost of the `create` mint entry point.
@@ -23,7 +23,7 @@ pub const DEFAULT_BALANCE_COST: u32 = 10_000;
 /// Default cost of the `transfer` mint entry point.
 pub const DEFAULT_TRANSFER_COST: u32 = 100_000_000;
 /// Default cost of the `read_base_round_reward` mint entry point.
-pub const DEFAULT_READ_BASE_ROUND_REWARD_COST: u32 = 10_000;
+pub const DEFAULT_READ_BASE_ROUND_REWARD_COST: u32 = 2_500_000_000;
 /// Default cost of the `mint_into_existing_purse` mint entry point.
 pub const DEFAULT_MINT_INTO_EXISTING_PURSE_COST: u32 = 2_500_000_000;
 

--- a/types/src/chainspec/vm_config/system_config.rs
+++ b/types/src/chainspec/vm_config/system_config.rs
@@ -14,11 +14,14 @@ use crate::{
     chainspec::vm_config::{AuctionCosts, HandlePaymentCosts, MintCosts, StandardPaymentCosts},
 };
 
+/// Default cost for calls not a non-existent entrypoint.
+pub const DEFAULT_NO_SUCH_ENTRYPOINT_COST: u64 = 2_500_000_000;
+
 /// Definition of costs in the system.
 ///
 /// This structure contains the costs of all the system contract's entry points and, additionally,
 /// it defines a wasmless mint cost.
-#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[serde(deny_unknown_fields)]
 pub struct SystemConfig {
@@ -36,6 +39,19 @@ pub struct SystemConfig {
 
     /// Configuration of standard payment costs.
     standard_payment_costs: StandardPaymentCosts,
+}
+
+impl Default for SystemConfig {
+    /// Implements Default for SystemConfig.
+    fn default() -> Self {
+        Self {
+            no_such_entrypoint: DEFAULT_NO_SUCH_ENTRYPOINT_COST,
+            auction_costs: Default::default(),
+            handle_payment_costs: Default::default(),
+            mint_costs: Default::default(),
+            standard_payment_costs: Default::default(),
+        }
+    }
 }
 
 impl SystemConfig {

--- a/types/src/transaction/pricing_mode.rs
+++ b/types/src/transaction/pricing_mode.rs
@@ -172,25 +172,19 @@ impl PricingMode {
                                 costs.auction_costs().add_bid
                             }
                             TransactionEntryPoint::WithdrawBid => {
-                                costs.auction_costs().withdraw_bid.into()
+                                costs.auction_costs().withdraw_bid
                             }
-                            TransactionEntryPoint::Delegate => {
-                                costs.auction_costs().delegate.into()
-                            }
-                            TransactionEntryPoint::Undelegate => {
-                                costs.auction_costs().undelegate.into()
-                            }
-                            TransactionEntryPoint::Redelegate => {
-                                costs.auction_costs().redelegate.into()
-                            }
+                            TransactionEntryPoint::Delegate => costs.auction_costs().delegate,
+                            TransactionEntryPoint::Undelegate => costs.auction_costs().undelegate,
+                            TransactionEntryPoint::Redelegate => costs.auction_costs().redelegate,
                             TransactionEntryPoint::ChangeBidPublicKey => {
                                 costs.auction_costs().change_bid_public_key
                             }
                             TransactionEntryPoint::AddReservations => {
-                                costs.auction_costs().add_reservations.into()
+                                costs.auction_costs().add_reservations
                             }
                             TransactionEntryPoint::CancelReservations => {
-                                costs.auction_costs().cancel_reservations.into()
+                                costs.auction_costs().cancel_reservations
                             }
                         };
                         amount


### PR DESCRIPTION
Closes #5039 

This PR adds a gas charge for calling a non-existing system contract entry point. Additionally, some charges for incorrectly charged system contract entrypoints are raised significantly (10k motes -> 2.5 CSPR or more depending on complexity).

This PR changes fee_handling and refund_handling to be consistent with 1.5.x settings (refund 99% and pay to proposer)

#5047 
