### PR TITLE
Improve collections in the VM2 SDK

### DIFF
--- a/smart_contracts/sdk/src/collections.rs
+++ b/smart_contracts/sdk/src/collections.rs
@@ -14,4 +14,4 @@ pub use vector::Vector;
 pub use iterable_map::IterableMap;
 pub use iterable_map::IterableMapIter;
 pub use iterable_map::IterableMapKey;
-pub use iterable_map::IterableMapKeyRepr;
+pub use iterable_map::IterableMapPtr;

--- a/smart_contracts/sdk/src/collections.rs
+++ b/smart_contracts/sdk/src/collections.rs
@@ -4,6 +4,7 @@ mod map;
 mod set;
 pub mod sorted_vector;
 mod vector;
+mod iterable_map;
 
 pub use map::Map;
 pub use set::Set;

--- a/smart_contracts/sdk/src/collections.rs
+++ b/smart_contracts/sdk/src/collections.rs
@@ -1,17 +1,15 @@
 mod lookup_key;
 
+mod iterable_map;
+mod iterable_set;
 mod map;
 mod set;
 pub mod sorted_vector;
 mod vector;
-mod iterable_map;
-mod iterable_set;
 
 pub use map::Map;
 pub use set::Set;
 pub use vector::Vector;
 
-pub use iterable_map::IterableMap;
-pub use iterable_map::IterableMapIter;
-pub use iterable_map::IterableMapKey;
-pub use iterable_map::IterableMapPtr;
+pub use iterable_map::{IterableMap, IterableMapIter, IterableMapKey, IterableMapPtr};
+pub use iterable_set::IterableSet;

--- a/smart_contracts/sdk/src/collections.rs
+++ b/smart_contracts/sdk/src/collections.rs
@@ -9,3 +9,8 @@ mod iterable_map;
 pub use map::Map;
 pub use set::Set;
 pub use vector::Vector;
+
+pub use iterable_map::IterableMap;
+pub use iterable_map::IterableMapIter;
+pub use iterable_map::IterableMapKey;
+pub use iterable_map::IterableMapKeyRepr;

--- a/smart_contracts/sdk/src/collections.rs
+++ b/smart_contracts/sdk/src/collections.rs
@@ -11,5 +11,5 @@ pub use map::Map;
 pub use set::Set;
 pub use vector::Vector;
 
-pub use iterable_map::{IterableMap, IterableMapIter, IterableMapHash, IterableMapPtr};
+pub use iterable_map::{IterableMap, IterableMapHash, IterableMapIter, IterableMapPtr};
 pub use iterable_set::IterableSet;

--- a/smart_contracts/sdk/src/collections.rs
+++ b/smart_contracts/sdk/src/collections.rs
@@ -11,5 +11,5 @@ pub use map::Map;
 pub use set::Set;
 pub use vector::Vector;
 
-pub use iterable_map::{IterableMap, IterableMapIter, IterableMapKey, IterableMapPtr};
+pub use iterable_map::{IterableMap, IterableMapIter, IterableMapHash, IterableMapPtr};
 pub use iterable_set::IterableSet;

--- a/smart_contracts/sdk/src/collections.rs
+++ b/smart_contracts/sdk/src/collections.rs
@@ -5,6 +5,7 @@ mod set;
 pub mod sorted_vector;
 mod vector;
 mod iterable_map;
+mod iterable_set;
 
 pub use map::Map;
 pub use set::Set;

--- a/smart_contracts/sdk/src/collections/iterable_map.rs
+++ b/smart_contracts/sdk/src/collections/iterable_map.rs
@@ -263,8 +263,6 @@ where
     ///
     /// Traverses entries in reverse-insertion order.
     /// Each item is a tuple of the hashed key and the value.
