### PR TITLE
Rework deploy lane logic

### DIFF
--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -215,9 +215,12 @@ pub fn execute_finalized_block(
             baseline_motes_amount, // <-- default minimum cost, may be overridden later in logic
             current_gas_price,
         );
-        let transaction =
-            MetaTransaction::from_transaction(&stored_transaction, transaction_config)
-                .map_err(|err| BlockExecutionError::TransactionConversion(err.to_string()))?;
+        let transaction = MetaTransaction::from_transaction(
+            &stored_transaction,
+            chainspec.core_config.pricing_handling,
+            transaction_config,
+        )
+        .map_err(|err| BlockExecutionError::TransactionConversion(err.to_string()))?;
         let initiator_addr = transaction.initiator_addr();
         let transaction_hash = transaction.hash();
         let transaction_args = transaction.session_args().clone();
@@ -1323,8 +1326,11 @@ where
     S: StateProvider,
 {
     let transaction_config = &chainspec.transaction_config;
-    let maybe_transaction =
-        MetaTransaction::from_transaction(&input_transaction, transaction_config);
+    let maybe_transaction = MetaTransaction::from_transaction(
+        &input_transaction,
+        chainspec.core_config.pricing_handling,
+        transaction_config,
+    );
     if let Err(error) = maybe_transaction {
         return SpeculativeExecutionResult::invalid_transaction(error);
     }

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -113,8 +113,11 @@ impl TransactionAcceptor {
         debug!(%source, %input_transaction, "checking transaction before accepting");
         let verification_start_timestamp = Timestamp::now();
         let transaction_config = &self.chainspec.as_ref().transaction_config;
-        let maybe_meta_transaction =
-            MetaTransaction::from_transaction(&input_transaction, transaction_config);
+        let maybe_meta_transaction = MetaTransaction::from_transaction(
+            &input_transaction,
+            self.chainspec.as_ref().core_config.pricing_handling,
+            transaction_config,
+        );
         let meta_transaction = match maybe_meta_transaction {
             Ok(transaction) => transaction,
             Err(err) => {

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -1240,8 +1240,12 @@ fn inject_balance_check_for_peer(
     let txn = txn.clone();
     let block = TestBlockBuilder::new().build(rng);
     let block_header = Box::new(block.header().clone().into());
-    let meta_transaction =
-        MetaTransaction::from_transaction(&txn, &chainspec.transaction_config).unwrap();
+    let meta_transaction = MetaTransaction::from_transaction(
+        &txn,
+        chainspec.core_config.pricing_handling,
+        &chainspec.transaction_config,
+    )
+    .unwrap();
     |effect_builder: EffectBuilder<Event>| {
         let event_metadata = Box::new(EventMetadata::new(
             txn,

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -2742,8 +2742,8 @@ async fn should_reject_deploy_with_payment_amount_larger_than_max_wasm_lane_limi
     let result = run_transaction_acceptor(TestScenario::WasmDeployWithTooBigPayment).await;
     assert!(matches!(
         result,
-        Err(super::Error::InvalidTransaction(
-            InvalidTransaction::Deploy(InvalidDeploy::ExceededWasmLaneGasLimit { .. })
-        ))
-    ))
+        Err(super::Error::InvalidTransaction(InvalidTransaction::V1(
+            InvalidTransactionV1::NoWasmLaneMatchesTransaction()
+        )))
+    ));
 }

--- a/node/src/reactor/main_reactor/tests/fixture.rs
+++ b/node/src/reactor/main_reactor/tests/fixture.rs
@@ -19,7 +19,7 @@ use casper_storage::{
     global_state::state::{StateProvider, StateReader},
 };
 use casper_types::{
-    execution::{ExecutionResult, ExecutionResultV2, TransformV2},
+    execution::{ExecutionResult, TransformV2},
     system::auction::{DelegationRate, DelegatorKind},
     testing::TestRng,
     AccountConfig, AccountsConfig, ActivationPoint, AddressableEntityHash, Block, BlockBody,

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -2129,8 +2129,12 @@ async fn should_gas_hold_fee_erroneous_wasm(txn_pricing_mode: PricingMode) {
     .await;
 
     let txn = invalid_wasm_txn(BOB_SECRET_KEY.clone(), txn_pricing_mode);
-    let meta_transaction =
-        MetaTransaction::from_transaction(&txn, &test.chainspec().transaction_config).unwrap();
+    let meta_transaction = MetaTransaction::from_transaction(
+        &txn,
+        test.chainspec().core_config.pricing_handling,
+        &test.chainspec().transaction_config,
+    )
+    .unwrap();
     // Fixed transaction pricing.
     let expected_consumed_gas = Gas::new(0); // expect that this transaction doesn't consume any gas since it has invalid wasm.
     let expected_transaction_gas = gas_limit.unwrap_or(
@@ -5075,4 +5079,236 @@ async fn should_not_allow_unverified_native_burn() {
     let expected_error = format!("Forged reference: {}", alice_purse);
     assert_eq!(result.error_message, Some(expected_error));
     assert_eq!(result.cost, expected_cost);
+}
+
+enum SizingScenario {
+    Gas,
+    SerializedLength,
+}
+
+async fn run_sizing_scenario(sizing_scenario: SizingScenario) {
+    let mut rng = TestRng::new();
+    let alice_stake = 200_000_000_000_u64;
+    let bob_stake = 300_000_000_000_u64;
+    let charlie_stake = 300_000_000_000_u64;
+    let initial_stakes: Vec<U512> =
+        vec![alice_stake.into(), bob_stake.into(), charlie_stake.into()];
+
+    let mut secret_keys: Vec<Arc<SecretKey>> = (0..3)
+        .map(|_| Arc::new(SecretKey::random(&mut rng)))
+        .collect();
+
+    let stakes = secret_keys
+        .iter()
+        .zip(initial_stakes)
+        .map(|(secret_key, stake)| (PublicKey::from(secret_key.as_ref()), stake))
+        .collect();
+
+    let mut fixture = TestFixture::new_with_keys(rng, secret_keys, stakes, None).await;
+
+    let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
+    fixture
+        .run_until_stored_switch_block_header(ERA_ONE, ONE_MIN)
+        .await;
+
+    fixture.run_until_consensus_in_era(ERA_ONE, ONE_MIN).await;
+
+    let base_path = RESOURCES_PATH
+        .parent()
+        .unwrap()
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release");
+
+    let (payment_1, session_1) = match sizing_scenario {
+        SizingScenario::Gas => {
+            // We create two equally sized deploys, and ensure that they are both
+            // executed in the non largest lane by gas limit.
+            let gas_limit_for_lane_4 = fixture
+                .chainspec
+                .transaction_config
+                .transaction_v1_config
+                .get_max_transaction_gas_limit(4u8);
+
+            let payment = ExecutableDeployItem::ModuleBytes {
+                module_bytes: Bytes::new(),
+                args: runtime_args! {
+                "amount" =>  U512::from(gas_limit_for_lane_4),
+                            },
+            };
+
+            let session = ExecutableDeployItem::ModuleBytes {
+                module_bytes: std::fs::read(base_path.join("do_nothing.wasm"))
+                    .unwrap()
+                    .into(),
+                args: runtime_args! {},
+            };
+
+            (payment, session)
+        }
+        SizingScenario::SerializedLength => {
+            let gas_limit_for_lane_3 = fixture
+                .chainspec
+                .transaction_config
+                .transaction_v1_config
+                .get_max_transaction_gas_limit(3u8);
+
+            let payment = ExecutableDeployItem::ModuleBytes {
+                module_bytes: Bytes::new(),
+                args: runtime_args! {
+                    "amount" =>  U512::from(gas_limit_for_lane_3)
+                },
+            };
+
+            let args_length = fixture
+                .chainspec
+                .transaction_config
+                .transaction_v1_config
+                .get_max_args_length(3u8);
+
+            let session = ExecutableDeployItem::ModuleBytes {
+                module_bytes: std::fs::read(base_path.join("do_nothing.wasm"))
+                    .unwrap()
+                    .into(),
+                args: runtime_args! {},
+            };
+
+            (payment, session)
+        }
+    };
+
+    let timestamp = Timestamp::now();
+    let ttl = TimeDiff::from_seconds(100);
+    let gas_price = 1;
+    let chain_name = fixture.chainspec.network_config.name.clone();
+
+    let transaction_1 = Transaction::Deploy(Deploy::new_signed(
+        timestamp,
+        ttl,
+        gas_price,
+        vec![],
+        chain_name.clone(),
+        payment_1,
+        session_1,
+        &ALICE_SECRET_KEY,
+        Some(ALICE_PUBLIC_KEY.clone()),
+    ));
+
+    let wasm_lanes = fixture
+        .chainspec
+        .transaction_config
+        .transaction_v1_config
+        .wasm_lanes();
+
+    let largest_lane = wasm_lanes
+        .iter()
+        .max_by(|left, right| {
+            left.max_transaction_length
+                .cmp(&right.max_transaction_length)
+        })
+        .map(|definition| definition.id)
+        .expect("must have lane id for largest lane");
+
+    let (payment_2, session_2) = match sizing_scenario {
+        SizingScenario::Gas => {
+            // We create two equally sized deploys, and ensure that they are both
+            // executed in the non largest lane by gas limit.
+            let gas_limit_for_lane_3 = fixture
+                .chainspec
+                .transaction_config
+                .transaction_v1_config
+                .get_max_transaction_gas_limit(3u8);
+
+            let payment = ExecutableDeployItem::ModuleBytes {
+                module_bytes: Bytes::new(),
+                args: runtime_args! {
+                "amount" =>  U512::from(gas_limit_for_lane_3),
+                            },
+            };
+
+            let session = ExecutableDeployItem::ModuleBytes {
+                module_bytes: std::fs::read(base_path.join("do_nothing.wasm"))
+                    .unwrap()
+                    .into(),
+                args: runtime_args! {},
+            };
+
+            (payment, session)
+        }
+        SizingScenario::SerializedLength => {
+            let largest_lane_gas_limit = fixture
+                .chainspec
+                .transaction_config
+                .transaction_v1_config
+                .get_max_transaction_gas_limit(largest_lane);
+
+            let payment = ExecutableDeployItem::ModuleBytes {
+                module_bytes: Bytes::new(),
+                args: runtime_args! {
+                    "amount" =>  U512::from(largest_lane_gas_limit)
+                },
+            };
+
+            let faucet_fund_amount = U512::from(400_000_000_000_000u64);
+
+            let session = ExecutableDeployItem::ModuleBytes {
+                module_bytes: std::fs::read(base_path.join("faucet_stored.wasm"))
+                    .unwrap()
+                    .into(),
+                args: runtime_args! {"id" => 1u64, ARG_AMOUNT => faucet_fund_amount },
+            };
+
+            (payment, session)
+        }
+    };
+
+    let transaction_2 = Transaction::Deploy(Deploy::new_signed(
+        timestamp,
+        ttl,
+        gas_price,
+        vec![],
+        chain_name.clone(),
+        payment_2,
+        session_2,
+        &ALICE_SECRET_KEY,
+        Some(ALICE_PUBLIC_KEY.clone()),
+    ));
+
+    // Both deploys are of roughly equal length but should be sized differently based on
+    // their payment amount.
+
+    let txn_1 = transaction_1.hash();
+    let txn_2 = transaction_2.hash();
+
+    fixture.inject_transaction(transaction_1).await;
+    fixture.inject_transaction(transaction_2).await;
+
+    match sizing_scenario {
+        SizingScenario::Gas => {
+            fixture
+                .assert_execution_in_lane(&txn_1, 4u8, TEN_SECS)
+                .await;
+            fixture
+                .assert_execution_in_lane(&txn_2, 3u8, TEN_SECS)
+                .await;
+        }
+        SizingScenario::SerializedLength => {
+            fixture
+                .assert_execution_in_lane(&txn_1, 3u8, TEN_SECS)
+                .await;
+            fixture
+                .assert_execution_in_lane(&txn_2, largest_lane, TEN_SECS)
+                .await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn should_correctly_assign_wasm_deploys_in_lanes_for_payment_limited_by_gas_limit() {
+    run_sizing_scenario(SizingScenario::Gas).await
+}
+
+#[tokio::test]
+async fn should_correctly_assign_wasm_deploys_in_lanes_for_payment_limited_by_serialized_length() {
+    run_sizing_scenario(SizingScenario::SerializedLength).await
 }

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -5094,7 +5094,7 @@ async fn run_sizing_scenario(sizing_scenario: SizingScenario) {
     let initial_stakes: Vec<U512> =
         vec![alice_stake.into(), bob_stake.into(), charlie_stake.into()];
 
-    let mut secret_keys: Vec<Arc<SecretKey>> = (0..3)
+    let secret_keys: Vec<Arc<SecretKey>> = (0..3)
         .map(|_| Arc::new(SecretKey::random(&mut rng)))
         .collect();
 
@@ -5106,7 +5106,6 @@ async fn run_sizing_scenario(sizing_scenario: SizingScenario) {
 
     let mut fixture = TestFixture::new_with_keys(rng, secret_keys, stakes, None).await;
 
-    let alice_secret_key = Arc::clone(&fixture.node_contexts[0].secret_key);
     fixture
         .run_until_stored_switch_block_header(ERA_ONE, ONE_MIN)
         .await;
@@ -5159,12 +5158,6 @@ async fn run_sizing_scenario(sizing_scenario: SizingScenario) {
                     "amount" =>  U512::from(gas_limit_for_lane_3)
                 },
             };
-
-            let args_length = fixture
-                .chainspec
-                .transaction_config
-                .transaction_v1_config
-                .get_max_args_length(3u8);
 
             let session = ExecutableDeployItem::ModuleBytes {
                 module_bytes: std::fs::read(base_path.join("do_nothing.wasm"))

--- a/node/src/testing/fake_transaction_acceptor.rs
+++ b/node/src/testing/fake_transaction_acceptor.rs
@@ -62,9 +62,12 @@ impl FakeTransactionAcceptor {
         source: Source,
         maybe_responder: Option<Responder<Result<(), Error>>>,
     ) -> Effects<Event> {
-        let meta_transaction =
-            MetaTransaction::from_transaction(&transaction, &self.chainspec.transaction_config)
-                .unwrap();
+        let meta_transaction = MetaTransaction::from_transaction(
+            &transaction,
+            self.chainspec.core_config.pricing_handling,
+            &self.chainspec.transaction_config,
+        )
+        .unwrap();
         let event_metadata = Box::new(EventMetadata::new(
             transaction.clone(),
             meta_transaction,

--- a/node/src/types/transaction/meta_transaction.rs
+++ b/node/src/types/transaction/meta_transaction.rs
@@ -3,14 +3,14 @@ mod meta_deploy;
 mod meta_transaction_v1;
 mod transaction_header;
 use casper_execution_engine::engine_state::{SessionDataDeploy, SessionDataV1, SessionInputData};
+#[cfg(test)]
+use casper_types::InvalidTransactionV1;
 use casper_types::{
     account::AccountHash, bytesrepr::ToBytes, Approval, Chainspec, Digest, ExecutableDeployItem,
-    Gas, GasLimited, HashAddr, InitiatorAddr, InvalidTransaction, Phase, PricingMode, TimeDiff,
-    Timestamp, Transaction, TransactionArgs, TransactionConfig, TransactionEntryPoint,
-    TransactionHash, TransactionTarget, INSTALL_UPGRADE_LANE_ID,
+    Gas, GasLimited, HashAddr, InitiatorAddr, InvalidTransaction, Phase, PricingHandling,
+    PricingMode, TimeDiff, Timestamp, Transaction, TransactionArgs, TransactionConfig,
+    TransactionEntryPoint, TransactionHash, TransactionTarget, INSTALL_UPGRADE_LANE_ID,
 };
-#[cfg(test)]
-use casper_types::{InvalidDeploy, InvalidTransactionV1, MINT_LANE_ID};
 use core::fmt::{self, Debug, Display, Formatter};
 #[cfg(test)]
 use lane_id::calculate_transaction_lane;
@@ -241,13 +241,16 @@ impl MetaTransaction {
     /// Create a new `MetaTransaction` from a `Transaction`.
     pub fn from_transaction(
         transaction: &Transaction,
+        pricing_handling: PricingHandling,
         transaction_config: &TransactionConfig,
     ) -> Result<Self, InvalidTransaction> {
         match transaction {
-            Transaction::Deploy(deploy) => {
-                MetaDeploy::from_deploy(deploy.clone(), &transaction_config.transaction_v1_config)
-                    .map(MetaTransaction::Deploy)
-            }
+            Transaction::Deploy(deploy) => MetaDeploy::from_deploy(
+                deploy.clone(),
+                pricing_handling,
+                &transaction_config.transaction_v1_config,
+            )
+            .map(MetaTransaction::Deploy),
             Transaction::V1(v1) => MetaTransactionV1::from_transaction_v1(
                 v1,
                 &transaction_config.transaction_v1_config,
@@ -429,24 +432,13 @@ pub(crate) fn calculate_transaction_lane_for_transaction(
     chainspec: &Chainspec,
 ) -> Result<u8, InvalidTransaction> {
     match transaction {
-        Transaction::Deploy(deploy) => {
-            if deploy.is_transfer() {
-                Ok(MINT_LANE_ID)
-            } else {
-                let wasm_lanes = chainspec
-                    .transaction_config
-                    .transaction_v1_config
-                    .wasm_lanes();
-                let maybe_biggest_lane_limit = calculate_lane_id_of_biggest_wasm(wasm_lanes);
-                if let Some(largest_wasm_id) = maybe_biggest_lane_limit {
-                    Ok(largest_wasm_id)
-                } else {
-                    // Seems like chainspec didn't have any wasm lanes configured
-                    Err(InvalidTransaction::Deploy(
-                        InvalidDeploy::ChainspecHasNoWasmLanesDefined,
-                    ))
-                }
-            }
+        Transaction::Deploy(_) => {
+            let meta = MetaTransaction::from_transaction(
+                transaction,
+                chainspec.core_config.pricing_handling,
+                &chainspec.transaction_config,
+            )?;
+            Ok(meta.transaction_lane())
         }
         Transaction::V1(v1) => {
             let args_binary_len = v1
@@ -504,7 +496,7 @@ mod proptests {
                     max_transaction_count: 10,
                 },
                 ]);
-            let maybe_transaction = MetaTransaction::from_transaction(&transaction, &transaction_config);
+            let maybe_transaction = MetaTransaction::from_transaction(&transaction, PricingHandling::PaymentLimited, &transaction_config);
             prop_assert!(maybe_transaction.is_ok(), "{:?}", maybe_transaction);
         }
     }

--- a/node/src/types/transaction/meta_transaction.rs
+++ b/node/src/types/transaction/meta_transaction.rs
@@ -14,8 +14,6 @@ use casper_types::{
 use core::fmt::{self, Debug, Display, Formatter};
 #[cfg(test)]
 use lane_id::calculate_transaction_lane;
-#[cfg(test)]
-use meta_deploy::calculate_lane_id_of_biggest_wasm;
 use meta_deploy::MetaDeploy;
 pub(crate) use meta_transaction_v1::MetaTransactionV1;
 use serde::Serialize;

--- a/node/src/types/transaction/meta_transaction/lane_id.rs
+++ b/node/src/types/transaction/meta_transaction/lane_id.rs
@@ -34,8 +34,8 @@ pub(crate) fn calculate_transaction_lane(
         TransactionTarget::Stored { .. } => match entry_point {
             TransactionEntryPoint::Custom(_) => get_lane_for_non_install_wasm(
                 config,
-                size_estimation,
                 pricing_mode,
+                size_estimation,
                 runtime_args_size,
             ),
             TransactionEntryPoint::Call
@@ -66,8 +66,8 @@ pub(crate) fn calculate_transaction_lane(
                 } else {
                     get_lane_for_non_install_wasm(
                         config,
-                        size_estimation,
                         pricing_mode,
+                        size_estimation,
                         runtime_args_size,
                     )
                 }
@@ -100,8 +100,8 @@ pub(crate) fn calculate_transaction_lane(
                 } else {
                     get_lane_for_non_install_wasm(
                         config,
-                        size_estimation,
                         pricing_mode,
+                        size_estimation,
                         runtime_args_size,
                     )
                 }
@@ -125,10 +125,10 @@ pub(crate) fn calculate_transaction_lane(
     }
 }
 
-fn get_lane_for_non_install_wasm(
+pub(crate) fn get_lane_for_non_install_wasm(
     config: &TransactionV1Config,
-    transaction_size: u64,
     pricing_mode: &PricingMode,
+    transaction_size: u64,
     runtime_args_size: u64,
 ) -> Result<u8, InvalidTransactionV1> {
     match pricing_mode {

--- a/node/src/types/transaction/meta_transaction/meta_deploy.rs
+++ b/node/src/types/transaction/meta_transaction/meta_deploy.rs
@@ -5,9 +5,9 @@ use crate::types::transaction::meta_transaction::lane_id::get_lane_for_non_insta
 #[cfg(test)]
 use casper_types::TransactionLaneDefinition;
 use casper_types::{
-    bytesrepr::ToBytes, system::auction::ARG_AMOUNT, CLValue, Deploy, ExecutableDeployItem,
-    GasLimited, InvalidDeploy, InvalidTransaction, Phase, PricingHandling, PricingMode,
-    TransactionV1Config, MINT_LANE_ID, U512,
+    bytesrepr::ToBytes, system::auction::ARG_AMOUNT, Deploy, ExecutableDeployItem, GasLimited,
+    InvalidDeploy, InvalidTransaction, Phase, PricingHandling, PricingMode, TransactionV1Config,
+    MINT_LANE_ID, U512,
 };
 #[derive(Clone, Debug, Serialize, DataSize)]
 pub(crate) struct MetaDeploy {

--- a/node/src/types/transaction/meta_transaction/meta_deploy.rs
+++ b/node/src/types/transaction/meta_transaction/meta_deploy.rs
@@ -66,7 +66,6 @@ impl MetaDeploy {
             size_estimation,
             runtime_args_size,
         )?;
-        println!("{lane_id} for {}", deploy.hash());
         Ok(MetaDeploy { deploy, lane_id })
     }
 

--- a/node/src/types/transaction/transaction_footprint.rs
+++ b/node/src/types/transaction/transaction_footprint.rs
@@ -41,8 +41,11 @@ impl TransactionFootprint {
         chainspec: &Chainspec,
         transaction: &Transaction,
     ) -> Result<Self, InvalidTransaction> {
-        let transaction =
-            MetaTransaction::from_transaction(transaction, &chainspec.transaction_config)?;
+        let transaction = MetaTransaction::from_transaction(
+            transaction,
+            chainspec.core_config.pricing_handling,
+            &chainspec.transaction_config,
+        )?;
         Self::new_from_meta_transaction(chainspec, &transaction)
     }
 

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -219,7 +219,7 @@ native_mint_lane = [0, 2048, 1024, 100_000_000, 650]
 native_auction_lane = [1, 3096, 2048, 2_500_000_000, 650]
 install_upgrade_lane = [2, 750_000, 2048, 1_000_000_000_000, 1]
 wasm_lanes = [
-    [3, 262_144, 1024, 1_000_000_000_000, 1],
+    [3, 750_000, 2048, 1_000_000_000_000, 1],
     [4, 131_072, 1024, 100_000_000_000, 2],
     [5, 65_536, 512, 5_000_000_000, 80]
 ]
@@ -500,5 +500,5 @@ pay = 10_000
 # The cost charged for the transaction is simply the gas_used * current_gas_price.
 upper_threshold = 90
 lower_threshold = 50
-max_gas_price = 3
+max_gas_price = 1
 min_gas_price = 1

--- a/types/src/chainspec/transaction_config/transaction_v1_config.rs
+++ b/types/src/chainspec/transaction_config/transaction_v1_config.rs
@@ -426,8 +426,8 @@ impl TransactionV1Config {
             let max_transaction_size = lane.max_transaction_length;
             let max_runtime_args_size = lane.max_transaction_args_length;
             if max_transaction_gas >= gas_limit
-                && max_transaction_size >= transaction_size
-                && max_runtime_args_size >= runtime_args_size
+                && (max_transaction_size >= transaction_size
+                    || max_runtime_args_size >= runtime_args_size)
             {
                 maybe_adequate_lane_index = Some(i);
                 break;

--- a/types/src/chainspec/transaction_config/transaction_v1_config.rs
+++ b/types/src/chainspec/transaction_config/transaction_v1_config.rs
@@ -451,12 +451,12 @@ impl TransactionV1Config {
     #[allow(unreachable_code)]
     //We're allowing unreachable code here because there's a possibility that someone might
     // want to use the types crate without once_cell
-    // This function will take the wasm lanes odered by:
+    // This function will take the wasm lanes ordered by:
     //   - firstly gas limit
     //   - secondly max_transaction_length
     //   - thirdly max runtime args
-    //   - fourthly lane id (this has no "business" value, but it ensures that the ordering
-    //        is always reproducible since ids should be unique)
+    //   - fourthly lane id (this has no "business" value, but it ensures that the ordering is
+    //     always reproducible since ids should be unique)
     fn get_wasm_lanes_ordered(&self) -> &Vec<TransactionLaneDefinition> {
         #[cfg(any(feature = "once_cell", test))]
         return self
@@ -942,7 +942,8 @@ mod tests {
         ]);
         assert_eq!(res, vec![definition_3, definition_1, definition_2,]);
 
-        // If max_transaction_gas_limit and max_transaction_length equal, order by max_transaction_args_length
+        // If max_transaction_gas_limit and max_transaction_length equal, order by
+        // max_transaction_args_length
         let definition_1 = TransactionLaneDefinition::new(0, 2, 4, 1, 0);
         let definition_2 = TransactionLaneDefinition::new(1, 2, 2, 1, 0);
         let definition_3 = TransactionLaneDefinition::new(2, 2, 3, 1, 0);
@@ -953,7 +954,8 @@ mod tests {
         ]);
         assert_eq!(res, vec![definition_2, definition_3, definition_1,]);
 
-        // If max_transaction_gas_limit and max_transaction_length equal and max_transaction_args_length, order by id
+        // If max_transaction_gas_limit and max_transaction_length equal and
+        // max_transaction_args_length, order by id
         let definition_1 = TransactionLaneDefinition::new(2, 2, 3, 1, 0);
         let definition_2 = TransactionLaneDefinition::new(0, 2, 3, 1, 0);
         let definition_3 = TransactionLaneDefinition::new(1, 2, 3, 1, 0);

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -1227,17 +1227,17 @@ impl Deploy {
         chain_name: String,
         auction_contract_hash: AddressableEntityHash,
         public_key: PublicKey,
-        amount: U512,
+        bid_amount: U512,
         delegation_rate: u8,
         timestamp: Timestamp,
         ttl: TimeDiff,
     ) -> Self {
         let payment = ExecutableDeployItem::ModuleBytes {
             module_bytes: Bytes::new(),
-            args: runtime_args! { ARG_AMOUNT => U512::from(6_000_000_000_000u64) },
+            args: runtime_args! { ARG_AMOUNT => U512::from(100_000_000_000u64) },
         };
         let args = runtime_args! {
-            ARG_AUCTION_AMOUNT => amount,
+            ARG_AUCTION_AMOUNT => bid_amount,
             ARG_AUCTION_PUBLIC_KEY => public_key.clone(),
             ARG_DELEGATION_RATE => delegation_rate,
         };


### PR DESCRIPTION
Rework lane assignment of 1.x Deploys to mirror that of TransactionV1
Make the min and max gas price the same for the production chainspec