### PR TITLE
GH-5058: Handle payment fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,6 +2828,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gh-5058-regression"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -308,11 +308,13 @@ pub fn execute_finalized_block(
                 // in a custom way. If anything goes wrong, penalize the sender, do not execute
                 let custom_payment_gas_limit =
                     Gas::new(chainspec.transaction_config.native_transfer_minimum_motes * 5);
-                let session_input_data = transaction.to_session_input_data();
+
+                let payment_input_data = transaction.to_payment_input_data();
+
                 let pay_result = match WasmV1Request::new_custom_payment(
                     BlockInfo::new(state_root_hash, block_time, parent_block_hash, block_height),
                     custom_payment_gas_limit,
-                    &session_input_data,
+                    &payment_input_data,
                 ) {
                     Ok(mut pay_request) => {
                         // We'll send a hint to the custom payment logic on the amount

--- a/node/src/components/contract_runtime/tests.rs
+++ b/node/src/components/contract_runtime/tests.rs
@@ -1,6 +1,7 @@
-use std::{collections::BTreeMap, iter, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, fs, iter, path::PathBuf, sync::Arc, time::Duration};
 
 use derive_more::{Display, From};
+use once_cell::sync::Lazy;
 use prometheus::Registry;
 use rand::RngCore;
 use serde::Serialize;
@@ -11,6 +12,7 @@ use casper_types::{
     ExecutableDeployItem, PublicKey, SecretKey, TimeDiff, Timestamp, Transaction,
     TransactionConfig, MINT_LANE_ID, U512,
 };
+use tests::testing::LARGE_WASM_LANE_ID;
 
 use super::*;
 use crate::{

--- a/node/src/components/contract_runtime/tests.rs
+++ b/node/src/components/contract_runtime/tests.rs
@@ -1,7 +1,6 @@
-use std::{collections::BTreeMap, fs, iter, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, iter, sync::Arc, time::Duration};
 
 use derive_more::{Display, From};
-use once_cell::sync::Lazy;
 use prometheus::Registry;
 use rand::RngCore;
 use serde::Serialize;
@@ -12,7 +11,6 @@ use casper_types::{
     ExecutableDeployItem, PublicKey, SecretKey, TimeDiff, Timestamp, Transaction,
     TransactionConfig, MINT_LANE_ID, U512,
 };
-use tests::testing::LARGE_WASM_LANE_ID;
 
 use super::*;
 use crate::{

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -98,7 +98,7 @@ async fn send_wasm_transaction(
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_chain_name(chain_name)
         .with_pricing_mode(pricing)
@@ -1769,7 +1769,7 @@ async fn only_refunds_are_burnt_no_fee_custom_payment() {
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_chain_name(CHAIN_NAME)
         .with_pricing_mode(PricingMode::PaymentLimited {
@@ -2434,7 +2434,7 @@ fn invalid_wasm_txn(initiator: Arc<SecretKey>, pricing_mode: PricingMode) -> Tra
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_chain_name(CHAIN_NAME)
         .with_pricing_mode(pricing_mode)
@@ -3141,7 +3141,7 @@ async fn insufficient_funds_transfer_from_purse() {
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_runtime_args(runtime_args! { "destination" => purse_name, "amount" => U512::zero() })
         .with_chain_name(CHAIN_NAME)
@@ -3267,7 +3267,7 @@ async fn charge_when_session_code_succeeds() {
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_runtime_args(runtime_args! {
             ARG_TARGET => CHARLIE_PUBLIC_KEY.to_account_hash(),
@@ -3338,7 +3338,7 @@ async fn charge_when_session_code_fails_with_user_error() {
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_chain_name(CHAIN_NAME)
         .with_initiator_addr(BOB_PUBLIC_KEY.clone())
@@ -3406,7 +3406,7 @@ async fn charge_when_session_code_runs_out_of_gas() {
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_chain_name(CHAIN_NAME)
         .with_initiator_addr(BOB_PUBLIC_KEY.clone())
@@ -3732,7 +3732,7 @@ async fn out_of_gas_txn_does_not_produce_effects() {
         TransactionV1Builder::new_session(
             false,
             module_bytes,
-            casper_types::TransactionRuntimeParams::VmCasperV1,
+            TransactionRuntimeParams::VmCasperV1,
         )
         .with_chain_name(CHAIN_NAME)
         .with_initiator_addr(BOB_PUBLIC_KEY.clone())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.78.0"

--- a/smart_contracts/contracts/test/gh-5058-regression/Cargo.toml
+++ b/smart_contracts/contracts/test/gh-5058-regression/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "gh-5058-regression"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "gh_5058_regression"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/gh-5058-regression/src/main.rs
+++ b/smart_contracts/contracts/test/gh-5058-regression/src/main.rs
@@ -1,0 +1,61 @@
+#![no_main]
+#![no_std]
+
+extern crate alloc;
+
+use casper_contract::{
+    contract_api::{account, runtime, system},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+
+use casper_types::{
+    runtime_args, system::handle_payment, ApiError, Phase, RuntimeArgs, URef, U512,
+};
+
+const ARG_AMOUNT: &str = "amount";
+
+#[repr(u16)]
+enum Error {
+    InvalidPhase,
+}
+
+impl From<Error> for ApiError {
+    fn from(e: Error) -> Self {
+        ApiError::User(e as u16)
+    }
+}
+
+fn get_payment_purse() -> URef {
+    runtime::call_contract(
+        system::get_handle_payment(),
+        handle_payment::METHOD_GET_PAYMENT_PURSE,
+        RuntimeArgs::default(),
+    )
+}
+
+fn set_refund_purse(new_refund_purse: URef) {
+    let args = runtime_args! {
+        handle_payment::ARG_PURSE => new_refund_purse,
+    };
+
+    runtime::call_contract(
+        system::get_handle_payment(),
+        handle_payment::METHOD_SET_REFUND_PURSE,
+        args,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    if runtime::get_phase() != Phase::Payment {
+        runtime::revert(Error::InvalidPhase);
+    }
+
+    let amount: U512 = runtime::get_named_arg(ARG_AMOUNT);
+    let payment_purse = get_payment_purse();
+    set_refund_purse(account::get_main_purse());
+
+    // transfer amount from named purse to payment purse, which will be used to pay for execution
+    system::transfer_from_purse_to_purse(account::get_main_purse(), payment_purse, amount, None)
+        .unwrap_or_revert();
+}

--- a/smart_contracts/sdk/src/lib.rs
+++ b/smart_contracts/sdk/src/lib.rs
@@ -342,16 +342,6 @@ impl<'a, T: ContractRef> ContractBuilder<'a, T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[allow(dead_code)]
-    struct MyContract;
-
-    #[derive(BorshSerialize)]
-    struct DoSomethingArg {
-        foo: u64,
-    }
-
     // impl ToCallData for DoSomethingArg {
     //     const SELECTOR: Selector = Selector::new(1);
     //     type Return<'a> = ();

--- a/storage/src/data_access_layer/handle_refund.rs
+++ b/storage/src/data_access_layer/handle_refund.rs
@@ -83,12 +83,14 @@ impl HandleRefundMode {
     /// Returns the appropriate phase for the mode.
     pub fn phase(&self) -> Phase {
         match self {
-            HandleRefundMode::ClearRefundPurse
-            | HandleRefundMode::Burn { .. }
+            HandleRefundMode::Burn { .. }
             | HandleRefundMode::Refund { .. }
             | HandleRefundMode::CustomHold { .. }
             | HandleRefundMode::RefundAmount { .. } => Phase::FinalizePayment,
-            HandleRefundMode::SetRefundPurse { .. } => Phase::Payment,
+
+            HandleRefundMode::ClearRefundPurse | HandleRefundMode::SetRefundPurse { .. } => {
+                Phase::Payment
+            }
         }
     }
 }


### PR DESCRIPTION
This change fixes custom payment under `Transaction::Deploy` variant which incorrectly took session bytes, rather than payment field. Additionally, it does properly remove the named key when payment is finalized.

Closes #5058 