-    ///
-    /// Note: the original key type `K` is not recoverable during iteration.
     pub fn iter(&self) -> IterableMapIter<K, V> {
         IterableMapIter {
             prefix: &self.prefix,

--- a/smart_contracts/sdk/src/collections/iterable_map.rs
+++ b/smart_contracts/sdk/src/collections/iterable_map.rs
@@ -88,7 +88,7 @@ where
         Self {
             prefix: prefix.into(),
             tail_key_hash: None,
-            _marker: Default::default(),
+            _marker: PhantomData,
         }
     }
 
@@ -339,8 +339,7 @@ where
     }
 
     fn get_entry(&self, keyspace: Keyspace) -> Option<IterableMapEntry<K, V>> {
-        read_into_vec(keyspace)
-            .and_then(|vec| borsh::from_slice(&vec).ok())
+        read_into_vec(keyspace).and_then(|vec| borsh::from_slice(&vec).ok())
     }
 
     fn create_prefix_from_key(&self, key: &K) -> Vec<u8> {
@@ -351,9 +350,9 @@ where
     fn create_prefix_from_ptr(&self, hash: &IterableMapPtr) -> Vec<u8> {
         let mut context_key = Vec::new();
         context_key.extend(self.prefix.as_bytes());
-        context_key.extend("_".as_bytes());
+        context_key.extend(b"_");
         context_key.put_u64_le(hash.hash);
-        context_key.extend("_".as_bytes());
+        context_key.extend(b"_");
         context_key.put_u64_le(hash.index);
         context_key
     }
@@ -411,9 +410,9 @@ where
         let current_hash = self.current?;
         let mut key_bytes = Vec::new();
         key_bytes.extend(self.prefix.as_bytes());
-        key_bytes.extend("_".as_bytes());
+        key_bytes.extend(b"_");
         key_bytes.put_u64_le(current_hash.hash);
-        key_bytes.extend("_".as_bytes());
+        key_bytes.extend(b"_");
         key_bytes.put_u64_le(current_hash.index);
 
         let context_key = Keyspace::Context(&key_bytes);

--- a/smart_contracts/sdk/src/collections/iterable_map.rs
+++ b/smart_contracts/sdk/src/collections/iterable_map.rs
@@ -1,0 +1,420 @@
+use core::marker::PhantomData;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use bytes::BufMut;
+use casper_executor_wasm_common::keyspace::Keyspace;
+use const_fnv1a_hash::fnv1a_hash_128;
+
+use crate::casper::{self, read_into_vec};
+
+/// Internal key representation after hashing. Currently [`u128`].
+pub type IterableMapKeyRepr = u128;
+
+/// Trait for types that can be used as keys in [IterableMap].
+/// Must produce a deterministic [IterableMapKeyRepr] prefix via hashing.
+/// 
+/// A blanket implementation is provided for all types that implement
+/// [BorshSerialize].
+pub trait IterableMapKey {
+    fn to_key_prefix(&self) -> IterableMapKeyRepr;
+}
+
+impl<K: BorshSerialize> IterableMapKey for K {
+    fn to_key_prefix(&self) -> IterableMapKeyRepr {
+        let mut bytes = Vec::new();
+        self.serialize(&mut bytes).unwrap();
+        fnv1a_hash_128(&bytes, None)
+    }
+}
+
+/// A singly-linked map. Each entry at key `K_n` stores `(V, K_{n-1})`,
+/// where `V` is the value and `K_{n-1}` is the key of the previous entry.
+/// 
+/// This creates a constant spatial overhead; every entry stores a pointer
+/// to the one inserted before it.
+/// 
+/// Enables iteration without a guaranteed ordering; updating an existing
+/// key does not affect position.
+/// 
+/// Supports full traversal, typically in reverse-insertion order.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+#[borsh(crate = "crate::serializers::borsh")]
+pub struct IterableMap<K, V> {
+    pub(crate) prefix: String,
+
+    // Keys are hashed to u128 internally, but K is preserved to enforce type safety.
+    // While this map could accept arbitrary u128 keys, requiring a concrete K prevents
+    // misuse and clarifies intent at the type level.
+    pub(crate) head_key_hash: Option<IterableMapKeyRepr>,
+    _marker: PhantomData<(K, V)>
+}
+
+/// Single entry in `IterableMap`. Stores the value and the hash of the previous entry's key.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+#[borsh(crate = "crate::serializers::borsh")]
+pub struct IterableMapEntry<V> {
+    pub(crate) value: V,
+    pub(crate) previous: Option<IterableMapKeyRepr>,
+}
+
+impl<K, V> IterableMap<K, V>
+where
+    K: IterableMapKey,
+    V: BorshSerialize + BorshDeserialize,
+{
+    /// Creates an empty [IterableMap] with the given prefix.
+    pub fn new<S: Into<String>>(prefix: S) -> Self {
+        Self {
+            prefix: prefix.into(),
+            head_key_hash: None,
+            _marker: Default::default(),
+        }
+    }
+
+    /// Inserts a key-value pair into the map.
+    /// 
+    /// If the map did not have this key present, None is returned.
+    /// 
+    /// If the map did have this key present, the value is updated, and the old value is returned.
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        let prefix = self.create_prefix_from_key(&key);
+        let context_key = Keyspace::Context(&prefix);
+
+        // Either overwrite an existing entry, or create a new one.
+        let (entry_to_write, previous) = match self.get_entry(context_key) {
+            Some(mut entry) => {
+                let old_value = entry.value;
+                entry.value = value;
+                (entry, Some(old_value))
+            },
+            None => {
+                let entry = IterableMapEntry {
+                    value,
+                    previous: self.head_key_hash
+                };
+
+                // Additionally, since this is a new entry, we need to update the head
+                self.head_key_hash = Some(key.to_key_prefix());
+
+                (entry, None)
+            }
+        };
+
+        // Write the entry and return previous value if it exists
+        let mut entry_bytes = Vec::new();
+        entry_to_write.serialize(&mut entry_bytes).unwrap();
+        casper::write(context_key, &entry_bytes).unwrap();
+
+        return previous;
+    }
+
+    /// Returns a value corresponding to the key.
+    pub fn get(&self, key: &K) -> Option<V> {
+        let prefix = self.create_prefix_from_key(&key);
+        let context_key = Keyspace::Context(&prefix);
+
+        self.get_entry(context_key).map(|entry| entry.value)
+    }
+
+    /// Removes a key from the map. Returns the associated value if the key exists.
+    /// 
+    /// Has a worst-case runtime of O(n).
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        let to_remove_hash = key.to_key_prefix();
+        let to_remove_prefix = self.create_prefix_from_hash(to_remove_hash);
+        let Some(to_remove_entry) = self.get_entry(Keyspace::Context(&to_remove_prefix)) else {
+            // The entry to remove doesn't exist.
+            return None;
+        };
+
+        // Purge the entry from global state
+        purge_at_key(Keyspace::Context(&to_remove_prefix));
+        
+        // Edge case when removing head
+        if self.head_key_hash == Some(to_remove_hash) {
+            self.head_key_hash = to_remove_entry.previous;
+            return Some(to_remove_entry.value);
+        }
+
+        // Scan the map, find entry to remove, join adjacent entries
+        let mut current_hash = self.head_key_hash;
+        while let Some(key) = current_hash {
+            let current_prefix = self.create_prefix_from_hash(key);
+            let current_context_key = Keyspace::Context(&current_prefix);
+            let mut current_entry = self.get_entry(current_context_key).unwrap();
+            
+            // If there is no previous entry, then we've finished iterating
+            let Some(next_hash) = current_entry.previous else {
+                break;
+            };
+
+            // If the next entry is the one to be removed, repoint the current
+            // one to the one preceeding the one to remove.
+            if next_hash == to_remove_hash {
+                current_entry.previous = to_remove_entry.previous;
+
+                // Re-write the current entry
+                let mut entry_bytes = Vec::new();
+                current_entry.serialize(&mut entry_bytes).unwrap();
+                casper::write(current_context_key, &entry_bytes).unwrap();
+
+                return Some(to_remove_entry.value);
+            }
+
+            // Advance backwards
+            current_hash = current_entry.previous;
+        }
+
+        None
+    }
+
+    /// Returns an iterator over the entries in the map.
+    /// 
+    /// Traverses entries in reverse-insertion order.
+    /// Each item is a tuple of the hashed key and the value.
+    ///
+    /// Note: the original key type `K` is not recoverable during iteration.
+    pub fn iter(&self) -> IterableMapIter<K, V>
+    where
+        V: BorshDeserialize,
+    {
+        IterableMapIter {
+            prefix: &self.prefix,
+            current: self.head_key_hash,
+            _marker: PhantomData,
+        }
+    }
+
+    fn get_entry(&self, keyspace: Keyspace) -> Option<IterableMapEntry<V>> {
+        read_into_vec(keyspace).map(|vec| borsh::from_slice(&vec).ok()).flatten()
+    }
+
+    fn create_prefix_from_key(&self, key: &K) -> Vec<u8> {
+        let hash = key.to_key_prefix();
+        self.create_prefix_from_hash(hash)
+    }
+
+    fn create_prefix_from_hash(&self, hash: IterableMapKeyRepr) -> Vec<u8> {
+        let mut context_key = Vec::new();
+        context_key.extend(self.prefix.as_bytes());
+        context_key.extend("_".as_bytes());
+        context_key.put_u128_le(hash);
+        context_key
+    }
+}
+
+// TODO: Rn we just overwrite with zeroes ¯\_(ツ)_/¯
+// This is placeholder, and is to be removed when the appropriate functionality merges.
+fn purge_at_key(key: Keyspace) {
+    casper::write(key, &[0]).unwrap();
+}
+
+/// Iterator over entries in an [`IterableMap`].
+///
+/// Traverses the map in reverse-insertion order, following the internal
+/// linked structure via hashed key references [`u128`].
+///
+/// Yields a tuple ([`IterableMapKeyRepr`], V), where the key is the hashed
+/// representation of the original key. The original key type `K` is not recoverable.
+///
+/// Each iteration step deserializes a single entry from storage.
+/// 
+/// This iterator performs no allocation beyond internal buffers,
+/// and deserialization errors are treated as iteration termination.
+pub struct IterableMapIter<'a, K, V> {
+    prefix: &'a str,
+    current: Option<IterableMapKeyRepr>,
+    _marker: PhantomData<(K, V)>,
+}
+
+impl<'a, K, V> IntoIterator for &'a IterableMap<K, V>
+where
+    K: IterableMapKey,
+    V: BorshDeserialize,
+{
+    type Item = (IterableMapKeyRepr, V);
+    type IntoIter = IterableMapIter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IterableMapIter {
+            prefix: &self.prefix,
+            current: self.head_key_hash,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, K, V> Iterator for IterableMapIter<'a, K, V>
+where
+    V: BorshDeserialize,
+{
+    type Item = (IterableMapKeyRepr, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current_hash = self.current?;
+        let mut key_bytes = Vec::new();
+        key_bytes.extend(self.prefix.as_bytes());
+        key_bytes.extend("_".as_bytes());
+        key_bytes.put_u128_le(current_hash);
+
+        let context_key = Keyspace::Context(&key_bytes);
+
+        let Some(entry) = read_into_vec(context_key)
+            .map(|vec| borsh::from_slice::<IterableMapEntry<V>>(&vec).unwrap()) 
+        else {
+            return None;
+        };
+
+        self.current = entry.previous;
+        Some((current_hash, entry.value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::casper::native::dispatch;
+    use super::*;
+
+    #[test]
+    fn insert_and_get() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            assert_eq!(map.get(&1), None);
+
+            map.insert(1, "a".to_string());
+            assert_eq!(map.get(&1), Some("a".to_string()));
+
+            map.insert(2, "b".to_string());
+            assert_eq!(map.get(&2), Some("b".to_string()));
+        }).unwrap();
+    }
+
+    #[test]
+    fn overwrite_existing_key() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            assert_eq!(map.insert(1, "a".to_string()), None);
+            assert_eq!(map.insert(1, "b".to_string()), Some("a".to_string()));
+            assert_eq!(map.get(&1), Some("b".to_string()));
+        }).unwrap();
+    }
+
+    #[test]
+    fn remove_head_entry() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            map.insert(1, "a".to_string());
+            map.insert(2, "b".to_string());
+
+            assert_eq!(map.remove(&2), Some("b".to_string()));
+            assert_eq!(map.get(&2), None);
+            assert_eq!(map.get(&1), Some("a".to_string()));
+        }).unwrap();
+    }
+
+    #[test]
+    fn remove_middle_entry() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            map.insert(1, "a".to_string());
+            map.insert(2, "b".to_string());
+            map.insert(3, "c".to_string());
+
+            assert_eq!(map.remove(&2), Some("b".to_string()));
+            assert_eq!(map.get(&2), None);
+            assert_eq!(map.get(&1), Some("a".to_string()));
+            assert_eq!(map.get(&3), Some("c".to_string()));
+        }).unwrap();
+    }
+
+    #[test]
+    fn remove_nonexistent_key_does_nothing() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            map.insert(1, "a".to_string());
+
+            assert_eq!(map.remove(&999), None);
+            assert_eq!(map.get(&1), Some("a".to_string()));
+        }).unwrap();
+    }
+
+    #[test]
+    fn iterates_all_entries_in_reverse_insertion_order() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            map.insert(1, "a".to_string());
+            map.insert(2, "b".to_string());
+            map.insert(3, "c".to_string());
+
+            let values: Vec<_> = map.iter().map(|(_, v)| v).collect();
+            assert_eq!(values, vec![
+                "c".to_string(),
+                "b".to_string(),
+                "a".to_string(),
+            ]);
+        }).unwrap();
+    }
+
+    #[test]
+    fn iteration_skips_deleted_entries() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            map.insert(1, "a".to_string());
+            map.insert(2, "b".to_string());
+            map.insert(3, "c".to_string());
+
+            map.remove(&2);
+
+            let values: Vec<_> = map.iter().map(|(_, v)| v).collect();
+            assert_eq!(values, vec![
+                "c".to_string(),
+                "a".to_string(),
+            ]);
+        }).unwrap();
+    }
+
+    #[test]
+    fn empty_map_behaves_sanely() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            assert_eq!(map.get(&1), None);
+            assert_eq!(map.remove(&1), None);
+            assert_eq!(map.iter().count(), 0);
+        }).unwrap();
+    }
+
+    #[test]
+    fn separate_maps_do_not_conflict() {
+        dispatch(|| {
+            let mut map1 = IterableMap::<u64, String>::new("map1");
+            let mut map2 = IterableMap::<u64, String>::new("map2");
+
+            map1.insert(1, "a".to_string());
+            map2.insert(1, "b".to_string());
+
+            assert_eq!(map1.get(&1), Some("a".to_string()));
+            assert_eq!(map2.get(&1), Some("b".to_string()));
+        }).unwrap();
+    }
+
+    #[test]
+    fn insert_same_value_under_different_keys() {
+        dispatch(|| {
+            let mut map = IterableMap::<u64, String>::new("test_map");
+
+            map.insert(1, "shared".to_string());
+            map.insert(2, "shared".to_string());
+
+            assert_eq!(map.get(&1), Some("shared".to_string()));
+            assert_eq!(map.get(&2), Some("shared".to_string()));
+        }).unwrap();
+    }
+}

