### PR TITLE
Improve build log terminal output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,16 +647,19 @@ name = "cargo-casper"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atty",
  "cargo_metadata 0.19.2",
  "casper-sdk 0.1.0",
  "casper-sdk-sys 0.1.0",
  "clap 4.5.35",
  "clap-cargo",
+ "crossterm",
  "include_dir",
  "libloading",
  "once_cell",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
  "wabt",
 ]
 
@@ -997,7 +1000,7 @@ dependencies = [
  "casper-storage",
  "casper-types",
  "datasize",
- "derive_more",
+ "derive_more 0.99.19",
  "either",
  "enum-iterator 0.6.0",
  "erased-serde",
@@ -1182,7 +1185,7 @@ dependencies = [
  "blake2 0.9.2",
  "criterion",
  "datasize",
- "derive_more",
+ "derive_more 0.99.19",
  "derp",
  "ed25519-dalek",
  "getrandom 0.2.15",
@@ -1239,7 +1242,7 @@ dependencies = [
  "base16",
  "casper-types",
  "clap 3.2.25",
- "derive_more",
+ "derive_more 0.99.19",
  "hex",
  "serde",
  "serde_json",
@@ -1605,6 +1608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1826,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm_winapi",
+ "derive_more 2.0.1",
+ "document-features",
+ "mio 1.0.3",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2028,10 +2067,31 @@ version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case 0.7.1",
+ "proc-macro2",
+ "quote",
  "syn 2.0.100",
 ]
 
@@ -2161,6 +2221,15 @@ dependencies = [
  "casper-contract",
  "casper-types",
  "create-purse-01",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -3904,6 +3973,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "lmdb-rkv"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +4227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -5700,7 +5776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "derive_more",
+ "derive_more 0.99.19",
  "twox-hash",
 ]
 
@@ -6009,6 +6085,17 @@ checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 1.0.3",
+ "signal-hook",
 ]
 
 [[package]]

--- a/cargo-casper/Cargo.toml
+++ b/cargo-casper/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = { version = "1.0.140" }
 cargo_metadata = "0.19.2"
 wabt = "0.10.0"
 once_cell = "1.21.3"
+crossterm = "0.29.0"
+thiserror = "2.0.12"
+atty = "0.2.14"

--- a/cargo-casper/src/cli/build.rs
+++ b/cargo-casper/src/cli/build.rs
@@ -25,7 +25,7 @@ pub fn build_impl(
             String::from_utf8(buffer.into_inner()).context("Failed to read contract schema")?;
 
         // Build the contract with above schema injected
-        eprintln!("Building contract with schema injected...");
+        eprintln!("🔨 Step 2: Building contract with schema injected...");
         let production_wasm_path = CompileJob::new(
             package_name,
             None,
@@ -48,7 +48,7 @@ pub fn build_impl(
         production_wasm_path
     } else {
         // Compile and move to specified output directory
-        eprintln!("Building contract...");
+        eprintln!("🔨 Step 2: Building contract...");
         CompileJob::new(package_name, None, vec![])
             .dispatch("wasm32-unknown-unknown", Option::<String>::None)
             .context("Failed to compile user wasm")?
@@ -57,7 +57,7 @@ pub fn build_impl(
     };
 
     // Run wasm optimizations passes that will shrink the size of the wasm.
-    eprintln!("Applying optimizations...");
+    eprintln!("🔨 Step 3: Applying optimizations...");
     Command::new("wasm-strip")
         .args([&production_wasm_path])
         .spawn()
@@ -83,7 +83,7 @@ pub fn build_impl(
     }
 
     // Report paths
-    eprintln!("Completed. Build artifacts:");
+    eprintln!("✅ Completed. Build artifacts:");
     eprintln!("{:?}", out_wasm_path.canonicalize()?);
     if let Some(schema_path) = out_schema_path {
         eprintln!("{:?}", schema_path.canonicalize()?);

--- a/cargo-casper/src/cli/build_schema.rs
+++ b/cargo-casper/src/cli/build_schema.rs
@@ -16,7 +16,7 @@ pub fn build_schema_impl<W: Write>(
 ) -> Result<(), anyhow::Error> {
     // Compile contract package to a native library with extra code that will
     // produce ABI information including entrypoints, types, etc.
-    eprintln!("Building contract schema...");
+    eprintln!("🔨 Step 1: Building contract schema...");
 
     let rustflags = {
         let current = std::env::var("RUSTFLAGS").unwrap_or_default();

--- a/cargo-casper/src/main.rs
+++ b/cargo-casper/src/main.rs
@@ -5,6 +5,7 @@ use cli::{Cli, Command};
 
 pub(crate) mod cli;
 pub(crate) mod compilation;
+pub mod utils;
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();

--- a/cargo-casper/src/utils.rs
+++ b/cargo-casper/src/utils.rs
@@ -1,0 +1,1 @@
+pub mod command_runner;

--- a/cargo-casper/src/utils/command_runner.rs
+++ b/cargo-casper/src/utils/command_runner.rs
@@ -1,0 +1,314 @@
+use std::{
+    collections::VecDeque,
+    fmt::{Display, Formatter},
+    io::{self, BufRead, BufReader, Write},
+    os::unix::process::ExitStatusExt,
+    process::{Command, Stdio},
+    sync::mpsc,
+    thread,
+};
+
+use atty::Stream;
+use crossterm::{cursor, style, terminal, QueueableCommand};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Outcome {
+    #[error("Input/Output error: {0}")]
+    Io(#[from] io::Error),
+    #[error("Subprocess exited with error code: {0}")]
+    ErrorCode(i32),
+    #[error("Subprocess terminated by signal: {0}")]
+    Signal(i32),
+}
+
+#[derive(Debug)]
+pub enum Line {
+    Stdout(String),
+    Stderr(String),
+}
+
+impl Display for Line {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Line::Stdout(text) => write!(f, "{}", text),
+            Line::Stderr(text) => write!(f, "{}", text),
+        }
+    }
+}
+
+/// Maximum number of lines to keep in the rolling log.
+pub const DEFAULT_MAX_LINES: usize = 10;
+
+#[derive(Debug)]
+pub struct ProcessHandle {
+    pub receiver: mpsc::Receiver<Line>,
+    pub stdout_thread_handle: thread::JoinHandle<()>,
+    pub stderr_thread_handle: thread::JoinHandle<()>,
+    pub child: std::process::Child,
+}
+
+impl ProcessHandle {
+    pub fn wait(mut self) -> Result<(), Outcome> {
+        // Ensure the reader threads have completed.
+        self.stdout_thread_handle
+            .join()
+            .expect("Stdout thread panicked");
+        self.stderr_thread_handle
+            .join()
+            .expect("Stderr thread panicked");
+
+        // Wait for the subprocess to finish.
+        let exit_status = self.child.wait().expect("Failed to wait on child process");
+
+        match exit_status.code() {
+            Some(code) => {
+                if code == 0 {
+                    // Subprocess completed successfully.
+                    Ok(())
+                } else {
+                    // Subprocess exited with error code.
+                    Err(Outcome::ErrorCode(code))
+                }
+            }
+            None => {
+                // Subprocess terminated by signal.
+                if let Some(signal) = exit_status.signal() {
+                    // Subprocess terminated by signal
+                    Err(Outcome::Signal(signal))
+                } else {
+                    unreachable!("Unexpected exit status: {:?}", exit_status);
+                }
+            }
+        }
+    }
+}
+
+/// Runs a subprocess and captures its output.
+///
+/// Returns a `ProcessHandle` that can be used to read the output and wait for the process to
+/// finish.
+///
+/// Lines captured are available in a `receiver` attribute and can be piped to a `LogTrail`
+/// instance.
+pub fn run_process(command: &mut Command) -> io::Result<ProcessHandle> {
+    // Spawn the subprocess with stdout and stderr piped.
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    // Take the stdout and stderr handles.
+    let stdout_pipe = child.stdout.take().expect("Failed to capture stdout");
+    let stderr_pipe = child.stderr.take().expect("Failed to capture stderr");
+
+    // Create a channel to receive lines from both stdout and stderr.
+    let (tx, rx) = mpsc::channel();
+
+    // Spawn a thread to read stdout.
+    let stdout_thread = thread::spawn({
+        let tx = tx.clone();
+
+        move || {
+            let reader = BufReader::new(stdout_pipe);
+            for line in reader.lines() {
+                if let Ok(line_text) = line {
+                    // If send fails, the main thread is likely gone.
+                    if tx.send(Line::Stdout(line_text)).is_err() {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+    });
+
+    // Spawn a second thread to read stderr.
+
+    let stderr_thread = thread::spawn({
+        let tx_err = tx.clone();
+        move || {
+            let reader = BufReader::new(stderr_pipe);
+            for line in reader.lines() {
+                if let Ok(line_text) = line {
+                    if tx_err.send(Line::Stderr(line_text)).is_err() {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+    });
+
+    // Drop the extra sender so that the channel closes when both threads finish.
+    drop(tx);
+
+    Ok(ProcessHandle {
+        receiver: rx,
+        stdout_thread_handle: stdout_thread,
+        stderr_thread_handle: stderr_thread,
+        child,
+    })
+}
+
+/// Enum representing the interactive mode for the log trail.
+pub enum Interactive {
+    /// Program will figure it out if a logs can be printed interactively.
+    Auto,
+    /// Interactive mode is enabled.
+    Yes,
+    /// Interactive mode is disabled.
+    No,
+}
+
+impl Interactive {
+    /// Check if the interactive mode is enabled.
+    pub fn is_enabled(&self) -> bool {
+        match self {
+            Interactive::Auto => atty::is(Stream::Stdout),
+            Interactive::Yes => true,
+            Interactive::No => false,
+        }
+    }
+}
+/// A stateful log trail that maintains a rolling window of log lines.
+pub struct LogTrail {
+    max_lines: usize,
+    interactive: Interactive,
+    current_lines: VecDeque<String>,
+    printed_lines: usize,
+    stdout: std::io::Stdout,
+}
+
+impl LogTrail {
+    /// Create a new LogTrail.
+    ///
+    /// * `max_lines` specifies how many lines to keep in the rolling window.
+    /// * `interactive` should be true when you want the dynamic updating behavior (e.g. when
+    ///   running in a terminal).
+    pub fn new(max_lines: usize, interactive: Interactive) -> Self {
+        Self {
+            max_lines,
+            interactive,
+            current_lines: VecDeque::with_capacity(max_lines),
+            printed_lines: 0,
+            stdout: io::stdout(),
+        }
+    }
+
+    /// Push a new line into the log trail.
+    ///
+    /// This method tracks the line numbering and either updates the dynamic window (if interactive)
+    /// or prints the new line immediately.
+    pub fn push_line<S: Into<String>>(&mut self, line: S) -> io::Result<()> {
+        let line_text = line.into();
+        if self.interactive.is_enabled() {
+            // Maintain a rolling window of at most max_lines.
+            if self.current_lines.len() == self.max_lines {
+                self.current_lines.pop_front();
+            }
+            self.current_lines.push_back(line_text);
+            // Move the cursor up by the number of previously printed lines plus one extra
+            // (e.g. if a static header line is printed above the log).
+            if self.printed_lines > 0 {
+                self.stdout
+                    .queue(cursor::MoveUp(self.printed_lines as u16))?;
+            }
+            // Clear everything from the current cursor position downward.
+            self.stdout
+                .queue(terminal::Clear(terminal::ClearType::FromCursorDown))?;
+
+            // Reprint the rolling buffer with each line prefixed.
+            for text in self.current_lines.iter() {
+                self.stdout.queue(style::Print(text))?;
+                self.stdout.queue(style::Print("\n"))?;
+            }
+            self.printed_lines = self.current_lines.len();
+        } else {
+            // In non-interactive mode simply print the line.
+            self.stdout.queue(style::Print(line_text))?;
+            self.stdout.queue(style::Print("\n"))?;
+        }
+        self.stdout.flush()?;
+        Ok(())
+    }
+}
+
+/// Builder for creating a `LogTrail` instance.
+#[derive(Default)]
+pub struct LogTrailBuilder {
+    max_lines: Option<usize>,
+    interactive: Option<Interactive>,
+}
+
+impl LogTrailBuilder {
+    /// Creates a new builder with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the maximum number of lines for the rolling log.
+    pub fn max_lines(mut self, max_lines: usize) -> Self {
+        self.max_lines = Some(max_lines);
+        self
+    }
+
+    /// Sets whether the log trail should be interactive.
+    pub fn interactive(mut self, interactive: Interactive) -> Self {
+        self.interactive = Some(interactive);
+        self
+    }
+
+    /// Builds the `LogTrail` instance.
+    pub fn build(self) -> LogTrail {
+        let max_lines = self.max_lines.expect("Max lines must be set");
+        let interactive = self.interactive.expect("Interactive mode must be set");
+        LogTrail::new(max_lines, interactive)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_process() {
+        // This test will run the `echo` command, which should always succeed.
+        let result = run_process(Command::new("echo").args(["Hello, world!"]))
+            .expect("Failed to run process");
+        assert!(result.wait().is_ok());
+    }
+
+    #[test]
+    fn test_run_interactive_process() {
+        // This test will run the `echo` command, which should always succeed.
+        let result = run_process(Command::new("echo").args(["Hello, world!"]))
+            .expect("Failed to run process");
+        assert!(result.wait().is_ok());
+    }
+
+    #[test]
+    fn test_run_process_failure() {
+        // This test will run a non-existent command, which should fail.
+        let result = run_process(&mut Command::new("non_existent_command"))
+            .expect_err("Failed to run process");
+        assert_eq!(result.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_run_process_with_env() {
+        // This test will run the `env` command to print environment variables.
+        let handle = run_process(Command::new("env").envs([("TEST_VAR", "test_value")]))
+            .expect("Failed to run process");
+
+        let captured_lines: Vec<String> = handle
+            .receiver
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect();
+        let output = captured_lines.join("\n");
+        assert!(output.contains("TEST_VAR=test_value"));
+    }
+}

--- a/cargo-casper/test.py
+++ b/cargo-casper/test.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import itertools
+import time
+import sys
+import os
+
+for a in itertools.count():
+    if a % 2 == 0:
+        print(f'line {a}')
+    else:
+        print(f'error line {a}', file=sys.stderr)
+    time.sleep(0.05)
+    if a == 44:
+        os.kill(os.getpid(), 9)
+    if a > 100:
+        break
+
+print('Goodbye')


### PR DESCRIPTION
This PR improves readability of build log output in the terminal by maintaining a rotating window of max 10 messages coming from `cargo` subprocess. This will show both stdout and stderr as it arrives which will improve user experience

Follow up for #5171 