### PR TITLE
Update wasm lane 5.

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -80,4 +80,6 @@ jobs:
         run: make doc
 
       - name: audit
-        run: make audit
+        run: |
+          cargo install cargo-audit --locked
+          make audit

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -211,7 +211,8 @@ install_upgrade_lane = [2, 750_000, 2048, 100_000_000_000, 1]
 wasm_lanes = [
     [3, 262_144, 1024, 100_000_000_000, 1],
     [4, 131_072, 1024, 50_000_000_000, 2],
-    [5, 16_384, 512, 2_500_000_000, 80]]
+    [5, 65_536, 512, 3_000_000_000, 80]
+]
 
 [transactions.deploy]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -218,7 +218,8 @@ install_upgrade_lane = [2, 750_000, 2048, 100_000_000_000, 1]
 wasm_lanes = [
     [3, 262_144, 1024, 100_000_000_000, 1],
     [4, 131_072, 1024, 50_000_000_000, 2],
-    [5, 16_384, 512, 2_500_000_000, 80]]
+    [5, 65_536, 512, 3_000_000_000, 80]
+]
 
 [transactions.deploy]
 # The maximum number of Motes allowed to be spent during payment.  0 means unlimited.


### PR DESCRIPTION
This PR adjusts 5th lane in size, and in gas limit.

- 65k will fit more than half of the wasm sessions used in the mainnet to date 
- 3CSPR will accommodate a Wasm with at least one transfer (2.5CSPR) with some extra code.

See also mainnet data analysis here: https://gist.github.com/mpapierski/1b7a603bde1d4fe99c836ef9b68b3d0e#file-data_with_imports-csv