--- a/smart_contracts/sdk/src/collections/iterable_map.rs
+++ b/smart_contracts/sdk/src/collections/iterable_map.rs
@@ -511,14 +511,14 @@ mod tests {
         }).unwrap();
     }
 
-    #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
-    struct TestKey {
-        id: u64,
-        name: String,
-    }
-
     #[test]
     fn struct_as_key() {
+        #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+        struct TestKey {
+            id: u64,
+            name: String,
+        }
+        
         dispatch(|| {
             let key1 = TestKey { id: 1, name: "Key1".to_string() };
             let key2 = TestKey { id: 2, name: "Key2".to_string() };

--- a/smart_contracts/sdk/src/collections/iterable_map.rs
+++ b/smart_contracts/sdk/src/collections/iterable_map.rs
@@ -44,8 +44,8 @@ impl IterableMapHash for i64 {}
 impl IterableMapHash for i128 {}
 impl IterableMapHash for String {}
 
-/// A singly-linked HashMap. Each entry at key `K_n` stores `(V, K_{n-1})`,
-/// where `V` is the value and `K_{n-1}` is the key hash of the previous entry.
+/// A map over global state that allows iteration. Each entry at key `K_n` stores `(K_{n}, V,
+/// K_{n-1})`, where `V` is the value and `K_{n-1}` is the key hash of the previous entry.
 ///
 /// This creates a constant spatial overhead; every entry stores a pointer
 /// to the one inserted before it.
@@ -53,6 +53,7 @@ impl IterableMapHash for String {}
 /// Enables iteration without a guaranteed ordering; updating an existing
 /// key does not affect position.
 ///
+/// Under the hood, this is a singly-linked HashMap with linear probing for collision resolution.
 /// Supports full traversal, typically in reverse-insertion order.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
 #[borsh(crate = "crate::serializers::borsh")]

--- a/smart_contracts/sdk/src/collections/iterable_set.rs
+++ b/smart_contracts/sdk/src/collections/iterable_set.rs
@@ -35,7 +35,7 @@ impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<
     }
 
     /// Creates an iterator visiting all the values in arbitrary order.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = V> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = V> + '_ {
         self.map.iter().map(|(_, value)| value)
     }
 

