### PR TITLE
Disable default features in the prometheus crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4479,7 +4479,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror",
 ]
 
@@ -4524,12 +4523,6 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -53,7 +53,7 @@ num_cpus = "1"
 once_cell = "1"
 openssl = "0.10.70"
 pin-project = "1.0.6"
-prometheus = "0.13.4"
+prometheus = { version = "0.13.4", default-features = false }
 quanta = "0.9.2"
 rand = "0.8.3"
 rand_chacha = "0.3.0"


### PR DESCRIPTION
Disables the default features in `prometheus` to prevent the `protobuf` crate from being compiled into the node. This is in response to the recent [2024-0437 RUSTSEC](https://rustsec.org/advisories/RUSTSEC-2024-0437) entry.

Note that we seemingly never needed this functionality in the first place, so it only affects the auditing.