### PR TITLE
Raise unconsumed 0 to baseline

### DIFF
--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -7,10 +7,8 @@ mod wasm_v1;
 use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
 use casper_types::{
-    account::AccountHash, Gas, InitiatorAddr, Key, Phase, RuntimeArgs, StoredValue,
-    TransactionHash, U512,
+    account::AccountHash, Gas, InitiatorAddr, Key, Phase, RuntimeArgs, StoredValue, TransactionHash,
 };
-use once_cell::sync::Lazy;
 
 use casper_storage::{
     global_state::{
@@ -32,15 +30,6 @@ pub use wasm_v1::{
     BlockInfo, ExecutableItem, InvalidRequest, SessionDataDeploy, SessionDataV1, SessionInputData,
     WasmV1Request, WasmV1Result,
 };
-
-/// The maximum amount of motes that payment code execution can cost.
-const BASELINE_MOTES_AMOUNT: u64 = 2_500_000_000;
-/// The maximum amount of gas a payment code can use.
-///
-/// This value also indicates the minimum balance of the main purse of an account when
-/// executing payment code, as such amount is held as collateral to compensate for
-/// code execution.
-pub static BASELINE_MOTES: Lazy<U512> = Lazy::new(|| U512::from(BASELINE_MOTES_AMOUNT));
 
 /// Gas/motes conversion rate of wasmless transfer cost is always 1 regardless of what user wants to
 /// pay.

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -34,13 +34,13 @@ pub use wasm_v1::{
 };
 
 /// The maximum amount of motes that payment code execution can cost.
-pub const MAX_PAYMENT_AMOUNT: u64 = 2_500_000_000;
+const BASELINE_MOTES_AMOUNT: u64 = 2_500_000_000;
 /// The maximum amount of gas a payment code can use.
 ///
 /// This value also indicates the minimum balance of the main purse of an account when
 /// executing payment code, as such amount is held as collateral to compensate for
 /// code execution.
-pub static MAX_PAYMENT: Lazy<U512> = Lazy::new(|| U512::from(MAX_PAYMENT_AMOUNT));
+pub static BASELINE_MOTES: Lazy<U512> = Lazy::new(|| U512::from(BASELINE_MOTES_AMOUNT));
 
 /// Gas/motes conversion rate of wasmless transfer cost is always 1 regardless of what user wants to
 /// pay.

--- a/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
@@ -5,10 +5,10 @@ use casper_engine_test_support::{
     LmdbWasmTestBuilder, TransferRequestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_ACCOUNT_INITIAL_BALANCE, LOCAL_GENESIS_REQUEST,
 };
-use casper_execution_engine::engine_state::MAX_PAYMENT_AMOUNT;
+use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_types::{account::AccountHash, MintCosts, PublicKey, SecretKey, U512};
 
-static TRANSFER_AMOUNT: Lazy<U512> = Lazy::new(|| U512::from(MAX_PAYMENT_AMOUNT));
+static TRANSFER_AMOUNT: Lazy<U512> = Lazy::new(|| *BASELINE_MOTES);
 
 static ACCOUNT_1_SECRET_KEY: Lazy<SecretKey> =
     Lazy::new(|| SecretKey::secp256k1_from_bytes([234u8; 32]).unwrap());

--- a/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/transfer_cached.rs
@@ -5,10 +5,12 @@ use casper_engine_test_support::{
     LmdbWasmTestBuilder, TransferRequestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_ACCOUNT_INITIAL_BALANCE, LOCAL_GENESIS_REQUEST,
 };
-use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_types::{account::AccountHash, MintCosts, PublicKey, SecretKey, U512};
 
-static TRANSFER_AMOUNT: Lazy<U512> = Lazy::new(|| *BASELINE_MOTES);
+/// The maximum amount of motes that payment code execution can cost.
+const TRANSFER_MOTES_AMOUNT: u64 = 2_500_000_000;
+
+static TRANSFER_AMOUNT: Lazy<U512> = Lazy::new(|| U512::from(TRANSFER_MOTES_AMOUNT));
 
 static ACCOUNT_1_SECRET_KEY: Lazy<SecretKey> =
     Lazy::new(|| SecretKey::secp256k1_from_bytes([234u8; 32]).unwrap());

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -124,7 +124,7 @@ pub fn execute_finalized_block(
     let insufficient_balance_handling = InsufficientBalanceHandling::HoldRemaining;
     let refund_handling = chainspec.core_config.refund_handling;
     let fee_handling = chainspec.core_config.fee_handling;
-    let penalty_payment_amount = *casper_execution_engine::engine_state::MAX_PAYMENT;
+    let penalty_payment_amount = *casper_execution_engine::engine_state::BASELINE_MOTES;
     let balance_handling = BalanceHandling::Available;
 
     // get scratch state, which must be used for all processing and post-processing data
@@ -665,7 +665,10 @@ pub fn execute_finalized_block(
 
         // handle refunds per the chainspec determined setting.
         let refund_amount = {
-            let consumed = artifact_builder.consumed();
+            let mut consumed = artifact_builder.consumed();
+            if consumed == U512::zero() {
+                consumed = penalty_payment_amount;
+            }
             let refund_mode = match refund_handling {
                 RefundHandling::NoRefund => {
                     if fee_handling.is_no_fee() && is_custom_payment {

--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -79,10 +79,11 @@ pub(crate) struct ExecutionArtifactBuilder {
     limit: Gas,
     consumed: Gas,
     size_estimate: u64,
+    baseline_amount: U512,
 }
 
 impl ExecutionArtifactBuilder {
-    pub fn new(transaction: &Transaction) -> Self {
+    pub fn new(transaction: &Transaction, baseline_amount: U512) -> Self {
         ExecutionArtifactBuilder {
             effects: Effects::new(),
             hash: transaction.hash(),
@@ -95,6 +96,7 @@ impl ExecutionArtifactBuilder {
             limit: Gas::zero(),
             consumed: Gas::zero(),
             size_estimate: transaction.size_estimate() as u64,
+            baseline_amount,
         }
     }
 
@@ -103,7 +105,18 @@ impl ExecutionArtifactBuilder {
     }
 
     pub fn consumed(&self) -> U512 {
-        self.consumed.value()
+        // to prevent do-nothing exhaustion, if consumed == 0 we raise consumed to baseline
+        let consumed = self.consumed;
+        if consumed == Gas::zero() {
+            self.baseline_amount
+        } else {
+            consumed.value()
+        }
+    }
+
+    pub fn with_added_consumed(&mut self, consumed: Gas) -> &mut Self {
+        self.consumed = self.consumed.saturating_add(consumed);
+        self
     }
 
     pub fn with_appended_transfers(&mut self, transfers: &mut Vec<Transfer>) -> &mut Self {
@@ -265,11 +278,6 @@ impl ExecutionArtifactBuilder {
         self
     }
 
-    pub fn with_added_consumed(&mut self, consumed: Gas) -> &mut Self {
-        self.consumed = self.consumed.saturating_add(consumed);
-        self
-    }
-
     pub fn with_invalid_transaction(
         &mut self,
         invalid_transaction: &InvalidTransaction,
@@ -342,12 +350,13 @@ impl ExecutionArtifactBuilder {
     }
 
     pub(crate) fn build(self) -> ExecutionArtifact {
+        let consumed = Gas::new(self.consumed());
         let result = ExecutionResultV2 {
             effects: self.effects,
             transfers: self.transfers,
             initiator: self.initiator,
             limit: self.limit,
-            consumed: self.consumed,
+            consumed,
             cost: self.cost,
             size_estimate: self.size_estimate,
             error_message: self.error_message,

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -11,7 +11,6 @@ use datasize::DataSize;
 use prometheus::Registry;
 use tracing::{debug, error, trace};
 
-use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_storage::data_access_layer::{balance::BalanceHandling, BalanceRequest, ProofHandling};
 use casper_types::{
     account::AccountHash, addressable_entity::AddressableEntity, system::auction::ARG_AMOUNT,
@@ -295,7 +294,8 @@ impl TransactionAcceptor {
                 self.reject_transaction(effect_builder, *event_metadata, error)
             }
             Some(balance) => {
-                let has_minimum_balance = balance >= *BASELINE_MOTES;
+                let has_minimum_balance =
+                    balance >= self.chainspec.core_config.baseline_motes_amount_u512();
                 if !has_minimum_balance {
                     let initiator_addr = event_metadata.transaction.initiator_addr();
                     let error = Error::parameter_failure(

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -11,7 +11,7 @@ use datasize::DataSize;
 use prometheus::Registry;
 use tracing::{debug, error, trace};
 
-use casper_execution_engine::engine_state::MAX_PAYMENT;
+use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_storage::data_access_layer::{balance::BalanceHandling, BalanceRequest, ProofHandling};
 use casper_types::{
     account::AccountHash, addressable_entity::AddressableEntity, system::auction::ARG_AMOUNT,
@@ -295,7 +295,7 @@ impl TransactionAcceptor {
                 self.reject_transaction(effect_builder, *event_metadata, error)
             }
             Some(balance) => {
-                let has_minimum_balance = balance >= *MAX_PAYMENT;
+                let has_minimum_balance = balance >= *BASELINE_MOTES;
                 if !has_minimum_balance {
                     let initiator_addr = event_metadata.transaction.initiator_addr();
                     let error = Error::parameter_failure(

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -20,7 +20,6 @@ use tempfile::TempDir;
 use thiserror::Error;
 use tokio::time;
 
-use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_storage::{
     data_access_layer::{
         AddressableEntityResult, BalanceIdentifier, BalanceResult, EntryPointExistsResult,
@@ -39,6 +38,7 @@ use casper_types::{
     InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Key, PricingHandling, PricingMode,
     ProtocolVersion, PublicKey, SecretKey, StoredValue, TestBlockBuilder, TimeDiff, Timestamp,
     Transaction, TransactionArgs, TransactionConfig, TransactionRuntimeParams, TransactionV1, URef,
+    DEFAULT_BASELINE_MOTES_AMOUNT,
 };
 
 use super::*;
@@ -933,13 +933,14 @@ impl reactor::Reactor for Reactor {
                         StoredValue::CLValue(CLValue::from_t(()).expect("should get CLValue")),
                         VecDeque::new(),
                     );
+                    let baseline_amount = U512::from(DEFAULT_BASELINE_MOTES_AMOUNT);
                     let motes = if matches!(
                         self.test_scenario,
                         TestScenario::FromClientInsufficientBalance(_)
                     ) {
-                        *BASELINE_MOTES - 1
+                        baseline_amount - 1
                     } else {
-                        *BASELINE_MOTES
+                        baseline_amount
                     };
                     let balance_result =
                         if self.test_scenario == TestScenario::AccountWithUnknownBalance {
@@ -1060,13 +1061,13 @@ impl reactor::Reactor for Reactor {
         _rng: &mut NodeRng,
     ) -> Result<(Self, Effects<Self::Event>), Self::Error> {
         let (storage_config, storage_tempdir) = storage::Config::new_for_tests(1);
-        let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
+        let storage_with_dir = WithDir::new(storage_tempdir.path(), storage_config);
 
         let transaction_acceptor =
-            TransactionAcceptor::new(Config::default(), Arc::clone(&chainspec), registry).unwrap();
+            TransactionAcceptor::new(Config::default(), Arc::clone(&chainspec), registry)?;
 
         let storage = Storage::new(
-            &storage_withdir,
+            &storage_with_dir,
             None,
             ProtocolVersion::from_parts(1, 0, 0),
             EraId::default(),
@@ -1374,7 +1375,7 @@ async fn run_transaction_acceptor_without_timeout(
                     )
                 )
             }
-            // Check that a, new and valid, transaction sent by a peer raises an
+            // Check that a new and valid, transaction sent by a peer raises an
             // `AcceptedNewTransaction` announcement with the appropriate source.
             TestScenario::FromPeerValidTransaction(_)
             | TestScenario::FromPeerMissingAccount(_)

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -20,7 +20,7 @@ use tempfile::TempDir;
 use thiserror::Error;
 use tokio::time;
 
-use casper_execution_engine::engine_state::MAX_PAYMENT_AMOUNT;
+use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_storage::{
     data_access_layer::{
         AddressableEntityResult, BalanceIdentifier, BalanceResult, EntryPointExistsResult,
@@ -39,7 +39,6 @@ use casper_types::{
     InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Key, PricingHandling, PricingMode,
     ProtocolVersion, PublicKey, SecretKey, StoredValue, TestBlockBuilder, TimeDiff, Timestamp,
     Transaction, TransactionArgs, TransactionConfig, TransactionRuntimeParams, TransactionV1, URef,
-    U512,
 };
 
 use super::*;
@@ -938,9 +937,9 @@ impl reactor::Reactor for Reactor {
                         self.test_scenario,
                         TestScenario::FromClientInsufficientBalance(_)
                     ) {
-                        MAX_PAYMENT_AMOUNT - 1
+                        *BASELINE_MOTES - 1
                     } else {
-                        MAX_PAYMENT_AMOUNT
+                        *BASELINE_MOTES
                     };
                     let balance_result =
                         if self.test_scenario == TestScenario::AccountWithUnknownBalance {
@@ -953,7 +952,7 @@ impl reactor::Reactor for Reactor {
                             BalanceResult::Success {
                                 purse_addr,
                                 total_balance: Default::default(),
-                                available_balance: U512::from(motes),
+                                available_balance: motes,
                                 proofs_result,
                             }
                         };

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -285,7 +285,7 @@ impl TestFixture {
                 stakes.into_iter().map(|stake| stake.into()).collect()
             }
             InitialStakes::Random { count } => {
-                // By default we use very large stakes so we would catch overflow issues.
+                // By default, we use very large stakes so we would catch overflow issues.
                 iter::from_fn(|| Some(U512::from(rng.gen_range(100..999)) * U512::from(u128::MAX)))
                     .take(count)
                     .collect()
@@ -2116,7 +2116,7 @@ async fn run_withdraw_bid_network() {
     // The bid record should have been pruned once unbonding ran.
     fixture.check_bid_existence_at_tip(&alice_public_key, None, false);
 
-    // Crank the network forward until the unbonds are processed.
+    // Crank the network forward until the unbonding queue is processed.
     fixture
         .run_until_stored_switch_block_header(
             ERA_ONE.saturating_add(unbonding_delay + 1),
@@ -2321,7 +2321,7 @@ async fn run_undelegate_bid_network() {
     fixture.check_bid_existence_at_tip(&bob_public_key, None, true);
     fixture.check_bid_existence_at_tip(&bob_public_key, Some(&alice_public_key), false);
 
-    // Crank the network forward until the unbonds are processed.
+    // Crank the network forward until the unbonding queue is processed.
     fixture
         .run_until_stored_switch_block_header(
             ERA_ONE.saturating_add(unbonding_delay + 1),

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::{testing::LARGE_WASM_LANE_ID, types::MetaTransaction};
-use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_storage::data_access_layer::{
     AddressableEntityRequest, BalanceIdentifier, ProofHandling, QueryRequest, QueryResult,
 };
@@ -516,7 +515,7 @@ async fn transfer_cost_fixed_price_no_fee_no_refund() {
 
     // since FeeHandling is set to NoFee, we expect that there's a hold on Alice's balance for the
     // cost of the transfer. The total balance of Alice now should be the initial balance - the
-    // amount transfered to Charlie.
+    // amount transferred to Charlie.
     let alice_expected_total_balance = alice_initial_balance - TRANSFER_AMOUNT;
     // The available balance is the initial balance - the amount transferred to Charlie - the hold
     // for the transfer cost.
@@ -709,7 +708,7 @@ async fn transfer_cost_classic_price_no_fee_no_refund() {
 
     // since FeeHandling is set to NoFee, we expect that there's a hold on Alice's balance for the
     // cost of the transfer. The total balance of Alice now should be the initial balance - the
-    // amount transfered to Charlie.
+    // amount transferred to Charlie.
     let alice_expected_total_balance = alice_initial_balance - TRANSFER_AMOUNT;
     // The available balance is the initial balance - the amount transferred to Charlie - the hold
     // for the transfer cost.
@@ -950,12 +949,8 @@ async fn wasm_transaction_fees_are_refunded() {
         .chainspec
         .get_max_gas_limit_by_category(LARGE_WASM_LANE_ID);
     let expected_transaction_cost = expected_transaction_gas * MIN_GAS_PRICE as u64;
-    assert_exec_result_cost(
-        exec_result,
-        expected_transaction_cost.into(),
-        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
-                      * invalid wasm. */
-    );
+    let baseline = Gas::new(fixture.chainspec.core_config.baseline_motes_amount);
+    assert_exec_result_cost(exec_result, expected_transaction_cost.into(), baseline);
 
     let bob_available_balance =
         *get_balance(&mut fixture, &bob_public_key, Some(block_height), false)
@@ -974,11 +969,12 @@ async fn wasm_transaction_fees_are_refunded() {
             .total_balance()
             .expect("Expected Alice to have a balance");
 
-    // Bob should get back half of the cost for the unspent gas. Since this transaction consumed 0
-    // gas, the unspent gas is equal to the limit.
-    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
-        .to_integer()
-        .into();
+    // Bob should get back half of the cost for the unspent gas. Since this transaction consumed
+    // baseline gas, the unspent gas is equal to the limit.
+    let refund_amount: U512 = (refund_ratio
+        * Ratio::from(expected_transaction_cost - baseline.value().as_u64()))
+    .to_integer()
+    .into();
 
     let bob_expected_total_balance =
         bob_initial_balance - expected_transaction_cost + refund_amount;
@@ -1265,19 +1261,16 @@ async fn wasm_transaction_refunds_are_burnt(txn_pricing_mode: PricingMode) {
     );
     let expected_transaction_cost = expected_transaction_gas * min_gas_price as u64;
 
+    let baseline = Gas::new(test.fixture.chainspec.core_config.baseline_motes_amount);
     assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
-    assert_exec_result_cost(
-        exec_result,
-        expected_transaction_cost.into(),
-        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
-                      * invalid wasm. */
-    );
+    assert_exec_result_cost(exec_result, expected_transaction_cost.into(), baseline);
 
     // Bob should get back half of the cost for the unspent gas. Since this transaction consumed 0
     // gas, the unspent gas is equal to the limit.
-    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
-        .to_integer()
-        .into();
+    let refund_amount: U512 = (refund_ratio
+        * Ratio::from(expected_transaction_cost.saturating_sub(baseline.value().as_u64())))
+    .to_integer()
+    .into();
 
     // The refund should have been burnt. So expect the total supply should have been reduced by the
     // refund amount that was burnt.
@@ -1367,19 +1360,16 @@ async fn only_refunds_are_burnt_no_fee(txn_pricing_mode: PricingMode) {
     );
     let expected_transaction_cost = expected_transaction_gas * min_gas_price as u64;
 
+    let expected_consumed = Gas::new(test.fixture.chainspec.core_config.baseline_motes_amount);
     assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
     assert_exec_result_cost(
         exec_result,
         expected_transaction_cost.into(),
-        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
-                      * invalid wasm. */
+        expected_consumed,
     );
 
-    // This transaction consumed 0 gas, the unspent gas is equal to the limit, so we apply the
-    // refund ratio to the full transaction cost.
-    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
-        .to_integer()
-        .into();
+    let unconsumed = expected_transaction_cost.saturating_sub(expected_consumed.value().as_u64());
+    let refund_amount: U512 = (refund_ratio * Ratio::from(unconsumed)).to_integer().into();
 
     // We set it up so that the refunds are burnt so check this.
     assert_eq!(
@@ -1388,13 +1378,13 @@ async fn only_refunds_are_burnt_no_fee(txn_pricing_mode: PricingMode) {
     );
 
     let (alice_current_balance, bob_current_balance, _) = test.get_balances(Some(block_height));
-    // Bob doesn't get a refund. The refund is burnt. A hold is put in in place for the
+    // Bob doesn't get a refund. The refund is burnt. A hold is put in place for the
     // transaction cost.
     let bob_balance_hold = U512::from(expected_transaction_cost) - refund_amount;
     let bob_expected_total_balance = bob_initial_balance.total - refund_amount;
     let bob_expected_available_balance = bob_current_balance.total - bob_balance_hold;
 
-    // Alice should't get anything since we are operating with no fees
+    // Alice shouldn't get anything since we are operating with no fees
     let alice_expected_total_balance = alice_initial_balance.total;
     let alice_expected_available_balance = alice_expected_total_balance;
 
@@ -1428,7 +1418,7 @@ async fn only_refunds_are_burnt_no_fee_fixed_pricing() {
 #[tokio::test]
 async fn only_refunds_are_burnt_no_fee_classic_pricing() {
     only_refunds_are_burnt_no_fee(PricingMode::PaymentLimited {
-        payment_amount: 5000,
+        payment_amount: 5_000_000_000,
         gas_price_tolerance: MIN_GAS_PRICE,
         standard_payment: true,
     })
@@ -1473,8 +1463,7 @@ async fn fees_and_refunds_are_burnt_separately(txn_pricing_mode: PricingMode) {
     assert_exec_result_cost(
         exec_result,
         expected_transaction_cost.into(),
-        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
-                      * invalid wasm. */
+        Gas::new(test.fixture.chainspec.core_config.baseline_motes_amount),
     );
 
     // Both refunds and fees should be burnt (even though they are burnt separately). Refund + fee
@@ -1489,7 +1478,7 @@ async fn fees_and_refunds_are_burnt_separately(txn_pricing_mode: PricingMode) {
     let bob_expected_total_balance = bob_initial_balance.total - expected_transaction_cost;
     let bob_expected_available_balance = bob_current_balance.total;
 
-    // Alice should't get anything since we are operating with no fees
+    // Alice shouldn't get anything since we are operating with no fees
     let alice_expected_total_balance = alice_initial_balance.total;
     let alice_expected_available_balance = alice_expected_total_balance;
 
@@ -1565,19 +1554,19 @@ async fn refunds_are_payed_and_fees_are_burnt(txn_pricing_mode: PricingMode) {
 
     let (_txn_hash, block_height, exec_result) = test.send_transaction(txn).await;
 
+    let expected_consumed_gas = Gas::new(test.fixture.chainspec.core_config.baseline_motes_amount);
     assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
     assert_exec_result_cost(
         exec_result,
         expected_transaction_cost.into(),
-        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
-                      * invalid wasm. */
+        expected_consumed_gas,
     );
 
-    // This transaction consumed 0 gas, the unspent gas is equal to the limit, so we apply the
-    // refund ratio to the full transaction cost.
-    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
-        .to_integer()
-        .into();
+    let unconsumed =
+        expected_transaction_cost.saturating_sub(expected_consumed_gas.value().as_u64());
+    // This transaction consumed baseline gas, the unspent gas is equal to the limit,
+    // so we apply the refund ratio to the full transaction cost.
+    let refund_amount: U512 = (refund_ratio * Ratio::from(unconsumed)).to_integer().into();
 
     // Only fees are burnt, so the refund_amount should still be in the total supply.
     assert_eq!(
@@ -1591,7 +1580,7 @@ async fn refunds_are_payed_and_fees_are_burnt(txn_pricing_mode: PricingMode) {
         bob_initial_balance.total - expected_transaction_cost + refund_amount;
     let bob_expected_available_balance = bob_current_balance.total;
 
-    // Alice should't get anything since we are operating with no fees
+    // Alice shouldn't get anything since we are operating with no fees
     let alice_expected_total_balance = alice_initial_balance.total;
     let alice_expected_available_balance = alice_expected_total_balance;
 
@@ -1653,12 +1642,14 @@ async fn refunds_are_payed_and_fees_are_on_hold(txn_pricing_mode: PricingMode) {
     let meta_transaction =
         MetaTransaction::from_transaction(&txn, &test.chainspec().transaction_config).unwrap();
     // Fixed transaction pricing.
-    let expected_consumed_gas = Gas::new(0); // expect that this transaction doesn't consume any gas since it has invalid wasm.
+    let expected_consumed_gas = Gas::new(test.fixture.chainspec.core_config.baseline_motes_amount);
     let expected_transaction_cost = meta_transaction
         .gas_limit(test.chainspec())
         .unwrap()
         .value()
         * min_gas_price;
+
+    let unconsumed = expected_transaction_cost.saturating_sub(expected_consumed_gas.value());
 
     test.fixture
         .run_until_consensus_in_era(ERA_ONE, ONE_MIN)
@@ -1681,7 +1672,7 @@ async fn refunds_are_payed_and_fees_are_on_hold(txn_pricing_mode: PricingMode) {
     let refund_amount: U512 = (Ratio::<U512>::new(
         (*refund_ratio.numer()).into(),
         (*refund_ratio.denom()).into(),
-    ) * Ratio::from(expected_transaction_cost))
+    ) * Ratio::from(unconsumed))
     .to_integer();
 
     // Nothing is burnt so total supply should be the same.
@@ -1697,7 +1688,7 @@ async fn refunds_are_payed_and_fees_are_on_hold(txn_pricing_mode: PricingMode) {
     let bob_expected_available_balance =
         bob_current_balance.total - expected_transaction_cost + refund_amount;
 
-    // Alice should't get anything since we are operating with no fees
+    // Alice shouldn't get anything since we are operating with no fees
     let alice_expected_total_balance = alice_initial_balance.total;
     let alice_expected_available_balance = alice_expected_total_balance;
 
@@ -1818,7 +1809,7 @@ async fn only_refunds_are_burnt_no_fee_custom_payment() {
         bob_initial_balance.total - expected_transaction_cost + refund_amount;
     let bob_expected_available_balance = bob_expected_total_balance; // No holds expected.
 
-    // Alice should't get anything since we are operating with no fees
+    // Alice shouldn't get anything since we are operating with no fees
     let alice_expected_total_balance = alice_initial_balance.total;
     let alice_expected_available_balance = alice_expected_total_balance;
 
@@ -2200,13 +2191,9 @@ async fn wasm_transaction_fees_are_refunded_to_proposer(txn_pricing_mode: Pricin
     );
     let expected_transaction_cost = expected_transaction_gas * min_gas_price as u64;
 
+    let baseline = Gas::new(test.fixture.chainspec.core_config.baseline_motes_amount);
     assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
-    assert_exec_result_cost(
-        exec_result,
-        expected_transaction_cost.into(),
-        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
-                      * invalid wasm. */
-    );
+    assert_exec_result_cost(exec_result, expected_transaction_cost.into(), baseline);
 
     // Nothing is burnt so total supply should be the same.
     assert_eq!(
@@ -2214,11 +2201,12 @@ async fn wasm_transaction_fees_are_refunded_to_proposer(txn_pricing_mode: Pricin
         test.get_total_supply(Some(block_height))
     );
 
-    // Bob should get back half of the cost for the unspent gas. Since this transaction consumed 0
-    // gas, the unspent gas is equal to the limit.
-    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
-        .to_integer()
-        .into();
+    // Bob should get back half of the cost for the unspent gas. Since this transaction consumed
+    // the baseline  gas, the unspent gas is equal to the limit minus baseline.
+    let refund_amount: U512 = (refund_ratio
+        * Ratio::from(expected_transaction_cost.saturating_sub(baseline.value().as_u64())))
+    .to_integer()
+    .into();
 
     let (alice_current_balance, bob_current_balance, _) = test.get_balances(Some(block_height));
     let bob_expected_total_balance =
@@ -2620,19 +2608,22 @@ async fn fee_holds_are_amortized() {
 
     let expected_transaction_cost = expected_transaction_gas * MIN_GAS_PRICE as u64;
 
-    assert!(!exec_result_is_success(&exec_result)); // transaction should not succeed because the wasm bytes are invalid.
+    // transaction should not succeed because the wasm bytes are invalid.
+    // this transaction has invalid wasm, so the baseline will be used as consumed
+    assert!(!exec_result_is_success(&exec_result));
+
+    let expected_consumed = Gas::new(test.fixture.chainspec.core_config.baseline_motes_amount);
     assert_exec_result_cost(
         exec_result,
         expected_transaction_cost.into(),
-        Gas::new(0), /* expect that this transaction doesn't consume any gas since it has
-                      * invalid wasm. */
+        expected_consumed,
     );
 
-    // This transaction consumed 0 gas, the unspent gas is equal to the limit, so we apply the
+    let unconsumed = expected_transaction_cost - expected_consumed.value().as_u64();
+
+    // This transaction consumed 2.5 gas, the unspent gas is equal to the limit, so we apply the
     // refund ratio to the full transaction cost.
-    let refund_amount: U512 = (refund_ratio * Ratio::from(expected_transaction_cost))
-        .to_integer()
-        .into();
+    let refund_amount: U512 = (refund_ratio * Ratio::from(unconsumed)).to_integer().into();
 
     // We set it up so that the refunds are burnt so check this.
     assert_eq!(
@@ -2641,13 +2632,13 @@ async fn fee_holds_are_amortized() {
     );
 
     let (alice_current_balance, bob_current_balance, _) = test.get_balances(Some(block_height));
-    // Bob doesn't get a refund. The refund is burnt. A hold is put in in place for the
+    // Bob doesn't get a refund. The refund is burnt. A hold is put in place for the
     // transaction cost.
     let bob_balance_hold = U512::from(expected_transaction_cost) - refund_amount;
     let bob_expected_total_balance = bob_initial_balance.total - refund_amount;
     let bob_expected_available_balance = bob_current_balance.total - bob_balance_hold;
 
-    // Alice should't get anything since we are operating with no fees
+    // Alice shouldn't get anything since we are operating with no fees
     let alice_expected_total_balance = alice_initial_balance.total;
     let alice_expected_available_balance = alice_expected_total_balance;
 
@@ -3474,15 +3465,25 @@ async fn successful_purse_to_purse_transfer() {
     let module_bytes =
         Bytes::from(std::fs::read(purse_create_contract).expect("cannot read module bytes"));
 
+    let baseline_motes = test
+        .fixture
+        .chainspec
+        .core_config
+        .baseline_motes_amount_u512();
+
     let mut txn = Transaction::from(
-        TransactionV1Builder::new_session(false, module_bytes, TransactionRuntimeParams::VmCasperV1)
-            .with_runtime_args(
-                runtime_args! { "destination" => purse_name, "amount" => *BASELINE_MOTES + U512::one() },
-            )
-            .with_chain_name(CHAIN_NAME)
-            .with_initiator_addr(BOB_PUBLIC_KEY.clone())
-            .build()
-            .unwrap(),
+        TransactionV1Builder::new_session(
+            false,
+            module_bytes,
+            TransactionRuntimeParams::VmCasperV1,
+        )
+        .with_runtime_args(
+            runtime_args! { "destination" => purse_name, "amount" => baseline_motes + U512::one() },
+        )
+        .with_chain_name(CHAIN_NAME)
+        .with_initiator_addr(BOB_PUBLIC_KEY.clone())
+        .build()
+        .unwrap(),
     );
     txn.sign(&BOB_SECRET_KEY);
     let (_txn_hash, _block_height, exec_result) = test.send_transaction(txn).await;
@@ -3567,15 +3568,24 @@ async fn successful_purse_to_account_transfer() {
     let module_bytes =
         Bytes::from(std::fs::read(purse_create_contract).expect("cannot read module bytes"));
 
+    let baseline_motes = test
+        .fixture
+        .chainspec
+        .core_config
+        .baseline_motes_amount_u512();
     let mut txn = Transaction::from(
-        TransactionV1Builder::new_session(false, module_bytes, TransactionRuntimeParams::VmCasperV1)
-            .with_runtime_args(
-                runtime_args! { "destination" => purse_name, "amount" => *BASELINE_MOTES + U512::one() },
-            )
-            .with_chain_name(CHAIN_NAME)
-            .with_initiator_addr(BOB_PUBLIC_KEY.clone())
-            .build()
-            .unwrap(),
+        TransactionV1Builder::new_session(
+            false,
+            module_bytes,
+            TransactionRuntimeParams::VmCasperV1,
+        )
+        .with_runtime_args(
+            runtime_args! { "destination" => purse_name, "amount" => baseline_motes + U512::one() },
+        )
+        .with_chain_name(CHAIN_NAME)
+        .with_initiator_addr(BOB_PUBLIC_KEY.clone())
+        .build()
+        .unwrap(),
     );
     txn.sign(&BOB_SECRET_KEY);
     let (_txn_hash, _block_height, exec_result) = test.send_transaction(txn).await;

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{testing::LARGE_WASM_LANE_ID, types::MetaTransaction};
-use casper_execution_engine::engine_state::MAX_PAYMENT_AMOUNT;
+use casper_execution_engine::engine_state::BASELINE_MOTES;
 use casper_storage::data_access_layer::{
     AddressableEntityRequest, BalanceIdentifier, ProofHandling, QueryRequest, QueryResult,
 };
@@ -3477,7 +3477,7 @@ async fn successful_purse_to_purse_transfer() {
     let mut txn = Transaction::from(
         TransactionV1Builder::new_session(false, module_bytes, TransactionRuntimeParams::VmCasperV1)
             .with_runtime_args(
-                runtime_args! { "destination" => purse_name, "amount" => U512::from(MAX_PAYMENT_AMOUNT) + U512::one() },
+                runtime_args! { "destination" => purse_name, "amount" => *BASELINE_MOTES + U512::one() },
             )
             .with_chain_name(CHAIN_NAME)
             .with_initiator_addr(BOB_PUBLIC_KEY.clone())
@@ -3570,7 +3570,7 @@ async fn successful_purse_to_account_transfer() {
     let mut txn = Transaction::from(
         TransactionV1Builder::new_session(false, module_bytes, TransactionRuntimeParams::VmCasperV1)
             .with_runtime_args(
-                runtime_args! { "destination" => purse_name, "amount" => U512::from(MAX_PAYMENT_AMOUNT) + U512::one() },
+                runtime_args! { "destination" => purse_name, "amount" => *BASELINE_MOTES + U512::one() },
             )
             .with_chain_name(CHAIN_NAME)
             .with_initiator_addr(BOB_PUBLIC_KEY.clone())

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -157,7 +157,7 @@ administrators = []
 # Flag that triggers a migration of all accounts and contracts present in global state to the addressable
 # entity in lazy manner.
 # If the flag is set to false then no accounts and contracts are migrated during a protocol upgrade;
-# i.e all Account records will be present under Key::Account and Contracts and their associated ContractPackage
+# i.e. all Account records will be present under Key::Account and Contracts and their associated ContractPackage
 # will be written underneath Key::Hash.
 # If the flag is set to true then accounts and contracts are migrated lazily; i.e on first use of the Account
 # and/or Contract as part of the execution of a Transaction. This means the Accounts/Contracts will be migrated
@@ -167,6 +167,9 @@ administrators = []
 # Note: Enabling of the AddressableEntity feature is one-way; i.e once enabled as part of a protocol upgrade
 # the flag cannot be disabled in a future protocol upgrade.
 enable_addressable_entity = false
+# This value is used as the penalty payment amount, the minimum balance amount,
+# and the minimum consumed amount.
+baseline_motes_amount = 2_500_000_000
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -163,7 +163,7 @@ administrators = []
 # Flag that triggers a migration of all userland accounts and contracts present in global state to the addressable
 # entity in lazy manner.
 # If the flag is set to false then no accounts and contracts are migrated during a protocol upgrade;
-# i.e all Account records will be present under Key::Account and Contracts and their associated ContractPackage
+# i.e. all Account records will be present under Key::Account and Contracts and their associated ContractPackage
 # will be written underneath Key::Hash.
 # If the flag is set to true then accounts and contracts are migrated lazily; i.e on first use of the Account
 # and/or Contract as part of the execution of a Transaction. This means the Accounts/Contracts will be migrated
@@ -173,6 +173,9 @@ administrators = []
 # Note: Enabling of the AddressableEntity feature is one-way; i.e once enabled as part of a protocol upgrade
 # the flag cannot be disabled in a future protocol upgrade.
 enable_addressable_entity = false
+# This value is used as the penalty payment amount, the minimum balance amount,
+# and the minimum consumed amount.
+baseline_motes_amount = 2_500_000_000
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.
@@ -210,7 +213,7 @@ vm_casper_v2 = false
 # Different casper networks may not impose such a restriction.
 # [1] -> Max serialized length of the entire transaction in bytes for a given transaction in a certain lane
 # [2] -> Max args length size in bytes for a given transaction in a certain lane
-# [3] -> Transaction gas limit size in bytes for a given transaction in a certain lane
+# [3] -> Transaction gas limit for a given transaction in a certain lane
 # [4] -> The maximum number of transactions the lane can contain
 native_mint_lane = [0, 2048, 1024, 100_000_000, 650]
 native_auction_lane = [1, 3096, 2048, 2_500_000_000, 650]

--- a/types/src/chainspec.rs
+++ b/types/src/chainspec.rs
@@ -42,13 +42,13 @@ pub use accounts_config::{
 };
 pub use activation_point::ActivationPoint;
 pub use chainspec_raw_bytes::ChainspecRawBytes;
-#[cfg(any(feature = "testing", test))]
-pub use core_config::DEFAULT_FEE_HANDLING;
-#[cfg(any(feature = "std", test))]
-pub use core_config::DEFAULT_REFUND_HANDLING;
 pub use core_config::{
     ConsensusProtocolName, CoreConfig, LegacyRequiredFinality, DEFAULT_GAS_HOLD_INTERVAL,
     DEFAULT_MINIMUM_BID_AMOUNT,
+};
+#[cfg(any(feature = "std", test))]
+pub use core_config::{
+    DEFAULT_BASELINE_MOTES_AMOUNT, DEFAULT_FEE_HANDLING, DEFAULT_REFUND_HANDLING,
 };
 pub use fee_handling::FeeHandling;
 #[cfg(any(feature = "std", test))]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -132,8 +132,9 @@ pub use chainspec::{
     NetworkConfig, NextUpgrade, OpcodeCosts, PricingHandling, ProtocolConfig,
     ProtocolUpgradeConfig, RefundHandling, StandardPaymentCosts, StorageCosts, SystemConfig,
     TransactionConfig, TransactionLaneDefinition, TransactionV1Config, VacancyConfig,
-    ValidatorConfig, WasmConfig, WasmV1Config, DEFAULT_GAS_HOLD_INTERVAL,
-    DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, DEFAULT_MINIMUM_BID_AMOUNT, DEFAULT_REFUND_HANDLING,
+    ValidatorConfig, WasmConfig, WasmV1Config, DEFAULT_BASELINE_MOTES_AMOUNT,
+    DEFAULT_GAS_HOLD_INTERVAL, DEFAULT_HOST_FUNCTION_NEW_DICTIONARY, DEFAULT_MINIMUM_BID_AMOUNT,
+    DEFAULT_REFUND_HANDLING,
 };
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
 pub use chainspec::{


### PR DESCRIPTION
This PR changes the payment process logic to rise 0 gas consumed to a baseline amount. 