### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "casper-wasm"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f53c4e789fbff66ead0ea44030b1af2fc3c465201973483528e479a9155f98"
+checksum = "b78cbc1430f35f34ed8111f2ab74c857c9eb7ff1f21b3d2e2ddd4d56c96b1cf8"
 
 [[package]]
 name = "casper-wasm-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "casper-wasm"
-version = "0.46.1"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78cbc1430f35f34ed8111f2ab74c857c9eb7ff1f21b3d2e2ddd4d56c96b1cf8"
+checksum = "b23c58e3ab6d99d509534a23c988be743d6383c5a329095262efae90b7d9725e"
 
 [[package]]
 name = "casper-wasm-utils"


### PR DESCRIPTION
This PR bumps wasm parser to 0.46.1