--- a/smart_contracts/sdk/src/collections/iterable_set.rs
+++ b/smart_contracts/sdk/src/collections/iterable_set.rs
@@ -1,0 +1,50 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use super::{IterableMap, IterableMapKey};
+
+/// An iterable set backed by a map.
+pub struct IterableSet<V> {
+    pub(crate) map: IterableMap<V, V>
+}
+
+impl<V: BorshSerialize + BorshDeserialize> IterableSet<V> {
+    /// Creates an empty [IterableMap] with the given prefix.
+    pub fn new<S: Into<String>>(prefix: S) -> Self {
+        Self {
+            map: IterableMap::new(prefix),
+        }
+    }
+
+    /// Inserts a value into the set.
+    pub fn insert(&mut self, value: V) {
+        let hash = value.compute_key_hash();
+        self.map.insert_impl(hash, value);
+    }
+
+    /// Removes a value from the set.
+    /// 
+    /// Has a worst-case runtime of O(n).
+    pub fn remove(&mut self, value: &V) {
+        self.map.remove(value);
+    }
+
+    /// Returns true if the set contains a value.
+    pub fn contains(&self, value: &V) -> bool {
+        self.map.get(value).is_some()
+    }
+
+    /// Creates an iterator visiting all the values in arbitrary order.
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = V> + 'a {
+        self.map.iter().map(|(_, value)| value)
+    }
+
+    // Returns true if the set contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Clears the set, removing all values.
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+}

