### PR TITLE
[BUGFIX] in payment limited mode payment 0 should be rejected

### DIFF
--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -584,15 +584,15 @@ impl TestScenario {
                 }
             }
             TestScenario::InvalidPricingModeForTransactionV1 => {
-                let classic_mode_transaction = TransactionV1Builder::new_random(rng)
+                let payment_limited_mode_transaction = TransactionV1Builder::new_random(rng)
                     .with_pricing_mode(PricingMode::Fixed {
                         gas_price_tolerance: 5,
                         additional_computation_factor: 0,
                     })
                     .with_chain_name("casper-example")
                     .build()
-                    .expect("must create classic mode transaction");
-                Transaction::from(classic_mode_transaction)
+                    .expect("must create payment limited transaction");
+                Transaction::from(payment_limited_mode_transaction)
             }
             TestScenario::TooLowGasPriceToleranceForTransactionV1 => {
                 const TOO_LOW_GAS_PRICE_TOLERANCE: u8 = 0;

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -3278,7 +3278,7 @@ async fn run_gas_price_scenario(gas_price_scenario: GasPriceScenario) {
         .expect("must have gas price");
 
     let cost = match fixture.chainspec.core_config.pricing_handling {
-        PricingHandling::Classic => 0,
+        PricingHandling::PaymentLimited => 0,
         PricingHandling::Fixed => {
             fixture.chainspec.system_costs_config.mint_costs().transfer * (current_gas_price as u32)
         }

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -652,13 +652,13 @@ async fn failed_transfer_cost_fixed_price_no_fee_no_refund() {
 }
 
 #[tokio::test]
-async fn transfer_cost_classic_price_no_fee_no_refund() {
+async fn transfer_cost_payment_limited_price_no_fee_no_refund() {
     const TRANSFER_AMOUNT: u64 = 30_000_000_000;
 
     let initial_stakes = InitialStakes::FromVec(vec![u128::MAX, 1]);
 
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::NoRefund)
         .with_fee_handling(FeeHandling::NoFee);
 
@@ -771,7 +771,7 @@ async fn transaction_with_low_threshold_should_not_get_included() {
     let initial_stakes = InitialStakes::FromVec(vec![u128::MAX, 1]);
 
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::NoRefund)
         .with_fee_handling(FeeHandling::NoFee);
 
@@ -1317,7 +1317,7 @@ async fn wasm_transaction_refunds_are_burnt_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn wasm_transaction_refunds_are_burnt_classic_pricing() {
+async fn wasm_transaction_refunds_are_burnt_payment_limited_pricing() {
     wasm_transaction_refunds_are_burnt(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -1416,7 +1416,7 @@ async fn only_refunds_are_burnt_no_fee_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn only_refunds_are_burnt_no_fee_classic_pricing() {
+async fn only_refunds_are_burnt_no_fee_payment_limited_pricing() {
     only_refunds_are_burnt_no_fee(PricingMode::PaymentLimited {
         payment_amount: 5_000_000_000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -1510,7 +1510,7 @@ async fn fees_and_refunds_are_burnt_separately_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn fees_and_refunds_are_burnt_separately_classic_pricing() {
+async fn fees_and_refunds_are_burnt_separately_payment_limited_pricing() {
     fees_and_refunds_are_burnt_separately(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -1612,7 +1612,7 @@ async fn refunds_are_payed_and_fees_are_burnt_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn refunds_are_payed_and_fees_are_burnt_classic_pricing() {
+async fn refunds_are_payed_and_fees_are_burnt_payment_limited_pricing() {
     refunds_are_payed_and_fees_are_burnt(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -1720,7 +1720,7 @@ async fn refunds_are_payed_and_fees_are_on_hold_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn refunds_are_payed_and_fees_are_on_hold_classic_pricing() {
+async fn refunds_are_payed_and_fees_are_on_hold_payment_limited_pricing() {
     refunds_are_payed_and_fees_are_on_hold(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -1733,7 +1733,7 @@ async fn refunds_are_payed_and_fees_are_on_hold_classic_pricing() {
 async fn only_refunds_are_burnt_no_fee_custom_payment() {
     let refund_ratio = Ratio::new(1, 2);
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::Refund { refund_ratio })
         .with_fee_handling(FeeHandling::Burn);
 
@@ -1834,7 +1834,7 @@ async fn only_refunds_are_burnt_no_fee_custom_payment() {
 #[tokio::test]
 async fn no_refund_no_fee_custom_payment() {
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::NoRefund)
         .with_fee_handling(FeeHandling::NoFee);
 
@@ -2036,7 +2036,7 @@ async fn transfer_fee_is_burnt_no_refund_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn transfer_fee_is_burnt_no_refund_classic_pricing() {
+async fn transfer_fee_is_burnt_no_refund_payment_limited_pricing() {
     transfer_fee_is_burnt_no_refund(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -2147,7 +2147,7 @@ async fn fee_is_payed_to_proposer_no_refund_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn fee_is_payed_to_proposer_no_refund_classic_pricing() {
+async fn fee_is_payed_to_proposer_no_refund_payment_limited_pricing() {
     fee_is_payed_to_proposer_no_refund(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -2246,7 +2246,7 @@ async fn wasm_transaction_fees_are_refunded_to_proposer_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn wasm_transaction_fees_are_refunded_to_proposer_classic_pricing() {
+async fn wasm_transaction_fees_are_refunded_to_proposer_payment_limited_pricing() {
     wasm_transaction_fees_are_refunded_to_proposer(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -2385,7 +2385,7 @@ async fn fee_is_accumulated_and_distributed_no_refund_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn fee_is_accumulated_and_distributed_no_refund_classic_pricing() {
+async fn fee_is_accumulated_and_distributed_no_refund_payment_limited_pricing() {
     fee_is_accumulated_and_distributed_no_refund(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -2442,7 +2442,7 @@ fn match_pricing_mode(txn_pricing_mode: &PricingMode) -> (PricingHandling, u8, O
             payment_amount,
             ..
         } => (
-            PricingHandling::Classic,
+            PricingHandling::PaymentLimited,
             *gas_price_tolerance,
             Some(*payment_amount),
         ),
@@ -2464,7 +2464,7 @@ async fn holds_should_be_added_and_cleared_fixed_pricing() {
 }
 
 #[tokio::test]
-async fn holds_should_be_added_and_cleared_classic_pricing() {
+async fn holds_should_be_added_and_cleared_payment_limited_pricing() {
     holds_should_be_added_and_cleared(PricingMode::PaymentLimited {
         payment_amount: 5000,
         gas_price_tolerance: MIN_GAS_PRICE,
@@ -3035,7 +3035,7 @@ async fn insufficient_funds_transfer_from_account() {
             .unwrap();
     let price = txn_v1
         .payment_amount()
-        .expect("must have payment amount as txns are using classic");
+        .expect("must have payment amount as txns are using payment_limited");
     let mut txn = Transaction::from(txn_v1);
     txn.sign(&BOB_SECRET_KEY);
 
@@ -3965,7 +3965,7 @@ async fn gas_holds_accumulate_for_multiple_transactions_in_the_same_block() {
 #[tokio::test]
 async fn gh_5058_regression_custom_payment_with_deploy_variant_works() {
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::NoRefund)
         .with_fee_handling(FeeHandling::NoFee);
 
@@ -4038,7 +4038,7 @@ async fn gh_5058_regression_custom_payment_with_deploy_variant_works() {
 #[tokio::test]
 async fn should_penalize_failed_custom_payment() {
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::NoRefund)
         .with_fee_handling(FeeHandling::NoFee);
 
@@ -4118,7 +4118,7 @@ async fn should_penalize_failed_custom_payment() {
 #[tokio::test]
 async fn gh_5082_install_upgrade_should_allow_adding_new_version() {
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::NoRefund)
         .with_fee_handling(FeeHandling::NoFee);
 
@@ -4209,7 +4209,7 @@ async fn gh_5082_install_upgrade_should_allow_adding_new_version() {
 #[tokio::test]
 async fn should_allow_custom_payment() {
     let config = SingleTransactionTestCase::default_test_config()
-        .with_pricing_handling(PricingHandling::Classic)
+        .with_pricing_handling(PricingHandling::PaymentLimited)
         .with_refund_handling(RefundHandling::NoRefund)
         .with_fee_handling(FeeHandling::NoFee);
 

--- a/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
+++ b/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
@@ -366,8 +366,13 @@ impl MetaTransactionV1 {
 
                 match self.pricing_mode {
                     PricingMode::PaymentLimited {
-                        standard_payment, ..
+                        standard_payment,
+                        payment_amount,
+                        ..
                     } => {
+                        if payment_amount == 0u64 {
+                            return Err(InvalidTransactionV1::InvalidPaymentAmount);
+                        }
                         if !standard_payment {
                             // V2 runtime expects standard payment in the payment limited mode.
                             return Err(InvalidTransactionV1::InvalidPricingMode {
@@ -417,7 +422,7 @@ impl MetaTransactionV1 {
 
         match pricing_mode {
             PricingMode::PaymentLimited { .. } => {
-                if let PricingHandling::Classic = price_handling {
+                if let PricingHandling::PaymentLimited = price_handling {
                 } else {
                     return Err(InvalidTransactionV1::InvalidPricingMode {
                         price_mode: pricing_mode.clone(),

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -121,10 +121,10 @@ validator_credit_cap = [1, 5]
 # Defines how pricing is handled.
 #
 # Valid options are:
-#   'classic': senders of transaction self-specify how much they pay.
+#   'payment_limited': senders of transaction self-specify how much they pay.
 #   'fixed': costs are fixed, per the cost table
 #   'prepaid': prepaid transaction (currently not supported)
-pricing_handling = { type = 'classic' }
+pricing_handling = { type = 'payment_limited' }
 # Does the network allow pre-payment for future
 # execution? Currently not supported.
 #

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -127,10 +127,10 @@ validator_credit_cap = [1, 5]
 # Defines how pricing is handled.
 #
 # Valid options are:
-#   'classic': senders of transaction self-specify how much they pay.
+#   'payment_limited': senders of transaction self-specify how much they pay.
 #   'fixed': costs are fixed, per the cost table
 #   'prepaid': prepaid transaction (currently not supported)
-pricing_handling = { type = 'classic' }
+pricing_handling = { type = 'payment_limited' }
 # Does the network allow pre-payment for future
 # execution? Currently not supported.
 #

--- a/types/src/chainspec/core_config.rs
+++ b/types/src/chainspec/core_config.rs
@@ -269,7 +269,7 @@ impl CoreConfig {
         };
 
         let pricing_handling = if rng.gen() {
-            PricingHandling::Classic
+            PricingHandling::PaymentLimited
         } else {
             PricingHandling::Fixed
         };

--- a/types/src/chainspec/pricing_handling.rs
+++ b/types/src/chainspec/pricing_handling.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 const PRICING_HANDLING_TAG_LENGTH: u8 = 1;
 
-const PRICING_HANDLING_CLASSIC_TAG: u8 = 0;
+const PRICING_HANDLING_PAYMENT_LIMITED_TAG: u8 = 0;
 const PRICING_HANDLING_FIXED_TAG: u8 = 1;
 
 /// Defines what pricing mode a network allows. Correlates to the PricingMode of a
@@ -21,17 +21,16 @@ pub enum PricingHandling {
     #[default]
     /// The transaction sender self-specifies how much token they pay, which becomes their gas
     /// limit.
-    Classic,
+    PaymentLimited,
     /// The costs are fixed, per the cost tables.
-    // in 2.0 the default pricing handling is Fixed
     Fixed,
 }
 
 impl Display for PricingHandling {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
-            PricingHandling::Classic => {
-                write!(f, "PricingHandling::Classic")
+            PricingHandling::PaymentLimited => {
+                write!(f, "PricingHandling::PaymentLimited")
             }
             PricingHandling::Fixed => {
                 write!(f, "PricingHandling::Fixed")
@@ -45,8 +44,8 @@ impl ToBytes for PricingHandling {
         let mut buffer = bytesrepr::allocate_buffer(self)?;
 
         match self {
-            PricingHandling::Classic => {
-                buffer.push(PRICING_HANDLING_CLASSIC_TAG);
+            PricingHandling::PaymentLimited => {
+                buffer.push(PRICING_HANDLING_PAYMENT_LIMITED_TAG);
             }
             PricingHandling::Fixed => {
                 buffer.push(PRICING_HANDLING_FIXED_TAG);
@@ -65,7 +64,7 @@ impl FromBytes for PricingHandling {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (tag, rem) = u8::from_bytes(bytes)?;
         match tag {
-            PRICING_HANDLING_CLASSIC_TAG => Ok((PricingHandling::Classic, rem)),
+            PRICING_HANDLING_PAYMENT_LIMITED_TAG => Ok((PricingHandling::PaymentLimited, rem)),
             PRICING_HANDLING_FIXED_TAG => Ok((PricingHandling::Fixed, rem)),
             _ => Err(bytesrepr::Error::Formatting),
         }
@@ -78,8 +77,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bytesrepr_roundtrip_for_classic() {
-        let handling = PricingHandling::Classic;
+    fn bytesrepr_roundtrip_for_payment_limited() {
+        let handling = PricingHandling::PaymentLimited;
         bytesrepr::test_serialization_roundtrip(&handling);
     }
 

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -235,7 +235,7 @@ impl Transaction {
     ///
     /// For `Deploy` transactions, it checks if the session is a standard payment
     /// in the payment phase. For `V1` transactions, it returns the value of
-    /// `standard_payment` if the pricing mode is `Classic`, otherwise it returns `true`.
+    /// `standard_payment` if the pricing mode is `PaymentLimited`, otherwise it returns `true`.
     pub fn is_standard_payment(&self) -> bool {
         match self {
             Transaction::Deploy(txn) => txn.session().is_standard_payment(Phase::Payment),

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -469,6 +469,10 @@ impl Deploy {
         }
 
         let gas_limit = self.gas_limit(chainspec)?;
+        if gas_limit == Gas::zero() {
+            return Err(InvalidDeploy::InvalidPaymentAmount);
+        }
+
         let block_gas_limit = Gas::new(config.block_gas_limit);
         if gas_limit > block_gas_limit {
             debug!(
@@ -1364,7 +1368,7 @@ impl GasLimited for Deploy {
         let pricing_handling = chainspec.core_config.pricing_handling;
         let costs = &chainspec.system_costs_config;
         let gas_limit = match pricing_handling {
-            PricingHandling::Classic => {
+            PricingHandling::PaymentLimited => {
                 // in the original implementation, for standard deploys the payment amount
                 // specified by the sender is the gas limit (up to the max block limit).
                 if self.is_transfer() {
@@ -2001,7 +2005,7 @@ mod tests {
 
         let mut chainspec = Chainspec::default();
         chainspec.with_chain_name(chain_name.to_string());
-        chainspec.with_pricing_handling(PricingHandling::Classic);
+        chainspec.with_pricing_handling(PricingHandling::PaymentLimited);
         let config = chainspec.transaction_config.clone();
 
         let payment = ExecutableDeployItem::ModuleBytes {
@@ -2048,7 +2052,7 @@ mod tests {
 
         let mut chainspec = Chainspec::default();
         chainspec.with_chain_name(chain_name.to_string());
-        chainspec.with_pricing_handling(PricingHandling::Classic);
+        chainspec.with_pricing_handling(PricingHandling::PaymentLimited);
         let config = chainspec.transaction_config.clone();
 
         let payment = ExecutableDeployItem::ModuleBytes {
@@ -2097,7 +2101,7 @@ mod tests {
 
         let mut chainspec = Chainspec::default();
         chainspec.with_chain_name(chain_name.to_string());
-        chainspec.with_pricing_handling(PricingHandling::Classic);
+        chainspec.with_pricing_handling(PricingHandling::PaymentLimited);
         let config = chainspec.transaction_config.clone();
         let amount = U512::from(config.block_gas_limit + 1);
 
@@ -2361,7 +2365,7 @@ mod tests {
     }
 
     #[test]
-    fn should_use_payment_amount_for_classic_payment() {
+    fn should_use_payment_amount_for_payment_limited_payment() {
         const GAS_PRICE_TOLERANCE: u8 = u8::MAX;
 
         let payment_amount = 500u64;
@@ -2370,7 +2374,7 @@ mod tests {
         let mut chainspec = Chainspec::default();
         chainspec
             .with_chain_name(chain_name.to_string())
-            .with_pricing_handling(PricingHandling::Classic);
+            .with_pricing_handling(PricingHandling::PaymentLimited);
 
         let config = chainspec.transaction_config.clone();
 
@@ -2407,7 +2411,7 @@ mod tests {
         assert_eq!(
             cost,
             U512::from(payment_amount),
-            "in classic pricing, the user selected amount should be the cost if gas price is 1"
+            "in payment limited pricing, the user selected amount should be the cost if gas price is 1"
         );
         gas_price += 1;
         let cost = deploy
@@ -2417,7 +2421,7 @@ mod tests {
         assert_eq!(
             cost,
             U512::from(payment_amount) * gas_price,
-            "in classic pricing, the cost should == user selected amount * gas_price"
+            "in payment limited pricing, the cost should == user selected amount * gas_price"
         );
     }
 
@@ -2431,7 +2435,7 @@ mod tests {
         let mut chainspec = Chainspec::default();
         chainspec
             .with_chain_name(chain_name.to_string())
-            .with_pricing_handling(PricingHandling::Classic);
+            .with_pricing_handling(PricingHandling::PaymentLimited);
 
         let config = chainspec.transaction_config.clone();
 

--- a/types/src/transaction/deploy/error.rs
+++ b/types/src/transaction/deploy/error.rs
@@ -149,6 +149,9 @@ pub enum InvalidDeploy {
         /// The payment amount received.
         got: Box<U512>,
     },
+
+    /// Invalid payment amount.
+    InvalidPaymentAmount,
 }
 
 impl Display for InvalidDeploy {
@@ -288,6 +291,7 @@ impl Display for InvalidDeploy {
                     got, wasm_lane_gas_limit
                 )
             }
+            InvalidDeploy::InvalidPaymentAmount => write!(formatter, "invalid payment amount",),
         }
     }
 }
@@ -326,7 +330,8 @@ impl StdError for InvalidDeploy {
             | InvalidDeploy::GasPriceToleranceTooLow { .. }
             | InvalidDeploy::InvalidRuntime
             | InvalidDeploy::ChainspecHasNoWasmLanesDefined
-            | InvalidDeploy::ExceededWasmLaneGasLimit { .. } => None,
+            | InvalidDeploy::ExceededWasmLaneGasLimit { .. }
+            | InvalidDeploy::InvalidPaymentAmount => None,
         }
     }
 }

--- a/types/src/transaction/pricing_mode.rs
+++ b/types/src/transaction/pricing_mode.rs
@@ -425,17 +425,11 @@ mod tests {
 
     #[test]
     fn test_to_bytes_and_from_bytes() {
-        let classic = PricingMode::PaymentLimited {
+        bytesrepr::test_serialization_roundtrip(&PricingMode::PaymentLimited {
             payment_amount: 100,
             gas_price_tolerance: 1,
             standard_payment: true,
-        };
-        match classic {
-            PricingMode::PaymentLimited { .. } => {}
-            PricingMode::Fixed { .. } => {}
-            PricingMode::Prepaid { .. } => {}
-        }
-        bytesrepr::test_serialization_roundtrip(&classic);
+        });
         bytesrepr::test_serialization_roundtrip(&PricingMode::Fixed {
             gas_price_tolerance: 2,
             additional_computation_factor: 1,

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -281,7 +281,7 @@ impl TransactionV1 {
         self.approvals.extend(approvals);
     }
 
-    /// Returns the payment amount if the txn is using classic mode.
+    /// Returns the payment amount if the txn is using payment limited mode.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn payment_amount(&self) -> Option<u64> {
         if let PricingMode::PaymentLimited { payment_amount, .. } = self.pricing_mode() {

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -204,6 +204,8 @@ pub enum InvalidTransaction {
     MissingSeed,
     // Pricing mode not implemented yet
     PricingModeNotSupported,
+    // Invalid payment amount.
+    InvalidPaymentAmount,
 }
 
 impl Display for InvalidTransaction {
@@ -325,10 +327,10 @@ impl Display for InvalidTransaction {
                 )
             }
             InvalidTransaction::UnableToCalculateGasLimit => {
-                write!(formatter, "unable to calculate gas limit",)
+                write!(formatter, "unable to calculate gas limit", )
             }
             InvalidTransaction::UnableToCalculateGasCost => {
-                write!(formatter, "unable to calculate gas cost",)
+                write!(formatter, "unable to calculate gas cost", )
             }
             InvalidTransaction::InvalidPricingMode { price_mode } => {
                 write!(
@@ -371,14 +373,14 @@ impl Display for InvalidTransaction {
                         index,
                     ),
                 }
-            },
+            }
             InvalidTransaction::CannotCalculateFieldsHash => write!(
                 formatter,
                 "cannot calculate a hash digest for the transaction"
             ),
             InvalidTransaction::EntryPointMustBeCall { entry_point } => {
                 write!(formatter, "entry point must be call: {entry_point}")
-            },
+            }
             InvalidTransaction::NoWasmLaneMatchesTransaction() => write!(formatter, "Could not match any generic wasm lane to the specified transaction"),
             InvalidTransaction::UnexpectedTransactionFieldEntries => write!(formatter, "There were entries in the fields map of the payload that could not be matched"),
             InvalidTransaction::ExpectedNamedArguments => {
@@ -398,6 +400,9 @@ impl Display for InvalidTransaction {
             }
             InvalidTransaction::PricingModeNotSupported => {
                 write!(formatter, "Pricing mode not supported")
+            }
+            InvalidTransaction::InvalidPaymentAmount => {
+                write!(formatter, "invalid payment amount")
             }
         }
     }
@@ -451,7 +456,8 @@ impl StdError for InvalidTransaction {
             | InvalidTransaction::ExpectedBytesArguments
             | InvalidTransaction::InvalidTransactionRuntime { .. }
             | InvalidTransaction::MissingSeed
-            | InvalidTransaction::PricingModeNotSupported => None,
+            | InvalidTransaction::PricingModeNotSupported
+            | InvalidTransaction::InvalidPaymentAmount => None,
         }
     }
 }


### PR DESCRIPTION
This PR addresses #5119

It also updates the name of the host side PricingHandling variant to match the corresponding variant of the transactionv1 PricingMode. 