### PR TITLE
[BUGFIX] extend transaction_acceptor coverage

### DIFF
--- a/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
+++ b/node/src/types/transaction/meta_transaction/meta_transaction_v1.rs
@@ -491,6 +491,8 @@ impl MetaTransactionV1 {
                         if *payment_amount < expected_payment {
                             return Err(InvalidTransactionV1::InvalidPaymentAmount);
                         }
+                    } else if *payment_amount < chainspec.core_config.baseline_motes_amount {
+                        return Err(InvalidTransactionV1::InvalidPaymentAmount);
                     }
                 } else {
                     return Err(InvalidTransactionV1::InvalidPricingMode {


### PR DESCRIPTION
This PR handles rejecting insufficient payment for non-native txn's
