### PR TITLE
[BUGFIX] Fix small wasm / big args lane assignment

### DIFF
--- a/node/src/types/transaction/meta_transaction.rs
+++ b/node/src/types/transaction/meta_transaction.rs
@@ -353,14 +353,14 @@ mod proptests {
                 TransactionLaneDefinition {
                     id: 3,
                     max_transaction_length: u64::MAX/2,
-                    max_transaction_args_length: 100,
+                    max_transaction_args_length: 10000,
                     max_transaction_gas_limit: u64::MAX/2,
                     max_transaction_count: 10,
                 },
                 TransactionLaneDefinition {
                     id: 4,
                     max_transaction_length: u64::MAX,
-                    max_transaction_args_length: 100,
+                    max_transaction_args_length: 10000,
                     max_transaction_gas_limit: u64::MAX,
                     max_transaction_count: 10,
                 },

--- a/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
+++ b/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
@@ -48,6 +48,12 @@ impl MetaTransactionV1 {
         v1: &TransactionV1,
         transaction_v1_config: &TransactionV1Config,
     ) -> Result<MetaTransactionV1, InvalidTransaction> {
+        let args_binary_len = v1
+            .payload()
+            .fields()
+            .get(&ARGS_MAP_KEY)
+            .map(|field| field.len())
+            .unwrap_or(0);
         let args: TransactionArgs = v1.deserialize_field(ARGS_MAP_KEY).map_err(|error| {
             InvalidTransaction::V1(InvalidTransactionV1::CouldNotDeserializeField { error })
         })?;
@@ -72,13 +78,13 @@ impl MetaTransactionV1 {
         let payload_hash = v1.payload_hash()?;
         let serialized_length = v1.serialized_length();
         let pricing_mode = v1.payload().pricing_mode();
-
         let lane_id = calculate_transaction_lane(
             &entry_point,
             &target,
             pricing_mode,
             transaction_v1_config,
             serialized_length as u64,
+            args_binary_len as u64,
         )?;
         let has_valid_hash = v1.has_valid_hash();
         let approvals = v1.approvals().clone();

--- a/types/src/auction_state.rs
+++ b/types/src/auction_state.rs
@@ -1,6 +1,9 @@
-use alloc::collections::{btree_map::Entry, BTreeMap};
+#![allow(deprecated)]
 
-use alloc::vec::Vec;
+use alloc::{
+    collections::{btree_map::Entry, BTreeMap},
+    vec::Vec,
+};
 #[cfg(feature = "json-schema")]
 use once_cell::sync::Lazy;
 #[cfg(feature = "json-schema")]
@@ -32,6 +35,7 @@ static ERA_VALIDATORS: Lazy<EraValidators> = Lazy::new(|| {
 
     era_validators
 });
+
 #[cfg(feature = "json-schema")]
 static AUCTION_INFO: Lazy<AuctionState> = Lazy::new(|| {
     use crate::{system::auction::DelegationRate, AccessRights, SecretKey, URef};
@@ -74,6 +78,7 @@ static AUCTION_INFO: Lazy<AuctionState> = Lazy::new(|| {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
+#[deprecated(since = "5.0.0")]
 pub struct JsonValidatorWeights {
     public_key: PublicKey,
     weight: U512,
@@ -83,6 +88,7 @@ pub struct JsonValidatorWeights {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
+#[deprecated(since = "5.0.0")]
 pub struct JsonEraValidators {
     era_id: EraId,
     validator_weights: Vec<JsonValidatorWeights>,
@@ -92,6 +98,7 @@ pub struct JsonEraValidators {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[serde(deny_unknown_fields)]
+#[deprecated(since = "5.0.0")]
 pub struct AuctionState {
     /// Global state hash.
     pub state_root_hash: Digest,
@@ -106,6 +113,8 @@ pub struct AuctionState {
 
 impl AuctionState {
     /// Create new instance of `AuctionState`
+    /// this logic will retrofit new data into old structure if applicable (it's a lossy
+    /// conversion).
     pub fn new(
         state_root_hash: Digest,
         block_height: u64,
@@ -186,7 +195,7 @@ impl AuctionState {
             state_root_hash,
             block_height,
             era_validators: json_era_validators,
-            bids: BTreeMap::new(), // TODO: figure out if we can retro compat or not
+            bids,
         }
     }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -94,6 +94,7 @@ pub use addressable_entity::{
 };
 #[doc(inline)]
 pub use api_error::ApiError;
+#[allow(deprecated)]
 pub use auction_state::{AuctionState, JsonEraValidators, JsonValidatorWeights};
 #[cfg(all(feature = "std", feature = "json-schema"))]
 pub use block::JsonBlockWithSignatures;


### PR DESCRIPTION
Lane determination improved to consider more variables to cover edge case assignment of transactions with small wasm byte count but large args byte count.
