### PR TITLE
[BUGFIX] Return intended error variants from several auction internal methods

### DIFF
--- a/execution_engine/src/runtime/auction_internal.rs
+++ b/execution_engine/src/runtime/auction_internal.rs
@@ -487,23 +487,25 @@ where
             <Option<Error>>::from(exec_error).unwrap_or(Error::MissingValue)
         })?;
         self.mint_read_base_round_reward(mint_hash)
-            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::MissingValue))
+            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::MintReward))
     }
 
     fn mint(&mut self, amount: U512) -> Result<URef, Error> {
-        let mint_hash = self
-            .get_mint_hash()
-            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::MintReward))?;
+        let mint_hash = self.get_mint_hash().map_err(|exec_error| {
+            <Option<Error>>::from(exec_error).unwrap_or(Error::MissingValue)
+        })?;
         self.mint_mint(mint_hash, amount)
-            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::MintReward))
+            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::MintError))
     }
 
     fn reduce_total_supply(&mut self, amount: U512) -> Result<(), Error> {
-        let mint_hash = self
-            .get_mint_hash()
-            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::MintReward))?;
+        let mint_hash = self.get_mint_hash().map_err(|exec_error| {
+            <Option<Error>>::from(exec_error).unwrap_or(Error::MissingValue)
+        })?;
         self.mint_reduce_total_supply(mint_hash, amount)
-            .map_err(|exec_error| <Option<Error>>::from(exec_error).unwrap_or(Error::MintReward))
+            .map_err(|exec_error| {
+                <Option<Error>>::from(exec_error).unwrap_or(Error::MintReduceTotalSupply)
+            })
     }
 }
 

--- a/execution_engine/src/runtime_context/mod.rs
+++ b/execution_engine/src/runtime_context/mod.rs
@@ -857,7 +857,7 @@ where
             Ok(entity_addr) => key.is_addable(&entity_addr),
             Err(error) => {
                 error!(?error, "entity_key is unexpected key variant");
-                panic!("is_readable: entity_key is unexpected key variant");
+                panic!("is_addable: entity_key is unexpected key variant");
             }
         }
     }
@@ -868,7 +868,7 @@ where
             Ok(entity_addr) => key.is_writeable(&entity_addr),
             Err(error) => {
                 error!(?error, "entity_key is unexpected key variant");
-                panic!("is_readable: entity_key is unexpected key variant");
+                panic!("is_writeable: entity_key is unexpected key variant");
             }
         }
     }

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -637,7 +637,7 @@ impl TransactionAcceptor {
                     is_payment,
                     entry_point_name,
                     addressable_entity,
-                    entry_point_exists: entry_point_result.is_some(),
+                    entry_point_exists: entry_point_result.is_success(),
                 }),
 
             None => {

--- a/storage/src/data_access_layer/entry_points.rs
+++ b/storage/src/data_access_layer/entry_points.rs
@@ -110,7 +110,7 @@ pub enum EntryPointExistsResult {
 
 impl EntryPointExistsResult {
     /// Returns `true` if the result is `Success`.
-    pub fn is_some(self) -> bool {
+    pub fn is_success(self) -> bool {
         matches!(self, Self::Success { .. })
     }
 }


### PR DESCRIPTION
Fixes HAL-006 by ensuring returned Errors correctly represent the underlying issue. Additionally, addresses HAL-005 by renaming ``EntryPointExistsResult::is_some`` to ``EntryPointExistsResult::is_success``.