--- a/smart_contracts/sdk/src/collections/iterable_set.rs
+++ b/smart_contracts/sdk/src/collections/iterable_set.rs
@@ -3,10 +3,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use super::{IterableMap, IterableMapKey};
 
 /// An iterable set backed by a map.
-/// TODO: Instead of naively relying on IterableMap, actually duplicate the impl with the tweak of
-/// not storing (V, V) but just V.
 pub struct IterableSet<V> {
-    pub(crate) map: IterableMap<V, V>
+    // TODO: Instead of naively relying on IterableMap, actually duplicate the impl with the tweak
+    // of not storing (V, V) but just V.
+    pub(crate) map: IterableMap<V, V>,
 }
 
 impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<V> {
@@ -23,7 +23,7 @@ impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<
     }
 
     /// Removes a value from the set.
-    /// 
+    ///
     /// Has a worst-case runtime of O(n).
     pub fn remove(&mut self, value: &V) {
         self.map.remove(value);

--- a/smart_contracts/sdk/src/collections/iterable_set.rs
+++ b/smart_contracts/sdk/src/collections/iterable_set.rs
@@ -1,13 +1,13 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use super::{IterableMap, IterableMapKey};
+use super::{IterableMap, IterableMapHash};
 
 /// An iterable set backed by a map.
 pub struct IterableSet<V> {
     pub(crate) map: IterableMap<V, ()>,
 }
 
-impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<V> {
+impl<V: IterableMapHash + BorshSerialize + BorshDeserialize + Clone> IterableSet<V> {
     /// Creates an empty [IterableMap] with the given prefix.
     pub fn new<S: Into<String>>(prefix: S) -> Self {
         Self {
@@ -141,7 +141,7 @@ mod tests {
         field2: String,
     }
 
-    impl IterableMapKey for TestStruct {}
+    impl IterableMapHash for TestStruct {}
 
     #[test]
     fn struct_values() {

--- a/smart_contracts/sdk/src/collections/iterable_set.rs
+++ b/smart_contracts/sdk/src/collections/iterable_set.rs
@@ -4,9 +4,7 @@ use super::{IterableMap, IterableMapKey};
 
 /// An iterable set backed by a map.
 pub struct IterableSet<V> {
-    // TODO: Instead of naively relying on IterableMap, actually duplicate the impl with the tweak
-    // of not storing (V, V) but just V.
-    pub(crate) map: IterableMap<V, V>,
+    pub(crate) map: IterableMap<V, ()>,
 }
 
 impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<V> {
@@ -19,7 +17,7 @@ impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<
 
     /// Inserts a value into the set.
     pub fn insert(&mut self, value: V) {
-        self.map.insert(value.clone(), value);
+        self.map.insert(value, ());
     }
 
     /// Removes a value from the set.
@@ -36,7 +34,7 @@ impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<
 
     /// Creates an iterator visiting all the values in arbitrary order.
     pub fn iter(&self) -> impl Iterator<Item = V> + '_ {
-        self.map.iter().map(|(_, value)| value)
+        self.map.iter().map(|(value, _)| value)
     }
 
     // Returns true if the set contains no elements.
@@ -47,5 +45,172 @@ impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<
     /// Clears the set, removing all values.
     pub fn clear(&mut self) {
         self.map.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::casper::native::dispatch;
+    use borsh::{BorshDeserialize, BorshSerialize};
+
+    #[test]
+    fn basic_insert_contains() {
+        dispatch(|| {
+            let mut set = IterableSet::new("test_set");
+            assert!(!set.contains(&1));
+
+            set.insert(1);
+            assert!(set.contains(&1));
+
+            set.insert(2);
+            assert!(set.contains(&2));
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn remove_elements() {
+        dispatch(|| {
+            let mut set = IterableSet::new("test_set");
+            set.insert(1);
+            set.insert(2);
+
+            set.remove(&1);
+            assert!(!set.contains(&1));
+            assert!(set.contains(&2));
+
+            set.remove(&2);
+            assert!(set.is_empty());
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn iterator_order_and_contents() {
+        dispatch(|| {
+            let mut set = IterableSet::new("test_set");
+            set.insert(1);
+            set.insert(2);
+            set.insert(3);
+
+            let mut items: Vec<_> = set.iter().collect();
+            items.sort();
+            assert_eq!(items, vec![1, 2, 3]);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn clear_functionality() {
+        dispatch(|| {
+            let mut set = IterableSet::new("test_set");
+            set.insert(1);
+            set.insert(2);
+
+            assert!(!set.is_empty());
+            set.clear();
+            assert!(set.is_empty());
+            assert_eq!(set.iter().count(), 0);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn multiple_sets_independence() {
+        dispatch(|| {
+            let mut set1 = IterableSet::new("set1");
+            let mut set2 = IterableSet::new("set2");
+
+            set1.insert(1);
+            set2.insert(1);
+
+            assert!(set1.contains(&1));
+            assert!(set2.contains(&1));
+
+            set1.remove(&1);
+            assert!(!set1.contains(&1));
+            assert!(set2.contains(&1));
+        })
+        .unwrap();
+    }
+
+    #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq)]
+    struct TestStruct {
+        field1: u64,
+        field2: String,
+    }
+
+    impl IterableMapKey for TestStruct {}
+
+    #[test]
+    fn struct_values() {
+        dispatch(|| {
+            let val1 = TestStruct {
+                field1: 1,
+                field2: "a".to_string(),
+            };
+            let val2 = TestStruct {
+                field1: 2,
+                field2: "b".to_string(),
+            };
+
+            let mut set = IterableSet::new("test_set");
+            set.insert(val1.clone());
+            set.insert(val2.clone());
+
+            assert!(set.contains(&val1));
+            assert!(set.contains(&val2));
+
+            let mut collected: Vec<_> = set.iter().collect();
+            collected.sort_by(|a, b| a.field1.cmp(&b.field1));
+            assert_eq!(collected, vec![val1, val2]);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn duplicate_insertions() {
+        dispatch(|| {
+            let mut set = IterableSet::new("test_set");
+            set.insert(1);
+            set.insert(1); // Should be no-op
+
+            assert_eq!(set.iter().count(), 1);
+            set.remove(&1);
+            assert!(set.is_empty());
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn empty_set_behavior() {
+        dispatch(|| {
+            let set = IterableSet::<u64>::new("test_set");
+            assert!(set.is_empty());
+            assert_eq!(set.iter().count(), 0);
+
+            let mut set = set;
+            set.remove(&999); // Shouldn't panic
+            assert!(set.is_empty());
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn complex_operations_sequence() {
+        dispatch(|| {
+            let mut set = IterableSet::new("test_set");
+            set.insert(1);
+            set.insert(2);
+            set.remove(&1);
+            set.insert(3);
+            set.clear();
+            set.insert(4);
+
+            let items: Vec<_> = set.iter().collect();
+            assert_eq!(items, vec![4]);
+        })
+        .unwrap();
     }
 }

--- a/smart_contracts/sdk/src/collections/iterable_set.rs
+++ b/smart_contracts/sdk/src/collections/iterable_set.rs
@@ -3,11 +3,13 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use super::{IterableMap, IterableMapKey};
 
 /// An iterable set backed by a map.
+/// TODO: Instead of naively relying on IterableMap, actually duplicate the impl with the tweak of
+/// not storing (V, V) but just V.
 pub struct IterableSet<V> {
     pub(crate) map: IterableMap<V, V>
 }
 
-impl<V: BorshSerialize + BorshDeserialize> IterableSet<V> {
+impl<V: IterableMapKey + BorshSerialize + BorshDeserialize + Clone> IterableSet<V> {
     /// Creates an empty [IterableMap] with the given prefix.
     pub fn new<S: Into<String>>(prefix: S) -> Self {
         Self {
@@ -17,8 +19,7 @@ impl<V: BorshSerialize + BorshDeserialize> IterableSet<V> {
 
     /// Inserts a value into the set.
     pub fn insert(&mut self, value: V) {
-        let hash = value.compute_key_hash();
-        self.map.insert_impl(hash, value);
+        self.map.insert(value.clone(), value);
     }
 
     /// Removes a value from the set.

--- a/smart_contracts/sdk/src/collections/vector.rs
+++ b/smart_contracts/sdk/src/collections/vector.rs
@@ -103,6 +103,12 @@ where
         self.length += 1;
     }
 
+    /// Clears the vector, removing all values.
+    pub fn clear(&mut self) {
+        self.length = 0;
+        // TODO: Remove all elements from global state
+    }
+
     #[inline(always)]
     pub fn len(&self) -> u64 {
         self.length
@@ -162,6 +168,10 @@ where
     }
 
     /// Removes the element at the specified index and returns it.
+    /// 
+    /// Note: Because this shifts over the remaining elements, it has a
+    /// worst-case performance of O(n). If you don’t need the order of
+    /// elements to be preserved, use `swap_remove` instead.
     pub fn remove(&mut self, index: u64) -> Option<T> {
         if index >= self.length {
             return None;
@@ -178,6 +188,25 @@ where
         self.length -= 1;
 
         Some(value)
+    }
+
+    /// Removes the element at the specified index and returns it.
+    /// 
+    /// The removed element is replaced by the last element of the vector.
+    /// This does not preserve ordering of the remaining elements, but is O(1).
+    pub fn swap_remove(&mut self, index: u64) -> Option<T> {
+        if index >= self.length {
+            return None;
+        }
+
+        let value_to_remove = self.get(index).unwrap();
+        let last_value = self.get(self.len() - 1).unwrap();
+
+        self.write(index, last_value);
+        self.length -= 1;
+        // TODO: remove self.len() - 1 from global state
+
+        Some(value_to_remove)
     }
 
     pub fn retain<F>(&mut self, mut f: F)

--- a/smart_contracts/sdk/src/collections/vector.rs
+++ b/smart_contracts/sdk/src/collections/vector.rs
@@ -53,7 +53,7 @@ where
     T: BorshSerialize + BorshDeserialize,
 {
     /// Constructs a new, empty Vector<T>.
-    /// 
+    ///
     /// The vector header will not write itself to the GS, even if
     /// values are pushed onto it later.
     pub fn new<S: Into<String>>(prefix: S) -> Self {
@@ -101,7 +101,8 @@ where
         (0..self.length).map(move |i| self.get(i).unwrap())
     }
 
-    /// Inserts an element at position `index` within the vector, shifting all elements after it to the right.
+    /// Inserts an element at position `index` within the vector, shifting all elements after it to
+    /// the right.
     pub fn insert(&mut self, index: u64, value: T) {
         assert!(index <= self.length, "index out of bounds");
 
@@ -136,7 +137,8 @@ where
         self.length == 0
     }
 
-    /// Binary searches this vector for a given element. If the vector is not sorted, the returned result is unspecified and meaningless.
+    /// Binary searches this vector for a given element. If the vector is not sorted, the returned
+    /// result is unspecified and meaningless.
     pub fn binary_search(&self, value: &T) -> Result<u64, u64>
     where
         T: Ord,
@@ -145,10 +147,11 @@ where
     }
 
     /// Binary searches this slice with a comparator function.
-    /// 
-    /// The comparator function should return an [Ordering] that indicates whether its argument is `Less`, `Equal` or `Greater`
-    /// the desired target. If the slice is not sorted or if the comparator function does not implement an order consistent with
-    /// the sort order of the underlying slice, the returned result is unspecified and meaningless.
+    ///
+    /// The comparator function should return an [Ordering] that indicates whether its argument is
+    /// `Less`, `Equal` or `Greater` the desired target. If the slice is not sorted or if the
+    /// comparator function does not implement an order consistent with the sort order of the
+    /// underlying slice, the returned result is unspecified and meaningless.
     pub fn binary_search_by<F>(&self, mut f: F) -> Result<u64, u64>
     where
         F: FnMut(&T) -> Ordering,
@@ -191,7 +194,7 @@ where
     }
 
     /// Removes the element at the specified index and returns it.
-    /// 
+    ///
     /// Note: Because this shifts over the remaining elements, it has a
     /// worst-case performance of O(n). If you don’t need the order of
     /// elements to be preserved, use `swap_remove` instead.
@@ -214,7 +217,7 @@ where
     }
 
     /// Removes the element at the specified index and returns it.
-    /// 
+    ///
     /// The removed element is replaced by the last element of the vector.
     /// This does not preserve ordering of the remaining elements, but is O(1).
     pub fn swap_remove(&mut self, index: u64) -> Option<T> {
@@ -360,7 +363,8 @@ pub(crate) mod tests {
             assert_eq!(vec.len(), 1);
             assert_eq!(vec.pop(), Some(1));
             assert!(vec.is_empty());
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -374,7 +378,8 @@ pub(crate) mod tests {
             assert!(!vec.contains(&3));
             vec.remove(0);
             assert!(!vec.contains(&1));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -391,7 +396,8 @@ pub(crate) mod tests {
             assert_eq!(vec.get(0), None);
             vec.push(3);
             assert_eq!(vec.get(0), Some(3));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -406,7 +412,8 @@ pub(crate) mod tests {
             assert_eq!(vec.binary_search(&3), Ok(2));
             assert_eq!(vec.binary_search(&0), Err(0));
             assert_eq!(vec.binary_search(&6), Err(5));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -421,7 +428,8 @@ pub(crate) mod tests {
             assert_eq!(vec.iter().collect::<Vec<_>>(), vec![1, 4, 3]);
             assert_eq!(vec.swap_remove(2), Some(3));
             assert_eq!(vec.iter().collect::<Vec<_>>(), vec![1, 4]);
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -431,7 +439,8 @@ pub(crate) mod tests {
             vec.push(1);
             vec.insert(1, 2);
             assert_eq!(vec.iter().collect::<Vec<_>>(), vec![1, 2]);
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -446,7 +455,8 @@ pub(crate) mod tests {
             vec.push(TestStruct { field: 1 });
             vec.push(TestStruct { field: 2 });
             assert_eq!(vec.get(1), Some(TestStruct { field: 2 }));
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -465,7 +475,8 @@ pub(crate) mod tests {
             assert_eq!(vec.get(0), Some(1));
             vec.clear();
             assert!(vec.is_empty());
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -476,7 +487,8 @@ pub(crate) mod tests {
             assert_eq!(vec.remove(1), None);
             assert_eq!(vec.remove(0), Some(1));
             assert_eq!(vec.remove(0), None);
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     #[test]
@@ -485,6 +497,7 @@ pub(crate) mod tests {
         dispatch(|| {
             let mut vec = Vector::<u64>::new("test");
             vec.insert(1, 1);
-        }).unwrap();
+        })
+        .unwrap();
     }
 }

--- a/smart_contracts/sdk/src/collections/vector.rs
+++ b/smart_contracts/sdk/src/collections/vector.rs
@@ -5,7 +5,6 @@ use crate::{
     serializers::borsh::{BorshDeserialize, BorshSerialize},
 };
 
-// use casper_macros::casper;
 use casper_executor_wasm_common::keyspace::Keyspace;
 use const_fnv1a_hash::fnv1a_hash_str_64;
 
@@ -53,6 +52,10 @@ impl<T> Vector<T>
 where
     T: BorshSerialize + BorshDeserialize,
 {
+    /// Constructs a new, empty Vector<T>.
+    /// 
+    /// The vector header will not write itself to the GS, even if
+    /// values are pushed onto it later.
     pub fn new<S: Into<String>>(prefix: S) -> Self {
         Self {
             prefix: prefix.into(),
@@ -61,6 +64,7 @@ where
         }
     }
 
+    /// Appends an element to the back of a collection.
     pub fn push(&mut self, value: T) {
         let mut prefix_bytes = self.prefix.as_bytes().to_owned();
         prefix_bytes.extend(&self.length.to_le_bytes());
@@ -69,6 +73,14 @@ where
         self.length += 1;
     }
 
+    /// Removes the last element from a vector and returns it, or None if it is empty.
+    pub fn pop(&mut self) -> Option<T> {
+        self.swap_remove(self.len() - 1)
+    }
+
+    /// Returns true if the slice contains an element with the given value.
+    ///
+    /// This operation is O(n).
     pub fn contains(&self, value: &T) -> bool
     where
         T: PartialEq,
@@ -76,6 +88,7 @@ where
         self.iter().any(|v| v == *value)
     }
 
+    /// Returns an element at index, deserialized.
     pub fn get(&self, index: u64) -> Option<T> {
         let mut prefix_bytes = self.prefix.as_bytes().to_owned();
         prefix_bytes.extend(&index.to_le_bytes());
@@ -83,10 +96,12 @@ where
         read_into_vec(prefix).map(|vec| borsh::from_slice(&vec).unwrap())
     }
 
+    /// Returns an iterator over self, with elements deserialized.
     pub fn iter(&self) -> impl Iterator<Item = T> + '_ {
         (0..self.length).map(move |i| self.get(i).unwrap())
     }
 
+    /// Inserts an element at position `index` within the vector, shifting all elements after it to the right.
     pub fn insert(&mut self, index: u64, value: T) {
         assert!(index <= self.length, "index out of bounds");
 
@@ -109,16 +124,19 @@ where
         // TODO: Remove all elements from global state
     }
 
+    /// Returns the number of elements in the vector, also referred to as its ‘length’.
     #[inline(always)]
     pub fn len(&self) -> u64 {
         self.length
     }
 
+    /// Returns `true` if the vector contains no elements.
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.length == 0
     }
 
+    /// Binary searches this vector for a given element. If the vector is not sorted, the returned result is unspecified and meaningless.
     pub fn binary_search(&self, value: &T) -> Result<u64, u64>
     where
         T: Ord,
@@ -126,6 +144,11 @@ where
         self.binary_search_by(|v| v.cmp(value))
     }
 
+    /// Binary searches this slice with a comparator function.
+    /// 
+    /// The comparator function should return an [Ordering] that indicates whether its argument is `Less`, `Equal` or `Greater`
+    /// the desired target. If the slice is not sorted or if the comparator function does not implement an order consistent with
+    /// the sort order of the underlying slice, the returned result is unspecified and meaningless.
     pub fn binary_search_by<F>(&self, mut f: F) -> Result<u64, u64>
     where
         F: FnMut(&T) -> Ordering,
@@ -202,13 +225,17 @@ where
         let value_to_remove = self.get(index).unwrap();
         let last_value = self.get(self.len() - 1).unwrap();
 
-        self.write(index, last_value);
+        if index != self.len() - 1 {
+            self.write(index, last_value);
+        }
+
         self.length -= 1;
         // TODO: remove self.len() - 1 from global state
 
         Some(value_to_remove)
     }
 
+    /// Retains only the elements specified by the predicate.
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> bool,
@@ -318,5 +345,146 @@ pub(crate) mod tests {
             assert_eq!(vec2.get(0), None);
         })
         .unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    // TODO: This should work when we allow purging GS entries
+    fn test_pop() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            assert_eq!(vec.pop(), None);
+            vec.push(1);
+            vec.push(2);
+            assert_eq!(vec.pop(), Some(2));
+            assert_eq!(vec.len(), 1);
+            assert_eq!(vec.pop(), Some(1));
+            assert!(vec.is_empty());
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_contains() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            vec.push(1);
+            vec.push(2);
+            assert!(vec.contains(&1));
+            assert!(vec.contains(&2));
+            assert!(!vec.contains(&3));
+            vec.remove(0);
+            assert!(!vec.contains(&1));
+        }).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    // TODO: This should work when we allow purging GS entries
+    fn test_clear() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            vec.push(1);
+            vec.push(2);
+            vec.clear();
+            assert_eq!(vec.len(), 0);
+            assert!(vec.is_empty());
+            assert_eq!(vec.get(0), None);
+            vec.push(3);
+            assert_eq!(vec.get(0), Some(3));
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_binary_search() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            vec.push(1);
+            vec.push(2);
+            vec.push(3);
+            vec.push(4);
+            vec.push(5);
+            assert_eq!(vec.binary_search(&3), Ok(2));
+            assert_eq!(vec.binary_search(&0), Err(0));
+            assert_eq!(vec.binary_search(&6), Err(5));
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_swap_remove() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            vec.push(1);
+            vec.push(2);
+            vec.push(3);
+            vec.push(4);
+            assert_eq!(vec.swap_remove(1), Some(2));
+            assert_eq!(vec.iter().collect::<Vec<_>>(), vec![1, 4, 3]);
+            assert_eq!(vec.swap_remove(2), Some(3));
+            assert_eq!(vec.iter().collect::<Vec<_>>(), vec![1, 4]);
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_insert_at_len() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            vec.push(1);
+            vec.insert(1, 2);
+            assert_eq!(vec.iter().collect::<Vec<_>>(), vec![1, 2]);
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_struct_elements() {
+        #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
+        struct TestStruct {
+            field: u64,
+        }
+
+        dispatch(|| {
+            let mut vec = Vector::<TestStruct>::new("test");
+            vec.push(TestStruct { field: 1 });
+            vec.push(TestStruct { field: 2 });
+            assert_eq!(vec.get(1), Some(TestStruct { field: 2 }));
+        }).unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    // TODO: This should work when we allow purging GS entries
+    fn test_multiple_operations() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            assert!(vec.is_empty());
+            vec.push(1);
+            vec.insert(0, 2);
+            vec.push(3);
+            assert_eq!(vec.iter().collect::<Vec<_>>(), vec![2, 1, 3]);
+            assert_eq!(vec.swap_remove(0), Some(2));
+            assert_eq!(vec.pop(), Some(3));
+            assert_eq!(vec.get(0), Some(1));
+            vec.clear();
+            assert!(vec.is_empty());
+        }).unwrap();
+    }
+
+    #[test]
+    fn test_remove_invalid_index() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            vec.push(1);
+            assert_eq!(vec.remove(1), None);
+            assert_eq!(vec.remove(0), Some(1));
+            assert_eq!(vec.remove(0), None);
+        }).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds")]
+    fn test_insert_out_of_bounds() {
+        dispatch(|| {
+            let mut vec = Vector::<u64>::new("test");
+            vec.insert(1, 1);
+        }).unwrap();
     }
 }


### PR DESCRIPTION
This PR adds a new `IterableMap` type, which allows for global-state aware, singly-linked iteration over the simple key-value store API provided by the host. It's also used as a basis for a new `IterableSet` type. Additionally, aligns the sdk with the conventions in ``std::collections``.
