### PR TITLE
Make get_package handle `Key::Hash`

### DIFF
--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -2360,7 +2360,6 @@ async fn should_reject_transaction_v1_with_missing_version_in_session_contract_p
         ContractPackageScenario::MissingContractVersion,
     );
     let result = run_transaction_acceptor(test_scenario).await;
-    println!("{:?}", result);
     assert!(matches!(
         result,
         Err(super::Error::Parameters {

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -1876,7 +1876,6 @@ async fn should_reject_deploy_with_missing_version_in_payment_contract_package_f
         ContractPackageScenario::MissingContractVersion,
     );
     let result = run_transaction_acceptor(test_scenario).await;
-    println!("{:?}", result);
     assert!(matches!(
         result,
         Err(super::Error::Parameters {

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -32,11 +32,11 @@ use casper_types::{
     account::{Account, AccountHash, ActionThresholds, AssociatedKeys, Weight},
     addressable_entity::AddressableEntity,
     bytesrepr::Bytes,
-    contracts::NamedKeys,
+    contracts::{ContractPackage, NamedKeys},
     global_state::TrieMerkleProof,
     testing::TestRng,
     Block, BlockV2, CLValue, Chainspec, ChainspecRawBytes, Contract, Deploy, EraId, HashAddr,
-    InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Package, PricingHandling, PricingMode,
+    InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Key, PricingHandling, PricingMode,
     ProtocolVersion, PublicKey, SecretKey, StoredValue, TestBlockBuilder, TimeDiff, Timestamp,
     Transaction, TransactionArgs, TransactionConfig, TransactionRuntimeParams, TransactionV1, URef,
     U512,
@@ -826,44 +826,47 @@ impl reactor::Reactor for Reactor {
                     request: query_request,
                     responder,
                 } => {
-                    let query_result = if let Key::SmartContract(_) = query_request.key() {
-                        match self.test_scenario {
-                            TestScenario::FromPeerCustomPaymentContractPackage(
-                                ContractPackageScenario::MissingPackageAtHash,
-                            )
-                            | TestScenario::FromPeerSessionContractPackage(
-                                _,
-                                ContractPackageScenario::MissingPackageAtHash,
-                            )
-                            | TestScenario::FromClientCustomPaymentContractPackage(
-                                ContractPackageScenario::MissingPackageAtHash,
-                            )
-                            | TestScenario::FromClientSessionContractPackage(
-                                _,
-                                ContractPackageScenario::MissingPackageAtHash,
-                            ) => QueryResult::ValueNotFound(String::new()),
-                            TestScenario::FromPeerCustomPaymentContractPackage(
-                                ContractPackageScenario::MissingContractVersion,
-                            )
-                            | TestScenario::FromPeerSessionContractPackage(
-                                _,
-                                ContractPackageScenario::MissingContractVersion,
-                            )
-                            | TestScenario::FromClientCustomPaymentContractPackage(
-                                ContractPackageScenario::MissingContractVersion,
-                            )
-                            | TestScenario::FromClientSessionContractPackage(
-                                _,
-                                ContractPackageScenario::MissingContractVersion,
-                            ) => QueryResult::Success {
-                                value: Box::new(StoredValue::SmartContract(Package::default())),
-                                proofs: vec![],
-                            },
-                            _ => panic!("unexpected query: {:?}", query_request),
-                        }
-                    } else {
-                        panic!("expect only queries using Key::Package variant");
-                    };
+                    let query_result =
+                        if let Key::Hash(_) | Key::SmartContract(_) = query_request.key() {
+                            match self.test_scenario {
+                                TestScenario::FromPeerCustomPaymentContractPackage(
+                                    ContractPackageScenario::MissingPackageAtHash,
+                                )
+                                | TestScenario::FromPeerSessionContractPackage(
+                                    _,
+                                    ContractPackageScenario::MissingPackageAtHash,
+                                )
+                                | TestScenario::FromClientCustomPaymentContractPackage(
+                                    ContractPackageScenario::MissingPackageAtHash,
+                                )
+                                | TestScenario::FromClientSessionContractPackage(
+                                    _,
+                                    ContractPackageScenario::MissingPackageAtHash,
+                                ) => QueryResult::ValueNotFound(String::new()),
+                                TestScenario::FromPeerCustomPaymentContractPackage(
+                                    ContractPackageScenario::MissingContractVersion,
+                                )
+                                | TestScenario::FromPeerSessionContractPackage(
+                                    _,
+                                    ContractPackageScenario::MissingContractVersion,
+                                )
+                                | TestScenario::FromClientCustomPaymentContractPackage(
+                                    ContractPackageScenario::MissingContractVersion,
+                                )
+                                | TestScenario::FromClientSessionContractPackage(
+                                    _,
+                                    ContractPackageScenario::MissingContractVersion,
+                                ) => QueryResult::Success {
+                                    value: Box::new(StoredValue::ContractPackage(
+                                        ContractPackage::default(),
+                                    )),
+                                    proofs: vec![],
+                                },
+                                _ => panic!("unexpected query: {:?}", query_request),
+                            }
+                        } else {
+                            panic!("expect only queries using Key::Package variant");
+                        };
                     responder.respond(query_result).ignore()
                 }
                 ContractRuntimeRequest::GetBalance {
@@ -1873,6 +1876,7 @@ async fn should_reject_deploy_with_missing_version_in_payment_contract_package_f
         ContractPackageScenario::MissingContractVersion,
     );
     let result = run_transaction_acceptor(test_scenario).await;
+    println!("{:?}", result);
     assert!(matches!(
         result,
         Err(super::Error::Parameters {
@@ -2357,6 +2361,7 @@ async fn should_reject_transaction_v1_with_missing_version_in_session_contract_p
         ContractPackageScenario::MissingContractVersion,
     );
     let result = run_transaction_acceptor(test_scenario).await;
+    println!("{:?}", result);
     assert!(matches!(
         result,
         Err(super::Error::Parameters {

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -2017,7 +2017,7 @@ impl<REv> EffectBuilder<REv> {
             QueryResult::ValueNotFound(_) => {
                 let query_request =
                     QueryRequest::new(state_root_hash, Key::SmartContract(package_addr), vec![]);
-                error!("requesting under different key");
+                debug!("requesting under different key");
                 if let QueryResult::Success { value, .. } =
                     self.query_global_state(query_request).await
                 {


### PR DESCRIPTION
CHANGELOG:

- Amend `get_package` on the effect builder to take a package addr and handle retrieving both contract packages and packages.


Closes #5050 