### PR TITLE
[BUGFIX] Fix remove_associated_keys

### DIFF
--- a/execution_engine/src/runtime/externals.rs
+++ b/execution_engine/src/runtime/externals.rs
@@ -682,7 +682,7 @@ where
                     output_size,
                 ) = Args::parse(args)?;
                 self.charge_host_function_call(
-                    &host_function_costs.add_package_version,
+                    &host_function_costs.add_contract_version_with_message_topics,
                     [
                         contract_package_hash_ptr,
                         contract_package_hash_size,

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -1177,12 +1177,6 @@ where
             // Get the current entity record
             let entity = {
                 let mut entity: AddressableEntity = self.read_gs_typed(&context_key)?;
-                // enforce max keys limit
-                if entity.associated_keys().len()
-                    >= (self.engine_config.max_associated_keys() as usize)
-                {
-                    return Err(ExecError::AddKeyFailure(AddKeyFailure::MaxKeysLimit));
-                }
 
                 // Exit early in case of error without updating global state
                 entity
@@ -1199,12 +1193,6 @@ where
             // Take an account out of the global state
             let account = {
                 let mut account: Account = self.read_gs_typed(&context_key)?;
-
-                if account.associated_keys().len()
-                    >= (self.engine_config.max_associated_keys() as usize)
-                {
-                    return Err(ExecError::AddKeyFailure(AddKeyFailure::MaxKeysLimit));
-                }
 
                 // Exit early in case of error without updating global state
                 account

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -17,7 +17,7 @@ use num_traits::{CheckedMul, Zero};
 use tempfile::TempDir;
 
 use casper_execution_engine::engine_state::{
-    Error, ExecutionEngineV1, WasmV1Request, WasmV1Result, DEFAULT_MAX_QUERY_DEPTH,
+    EngineConfig, Error, ExecutionEngineV1, WasmV1Request, WasmV1Result, DEFAULT_MAX_QUERY_DEPTH,
 };
 use casper_storage::{
     data_access_layer::{
@@ -1261,6 +1261,12 @@ where
     pub fn with_chainspec(&mut self, chainspec: ChainspecConfig) -> &mut Self {
         self.chainspec = chainspec;
         self.execution_engine = Rc::new(ExecutionEngineV1::new(self.chainspec.engine_config()));
+        self
+    }
+
+    /// Update the engine config of the builder.
+    pub fn with_engine_config(&mut self, engine_config: EngineConfig) -> &mut Self {
+        self.execution_engine = Rc::new(ExecutionEngineV1::new(engine_config));
         self
     }
 

--- a/execution_engine_testing/tests/src/test/contract_api/account/associated_keys.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/account/associated_keys.rs
@@ -4,7 +4,13 @@ use casper_engine_test_support::{
     ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT,
     LOCAL_GENESIS_REQUEST,
 };
-use casper_types::{account::AccountHash, addressable_entity::Weight, runtime_args, U512};
+use casper_execution_engine::{
+    engine_state::{EngineConfigBuilder, Error},
+    execution::ExecError,
+};
+use casper_types::{
+    account::AccountHash, addressable_entity::Weight, runtime_args, ApiError, U512,
+};
 
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";
 const CONTRACT_REMOVE_ASSOCIATED_KEY: &str = "remove_associated_key.wasm";
@@ -73,4 +79,62 @@ fn should_manage_associated_key() {
 
     let is_error = builder.is_error();
     assert!(!is_error);
+}
+
+#[ignore]
+#[test]
+fn should_remove_associated_key_when_at_max_allowed_cap() {
+    let mut builder = LmdbWasmTestBuilder::default();
+
+    let engine_config = EngineConfigBuilder::new()
+        .with_max_associated_keys(2)
+        .build();
+
+    builder
+        .with_engine_config(engine_config)
+        .run_genesis(LOCAL_GENESIS_REQUEST.clone())
+        .commit();
+
+    assert_eq!(builder.get_engine_state().config().max_associated_keys(), 2);
+
+    let exec_request_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_PURSE_TO_ACCOUNT,
+        runtime_args! { "target" => ACCOUNT_1_ADDR, "amount" => *ACCOUNT_1_INITIAL_FUND },
+    )
+    .build();
+    let exec_request_2 = ExecuteRequestBuilder::standard(
+        ACCOUNT_1_ADDR,
+        CONTRACT_ADD_UPDATE_ASSOCIATED_KEY,
+        runtime_args! { "account" => *DEFAULT_ACCOUNT_ADDR, },
+    )
+    .build();
+
+    builder.exec(exec_request_1).expect_success().commit();
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let exec_request_3 = ExecuteRequestBuilder::standard(
+        ACCOUNT_1_ADDR,
+        CONTRACT_ADD_UPDATE_ASSOCIATED_KEY,
+        runtime_args! { "account" => *DEFAULT_ACCOUNT_ADDR, },
+    )
+    .build();
+
+    builder.exec(exec_request_3).expect_failure();
+
+    let error = builder.get_error().expect("we asserted the failure");
+
+    assert!(matches!(
+        error,
+        Error::Exec(ExecError::Revert(ApiError::MaxKeysLimit))
+    ));
+
+    let exec_request_4 = ExecuteRequestBuilder::standard(
+        ACCOUNT_1_ADDR,
+        CONTRACT_REMOVE_ASSOCIATED_KEY,
+        runtime_args! { ARG_ACCOUNT => *DEFAULT_ACCOUNT_ADDR, },
+    )
+    .build();
+
+    builder.exec(exec_request_4).expect_success().commit();
 }

--- a/types/src/key.rs
+++ b/types/src/key.rs
@@ -952,14 +952,6 @@ impl Key {
             }
         }
 
-        // if let Some(contract_entity_hash) = input.strip_prefix(STATE_PREFIX) {
-        //     let addr = match EntityAddr::from_formatted_str(contract_entity_hash) {
-        //         Ok(ret) => ret,
-        //         Err(err) => panic!("{err}"),
-        //     };
-        //     return Ok(Key::State(addr));
-        // }
-
         Err(FromStrError::UnknownPrefix)
     }
 
@@ -991,16 +983,6 @@ impl Key {
             _ => None,
         }
     }
-
-    // /// Returns [`EntityAddr`] of `self` if `self` is of type [`Key::AddressableEntity`],
-    // ///  otherwise returns `None`.
-    // pub fn as_entity_addr(&self) -> Option<EntityAddr> {
-    //     match self {
-    //         Key::AddressableEntity(addr) => Some(*addr),
-    //         Key::Account(account_hash) => Some(EntityAddr::Account(account_hash.value())),
-    //         _ => None,
-    //     }
-    // }
 
     /// Returns the inner bytes of `self` if `self` is of type [`Key::SmartContract`], otherwise
     /// returns `None`.


### PR DESCRIPTION
CHANGELOG:

- Removed an incorrect check against the `max_associated_keys` limit in `remove_associated_keys`
- Correctly assign the charge for `add_contract_package_with_message_topics` in externals