### PR TITLE
Execute two sets of installer code to extend coverage

### DIFF
--- a/node/src/components/transaction_buffer.rs
+++ b/node/src/components/transaction_buffer.rs
@@ -256,8 +256,8 @@ impl TransactionBuffer {
     /// Update buffer considering new stored transaction.
     fn register_transaction(&mut self, transaction: Transaction) {
         let transaction_hash = transaction.hash();
-        if transaction.verify().is_err() {
-            error!(%transaction_hash, "TransactionBuffer: invalid transaction must not be buffered");
+        if let Err(error) = transaction.verify() {
+            error!(%transaction_hash, ?error, "TransactionBuffer: invalid transaction must not be buffered");
             return;
         }
 


### PR DESCRIPTION
One session code is an installer that uses standard payment and is expected to succeed, and another one uses same installer, but specifies non standard payment and will fail to execute.

Closes #5082 