### PR TITLE
[TECHDEBT] Misc small techdebt fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2024-0437
+	$(CARGO) audit --ignore RUSTSEC-2024-0437 --ignore RUSTSEC-2025-0022
 
 .PHONY: audit
 audit: audit-rs

--- a/node/src/components/transaction_buffer.rs
+++ b/node/src/components/transaction_buffer.rs
@@ -447,7 +447,6 @@ impl TransactionBuffer {
         }
 
         let mut holds = HashSet::new();
-        let mut dead = HashSet::new();
 
         let mut have_hit_mint_limit = false;
         let mut have_hit_wasm_limit = false;
@@ -511,18 +510,16 @@ impl TransactionBuffer {
                             // it should be physically impossible for a duplicate transaction or
                             // transaction to be in the transaction buffer, thus this should be
                             // unreachable
-                            error!(
+                            warn!(
                                 ?transaction_hash,
                                 "TransactionBuffer: duplicated transaction or transfer in transaction buffer"
                             );
-                            dead.insert(transaction_hash);
                         }
                         AddError::Expired => {
                             info!(
                                 ?transaction_hash,
                                 "TransactionBuffer: expired transaction or transfer in transaction buffer"
                             );
-                            dead.insert(transaction_hash);
                         }
                         AddError::Count(lane_id) => {
                             match lane_id {
@@ -588,7 +585,6 @@ impl TransactionBuffer {
                 }
             }
         }
-        self.dead.extend(dead);
 
         // Put a hold on all proposed transactions / transfers and update metrics
         match self.hold.entry(timestamp) {
@@ -797,7 +793,7 @@ where
                             self.register_transaction(*transaction);
                         }
                         None => {
-                            warn!("cannot register un-stored transaction({})", transaction_id);
+                            debug!("cannot register un-stored transaction({})", transaction_id);
                         }
                     }
                     Effects::new()

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -7,15 +7,34 @@
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
 # Historical sync behavior for this node. Options are:
-#  'genesis'  (node will attempt to acquire all block data back to genesis)
 #  'ttl'      (node will attempt to acquire all block data to comply with time to live enforcement)
+#  'genesis'  (node will attempt to acquire all block data back to genesis)
 #  'nosync'   (node will only acquire blocks moving forward)
 #  'isolated' (node will initialize without peers and will not accept peers)
+#  'completeblock' (node will acquire complete block and shutdown)
+# note: the only two states allowed to switch to Validate reactor state are `genesis` and `ttl`.
+#       it is recommended for dedicated validator nodes to be in ttl mode to increase
+#       their ability to maintain maximal uptime...if a long-running genesis validator
+#       goes offline and comes back up while in genesis mode, it must backfill
+#       any gaps in its block awareness before resuming validation.
+#
+#       it is recommended for reporting non-validator nodes to be in genesis mode to
+#       enable support for queries at any block height.
+#
+#       it is recommended for non-validator working nodes (for dapp support, etc) to run in
+#       ttl or nosync mode (depending upon their specific data requirements).
+#
+#       thus for instance a node backing a block explorer would prefer genesis mode,
+#       while a node backing a dapp interested in very recent activity would prefer to run in nosync mode,
+#       and a node backing a dapp interested in auction activity or tracking trends would prefer to run in ttl mode.
+# note: as time goes on, the time to sync back to genesis takes progressively longer.
 # note: ttl is a chainsepc configured behavior on a given network; consult the `max_ttl` chainspec setting
 #       (it is currently ~18 hours by default on production and production-like networks but subject to change).
 # note: `nosync` is incompatible with validator behavior; a nosync node is prevented from participating
 #        in consensus / switching to validate mode. it is primarily for lightweight nodes that are
 #        only interested in recent activity.
+# note: an isolated node will not connect to, sync with, or keep up with the network, but will respond to
+#       binary port, rest server, event server, and diagnostic port connections.
 sync_handling = 'genesis'
 
 # Idle time after which the syncing process is considered stalled.

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -7,16 +7,32 @@
 #trusted_hash = 'HEX-FORMATTED BLOCK HASH'
 
 # Historical sync behavior for this node. Options are:
-#  'genesis'  (node will attempt to acquire all block data back to genesis)
-# note: as time goes on, the time to sync all the way back to genesis takes progressively longer.
 #  'ttl'      (node will attempt to acquire all block data to comply with time to live enforcement)
+#  'genesis'  (node will attempt to acquire all block data back to genesis)
+#  'nosync'   (node will only acquire blocks moving forward)
+#  'isolated' (node will initialize without peers and will not accept peers)
+#  'completeblock' (node will acquire complete block and shutdown)
+# note: the only two states allowed to switch to Validate reactor state are `genesis` and `ttl`.
+#       it is recommended for dedicated validator nodes to be in ttl mode to increase
+#       their ability to maintain maximal uptime...if a long-running genesis validator
+#       goes offline and comes back up while in genesis mode, it must backfill
+#       any gaps in its block awareness before resuming validation.
+#
+#       it is recommended for reporting non-validator nodes to be in genesis mode to
+#       enable support for queries at any block height.
+#
+#       it is recommended for non-validator working nodes (for dapp support, etc) to run in
+#       ttl or nosync mode (depending upon their specific data requirements).
+#
+#       thus for instance a node backing a block explorer would prefer genesis mode,
+#       while a node backing a dapp interested in very recent activity would prefer to run in nosync mode,
+#       and a node backing a dapp interested in auction activity or tracking trends would prefer to run in ttl mode.
+# note: as time goes on, the time to sync back to genesis takes progressively longer.
 # note: ttl is a chainsepc configured behavior on a given network; consult the `max_ttl` chainspec setting
 #       (it is currently ~18 hours by default on production and production-like networks but subject to change).
-#  'nosync'   (node will only acquire blocks moving forward)
 # note: `nosync` is incompatible with validator behavior; a nosync node is prevented from participating
 #        in consensus / switching to validate mode. it is primarily for lightweight nodes that are
 #        only interested in recent activity.
-#  'isolated' (node will initialize without peers and will not accept peers)
 # note: an isolated node will not connect to, sync with, or keep up with the network, but will respond to
 #       binary port, rest server, event server, and diagnostic port connections.
 sync_handling = 'ttl'


### PR DESCRIPTION
This PR fixes an edge case where a txn identified as expired during proposal creation by a round leader was also registered as `dead`. Due to this, such a txn would not be seen by the next expiry sweep and clear and thus announcement of the expiry would not get sent to the sse event stream on that node (it would get detected and evented on other nodes).

The flagging of the expired txn during proposal creation was a premature optimization. Rather than encumber the proposable logic with sse eventing wire up, the approach taken is to instead remove the premature optimization returning the proposable logic to a single responsibility, and allowing the existing expiry process to solely own the responsibility of expiry and notification of same. This also has the positive side effect of removing the unnecessary subjectivity of a round proposer potentially having different observed eventing behavior than all other nodes. Win - win.

The edge case is not significant as it did not affect node or network operation and is not load bearing for the network in any way. However, it removes a irritating quirk for event listeners, particularly those that listen to the feed of only one node which happens to also be a validating node (and thus would never see an expiry event for any such txn that fell into this edge case).

This PR also updates documentation in the config file to provide clearer commentary on the sync-handling setting and also to make the local and release config files docu the same.

This PR lowers the log level of a couple of spammy log messages, to dial the noise down to an appropriate level.

Finally, this PR also temporarily ignores an audit check that just surfaced to unblock CI/CD. The rustsec will be addressed later as a separate concern.