### PR TITLE
[BUGFIX] Deploy native transfer entry point name resolution

### DIFF
--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -553,6 +553,11 @@ pub fn execute_finalized_block(
                             .with_added_consumed(gas_limit)
                             .with_burn_result(burn_result)
                             .map_err(|_| BlockExecutionError::RootNotFound(state_root_hash))?;
+                    } else {
+                        artifact_builder.with_error_message(format!(
+                            "Attempt to call unsupported native mint entrypoint: {}",
+                            entry_point
+                        ));
                     }
                 }
                 lane_id if lane_id == AUCTION_LANE_ID => {

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -4556,7 +4556,7 @@ async fn should_allow_native_burn() {
         .with_initiator_addr(PublicKey::from(&**BOB_SECRET_KEY))
         .build()
         .unwrap();
-    let price = txn_v1
+    let payment = txn_v1
         .payment_amount()
         .expect("must have payment amount as txns are using payment_limited");
     let mut txn = Transaction::from(txn_v1);
@@ -4566,7 +4566,7 @@ async fn should_allow_native_burn() {
     let ExecutionResult::V2(result) = exec_result else {
         panic!("Expected ExecutionResult::V2 but got {:?}", exec_result);
     };
-    let expected_cost: U512 = U512::from(price) * MIN_GAS_PRICE;
+    let expected_cost: U512 = U512::from(payment) * MIN_GAS_PRICE;
     assert_eq!(result.error_message.as_deref(), None);
     assert_eq!(result.cost, expected_cost);
 }
@@ -4598,7 +4598,7 @@ async fn should_allow_native_transfer_v1() {
             .with_initiator_addr(PublicKey::from(&**BOB_SECRET_KEY))
             .build()
             .unwrap();
-    let price = txn_v1
+    let payment = txn_v1
         .payment_amount()
         .expect("must have payment amount as txns are using payment_limited");
     let mut txn = Transaction::from(txn_v1);
@@ -4608,7 +4608,7 @@ async fn should_allow_native_transfer_v1() {
     let ExecutionResult::V2(result) = exec_result else {
         panic!("Expected ExecutionResult::V2 but got {:?}", exec_result);
     };
-    let expected_cost: U512 = U512::from(price) * MIN_GAS_PRICE;
+    let expected_cost: U512 = U512::from(payment) * MIN_GAS_PRICE;
     assert_eq!(result.error_message.as_deref(), None);
     assert_eq!(result.cost, expected_cost);
     assert_eq!(result.transfers.len(), 1, "should have exactly 1 transfer");

--- a/types/src/execution/execution_result.rs
+++ b/types/src/execution/execution_result.rs
@@ -37,11 +37,11 @@ pub enum ExecutionResult {
 }
 
 impl ExecutionResult {
-    /// Returns refund amount.
-    pub fn refund(&self) -> Option<U512> {
+    /// Returns consumed amount.
+    pub fn cost(&self) -> U512 {
         match self {
-            ExecutionResult::V1(_) => None,
-            ExecutionResult::V2(result) => Some(result.refund),
+            ExecutionResult::V1(result) => result.cost(),
+            ExecutionResult::V2(result) => result.cost,
         }
     }
 
@@ -50,6 +50,14 @@ impl ExecutionResult {
         match self {
             ExecutionResult::V1(result) => result.cost(),
             ExecutionResult::V2(result) => result.consumed.value(),
+        }
+    }
+
+    /// Returns refund amount.
+    pub fn refund(&self) -> Option<U512> {
+        match self {
+            ExecutionResult::V1(_) => None,
+            ExecutionResult::V2(result) => Some(result.refund),
         }
     }
 

--- a/types/src/execution/execution_result.rs
+++ b/types/src/execution/execution_result.rs
@@ -37,7 +37,7 @@ pub enum ExecutionResult {
 }
 
 impl ExecutionResult {
-    /// Returns consumed amount.
+    /// Returns cost.
     pub fn cost(&self) -> U512 {
         match self {
             ExecutionResult::V1(result) => result.cost(),

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -186,6 +186,7 @@ pub use semver::{ParseSemVerError, SemVer, SEM_VER_SERIALIZED_LENGTH};
 pub use stored_value::{
     GlobalStateIdentifier, StoredValue, StoredValueTag, TypeMismatch as StoredValueTypeMismatch,
 };
+pub use system::mint::METHOD_TRANSFER;
 pub use tagged::Tagged;
 #[cfg(any(feature = "std", test))]
 pub use timestamp::serde_option_time_diff;

--- a/types/src/transaction/deploy/executable_deploy_item.rs
+++ b/types/src/transaction/deploy/executable_deploy_item.rs
@@ -24,7 +24,7 @@ use crate::{
     system::mint::ARG_AMOUNT,
     transaction::{RuntimeArgs, TransferTarget},
     AddressableEntityHash, AddressableEntityIdentifier, Gas, Motes, PackageIdentifier, Phase, URef,
-    U512,
+    METHOD_TRANSFER, U512,
 };
 #[cfg(any(feature = "testing", test))]
 use crate::{testing::TestRng, CLValue};
@@ -255,9 +255,8 @@ impl ExecutableDeployItem {
     /// Returns the entry point name.
     pub fn entry_point_name(&self) -> &str {
         match self {
-            ExecutableDeployItem::ModuleBytes { .. } | ExecutableDeployItem::Transfer { .. } => {
-                DEFAULT_ENTRY_POINT_NAME
-            }
+            ExecutableDeployItem::ModuleBytes { .. } => DEFAULT_ENTRY_POINT_NAME,
+            ExecutableDeployItem::Transfer { .. } => METHOD_TRANSFER,
             ExecutableDeployItem::StoredVersionedContractByName { entry_point, .. }
             | ExecutableDeployItem::StoredVersionedContractByHash { entry_point, .. }
             | ExecutableDeployItem::StoredContractByHash { entry_point, .. }


### PR DESCRIPTION
This PR fixes a bug in underlying logic that would incorrectly resolve the entry point name for a native transfer on a deploy as `call` instead of `transfer`.