### PR TITLE
Making TransactionInvocationTarget::ByPackageHash::version; Transacti…

### DIFF
--- a/binary_port/CHANGELOG.md
+++ b/binary_port/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.  The format is based on [Keep a Changelog].
+
+[comment]: <> (Added:      new features)
+[comment]: <> (Changed:    changes in existing functionality)
+[comment]: <> (Deprecated: soon-to-be removed features)
+[comment]: <> (Removed:    now removed features)
+[comment]: <> (Fixed:      any bug fixes)
+[comment]: <> (Security:   in case of vulnerabilities)
+
+## [Unreleased]
+
+### Added
+* `ErrorCode` has a new code `117`
+
+## [1.0.0] - 
+
+### Added
+* Initial release of node for Casper mainnet.

--- a/binary_port/src/error_code.rs
+++ b/binary_port/src/error_code.rs
@@ -368,6 +368,8 @@ pub enum ErrorCode {
     InvalidReservedSlots = 115,
     #[error("Transaction attempts to set a delegation amount above the highest allowed value")]
     InvalidDelegationAmount = 116,
+    #[error("Calling a stored contract by targeting it's `version` is not supported")]
+    TargetingPackageVersionNotSupported = 117,
 }
 
 impl TryFrom<u16> for ErrorCode {
@@ -452,6 +454,9 @@ impl From<InvalidDeploy> for ErrorCode {
             }
             InvalidDeploy::InvalidPaymentAmount => ErrorCode::InvalidDeployInvalidPaymentAmount,
             InvalidDeploy::PricingModeNotSupported => ErrorCode::PricingModeNotSupported,
+            InvalidDeploy::TargetingPackageVersionNotSupported => {
+                ErrorCode::TargetingPackageVersionNotSupported
+            }
             _ => ErrorCode::InvalidDeployUnspecified,
         }
     }
@@ -565,6 +570,9 @@ impl From<InvalidTransactionV1> for ErrorCode {
             InvalidTransactionV1::InvalidReservedSlots { .. } => ErrorCode::InvalidReservedSlots,
             InvalidTransactionV1::InvalidDelegationAmount { .. } => {
                 ErrorCode::InvalidDelegationAmount
+            }
+            InvalidTransactionV1::TargetingPackageVersionNotSupported => {
+                ErrorCode::TargetingPackageVersionNotSupported
             }
             _other => ErrorCode::InvalidTransactionUnspecified,
         }

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -107,7 +107,6 @@ impl ExecutionEngineV1 {
             &named_keys,
             &executable_item,
             entry_point,
-            protocol_version,
         ) {
             Ok(execution_kind) => execution_kind,
             Err(ese) => return WasmV1Result::precondition_failure(gas_limit, ese),
@@ -158,7 +157,7 @@ impl ExecutionEngineV1 {
         // A good deal of effort has been put into removing all such behaviors; please do not
         // come along and start adding it back.
 
-        let account_hash = initiator_addr.account_hash();
+        let account_hash: AccountHash = initiator_addr.account_hash();
         let protocol_version = self.config.protocol_version();
         let tc = Rc::new(RefCell::new(tracking_copy));
         let (runtime_footprint, entity_addr) = {
@@ -180,7 +179,6 @@ impl ExecutionEngineV1 {
             &named_keys,
             &executable_item,
             entry_point,
-            protocol_version,
         ) {
             Ok(execution_kind) => execution_kind,
             Err(ese) => return WasmV1Result::precondition_failure(gas_limit, ese),

--- a/execution_engine/src/engine_state/mod.rs
+++ b/execution_engine/src/engine_state/mod.rs
@@ -157,7 +157,7 @@ impl ExecutionEngineV1 {
         // A good deal of effort has been put into removing all such behaviors; please do not
         // come along and start adding it back.
 
-        let account_hash: AccountHash = initiator_addr.account_hash();
+        let account_hash = initiator_addr.account_hash();
         let protocol_version = self.config.protocol_version();
         let tc = Rc::new(RefCell::new(tracking_copy));
         let (runtime_footprint, entity_addr) = {

--- a/execution_engine/src/engine_state/wasm_v1.rs
+++ b/execution_engine/src/engine_state/wasm_v1.rs
@@ -752,27 +752,27 @@ fn build_session_info_for_executable_item(
         }
         ExecutableDeployItem::StoredVersionedContractByHash {
             hash,
-            version,
+            version: _,
             entry_point,
             args,
         } => {
-            session = ExecutableItem::Invocation(TransactionInvocationTarget::new_package(
-                PackageHash::new(hash.value()),
-                *version,
-            ));
+            session =
+                ExecutableItem::Invocation(TransactionInvocationTarget::new_package_with_key(
+                    PackageHash::new(hash.value()),
+                    None,
+                ));
             session_entry_point = entry_point.clone();
             session_args = args.clone();
         }
         ExecutableDeployItem::StoredVersionedContractByName {
             name,
-            version,
+            version: _,
             entry_point,
             args,
         } => {
-            session = ExecutableItem::Invocation(TransactionInvocationTarget::new_package_alias(
-                name.clone(),
-                *version,
-            ));
+            session = ExecutableItem::Invocation(
+                TransactionInvocationTarget::new_package_alias_with_key(name.clone(), None),
+            );
             session_entry_point = entry_point.clone();
             session_args = args.clone();
         }
@@ -917,25 +917,27 @@ fn build_payment_info_for_executable_item(
         ExecutableDeployItem::StoredVersionedContractByHash {
             args,
             hash,
-            version,
+            version: _,
             entry_point,
         } => Ok(PaymentInfo(ExecutableInfo {
             item: ExecutableItem::Invocation(TransactionInvocationTarget::ByPackageHash {
                 addr: hash.value(),
-                version: *version,
+                version: None,
+                version_key: None,
             }),
             entry_point: entry_point.clone(),
             args: args.clone(),
         })),
         ExecutableDeployItem::StoredVersionedContractByName {
             name,
-            version,
+            version: _,
             args,
             entry_point,
         } => Ok(PaymentInfo(ExecutableInfo {
             item: ExecutableItem::Invocation(TransactionInvocationTarget::ByPackageName {
                 name: name.clone(),
-                version: *version,
+                version: None,
+                version_key: None,
             }),
             entry_point: entry_point.clone(),
             args: args.clone(),

--- a/execution_engine_testing/tests/src/test/regression/gh_3097.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3097.rs
@@ -1,16 +1,14 @@
 use casper_engine_test_support::{
     ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, LOCAL_GENESIS_REQUEST,
 };
-use casper_execution_engine::{engine_state::Error, execution::ExecError};
-use casper_types::{
-    runtime_args, AddressableEntityHash, EntityVersionKey, PackageHash, RuntimeArgs,
-};
+//use casper_execution_engine::execution::ExecError;
+use casper_types::{runtime_args, AddressableEntityHash, PackageHash, RuntimeArgs};
 use gh_1470_regression::PACKAGE_HASH_NAME;
 
 const GH_3097_REGRESSION_WASM: &str = "gh_3097_regression.wasm";
 const GH_3097_REGRESSION_CALL_WASM: &str = "gh_3097_regression_call.wasm";
 const DO_SOMETHING_ENTRYPOINT: &str = "do_something";
-const DISABLED_CONTRACT_HASH_KEY: &str = "disabled_contract_hash";
+//const DISABLED_CONTRACT_HASH_KEY: &str = "disabled_contract_hash";
 const ENABLED_CONTRACT_HASH_KEY: &str = "enabled_contract_hash";
 const CONTRACT_PACKAGE_HASH_KEY: &str = "contract_package_hash";
 const ARG_METHOD: &str = "method";
@@ -38,17 +36,9 @@ fn should_run_regression() {
         .exec(exec_request)
         .expect_success()
         .commit();
-
     let account = builder
         .get_entity_with_named_keys_by_account_hash(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");
-    let disabled_contract_hash = account
-        .named_keys()
-        .get(DISABLED_CONTRACT_HASH_KEY)
-        .unwrap()
-        .into_entity_hash_addr()
-        .map(AddressableEntityHash::new)
-        .unwrap();
     let enabled_contract_hash = account
         .named_keys()
         .get(ENABLED_CONTRACT_HASH_KEY)
@@ -84,14 +74,26 @@ fn should_run_regression() {
     )
     .build();
 
-    let direct_call_v1_request = ExecuteRequestBuilder::versioned_contract_call_by_name(
-        *DEFAULT_ACCOUNT_ADDR,
-        PACKAGE_HASH_NAME,
-        Some(1),
-        DO_SOMETHING_ENTRYPOINT,
-        RuntimeArgs::new(),
-    )
-    .build();
+    /* TODO The current Execution Engine Testing framework doesn't support calling a specific package version
+           // since it is based od Deploys ExecutableDeployItem. This part of the test should be reinstantiated once we can pass
+           // the TransactionInvocationTarget info to the execution engine testing framework
+
+        let disabled_contract_hash = account
+        .named_keys()
+        .get(DISABLED_CONTRACT_HASH_KEY)
+        .unwrap()
+        .into_entity_hash_addr()
+        .map(AddressableEntityHash::new)
+        .unwrap();
+        let direct_call_v1_request = ExecuteRequestBuilder::versioned_contract_call_by_name(
+            *DEFAULT_ACCOUNT_ADDR,
+            PACKAGE_HASH_NAME,
+            Some(1),
+            DO_SOMETHING_ENTRYPOINT,
+            RuntimeArgs::new(),
+        )
+        .build();
+    */
 
     builder
         .exec(direct_call_latest_request)
@@ -103,24 +105,25 @@ fn should_run_regression() {
         .expect_success()
         .commit();
 
-    builder
-        .exec(direct_call_v1_request)
-        .expect_failure()
-        .commit();
+    /*
+        builder
+            .exec(direct_call_v1_request)
+            .expect_failure()
+            .commit();
 
-    let error = builder.get_error().expect("should have error");
-    assert!(
-        matches!(
+        let error = builder.get_error().expect("should have error");
+        assert!(
+            matches!(
+                error,
+                Error::Exec(
+                    ExecError::DisabledEntityVersion(version)
+                )
+                if version == EntityVersionKey::new(2, 1),
+            ),
+            "Expected disabled contract version, found {:?}",
             error,
-            Error::Exec(
-                ExecError::DisabledEntityVersion(version)
-            )
-            if version == EntityVersionKey::new(2, 1),
-        ),
-        "Expected disabled contract version, found {:?}",
-        error,
-    );
-
+        );
+    */
     // Versioned contract calls by hash
 
     let direct_call_latest_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
@@ -141,14 +144,18 @@ fn should_run_regression() {
     )
     .build();
 
-    let direct_call_v1_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
-        *DEFAULT_ACCOUNT_ADDR,
-        contract_package_hash,
-        Some(1),
-        DO_SOMETHING_ENTRYPOINT,
-        RuntimeArgs::new(),
-    )
-    .build();
+    /* TODO The current Execution Engine Testing framework doesn't support calling a specific package version
+               // since it is based od Deploys ExecutableDeployItem. This part of the test should be reinstantiated once we can pass
+               // the TransactionInvocationTarget info to the execution engine testing framework
+        let direct_call_v1_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
+            *DEFAULT_ACCOUNT_ADDR,
+            contract_package_hash,
+            Some(1),
+            DO_SOMETHING_ENTRYPOINT,
+            RuntimeArgs::new(),
+        )
+        .build();
+    */
 
     builder
         .exec(direct_call_latest_request)
@@ -159,7 +166,7 @@ fn should_run_regression() {
         .exec(direct_call_v2_request)
         .expect_success()
         .commit();
-
+    /*
     builder
         .exec(direct_call_v1_request)
         .expect_failure()
@@ -177,19 +184,24 @@ fn should_run_regression() {
         "Expected disabled contract version, found {:?}",
         error,
     );
+    */
 
     // Versioned call from a session wasm
 
-    let session_call_v1_request = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
-        GH_3097_REGRESSION_CALL_WASM,
-        runtime_args! {
-            ARG_METHOD => METHOD_CALL_VERSIONED_CONTRACT,
-            ARG_MAJOR_VERSION => 2u32,
-            ARG_CONTRACT_VERSION => Some(1u32),
-        },
-    )
-    .build();
+    /* TODO The current Execution Engine Testing framework doesn't support calling a specific package version
+                   // since it is based od Deploys ExecutableDeployItem. This part of the test should be reinstantiated once we can pass
+                   // the TransactionInvocationTarget info to the execution engine testing framework
+        let session_call_v1_request = ExecuteRequestBuilder::standard(
+            *DEFAULT_ACCOUNT_ADDR,
+            GH_3097_REGRESSION_CALL_WASM,
+            runtime_args! {
+                ARG_METHOD => METHOD_CALL_VERSIONED_CONTRACT,
+                ARG_MAJOR_VERSION => 2u32,
+                ARG_CONTRACT_VERSION => Some(1u32),
+            },
+        )
+        .build();
+    */
 
     let session_call_v2_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -223,6 +235,7 @@ fn should_run_regression() {
         .expect_success()
         .commit();
 
+    /*
     builder
         .exec(session_call_v1_request)
         .expect_failure()
@@ -240,6 +253,7 @@ fn should_run_regression() {
         "Expected disabled contract version, found {:?}",
         error,
     );
+    */
 
     // Call by contract hashes
 
@@ -268,6 +282,9 @@ fn should_run_regression() {
         .expect_success()
         .commit();
 
+    /* TODO The current Execution Engine Testing framework doesn't support calling a specific package version
+                   // since it is based od Deploys ExecutableDeployItem. This part of the test should be reinstantiated once we can pass
+                   // the TransactionInvocationTarget info to the execution engine testing framework
     // This direct contract by name/hash should fail
     let call_by_hash_v1_request = ExecuteRequestBuilder::contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
@@ -319,18 +336,23 @@ fn should_run_regression() {
         "Expected invalid contract version, found {:?}",
         error,
     );
+    */
 
     // Session calls into hashes
 
-    let session_call_hash_v1_request = ExecuteRequestBuilder::standard(
-        *DEFAULT_ACCOUNT_ADDR,
-        GH_3097_REGRESSION_CALL_WASM,
-        runtime_args! {
-            ARG_METHOD => METHOD_CALL_CONTRACT,
-            ARG_CONTRACT_HASH_KEY => DISABLED_CONTRACT_HASH_KEY,
-        },
-    )
-    .build();
+    /* TODO The current Execution Engine Testing framework doesn't support calling a specific package version
+                       // since it is based od Deploys ExecutableDeployItem. This part of the test should be reinstantiated once we can pass
+                       // the TransactionInvocationTarget info to the execution engine testing framework
+        let session_call_hash_v1_request = ExecuteRequestBuilder::standard(
+            *DEFAULT_ACCOUNT_ADDR,
+            GH_3097_REGRESSION_CALL_WASM,
+            runtime_args! {
+                ARG_METHOD => METHOD_CALL_CONTRACT,
+                ARG_CONTRACT_HASH_KEY => DISABLED_CONTRACT_HASH_KEY,
+            },
+        )
+        .build();
+    */
 
     let session_call_hash_v2_request = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -342,24 +364,25 @@ fn should_run_regression() {
     )
     .build();
 
-    builder
-        .exec(session_call_hash_v1_request)
-        .expect_failure()
-        .commit();
+    /*
+        builder
+            .exec(session_call_hash_v1_request)
+            .expect_failure()
+            .commit();
 
-    let error = builder.get_error().expect("should have error");
-    assert!(
-        matches!(
+        let error = builder.get_error().expect("should have error");
+        assert!(
+            matches!(
+                error,
+                Error::Exec(
+                    ExecError::DisabledEntity(contract_hash)
+                )
+                if contract_hash == disabled_contract_hash
+            ),
+            "Expected invalid contract version, found {:?}",
             error,
-            Error::Exec(
-                ExecError::DisabledEntity(contract_hash)
-            )
-            if contract_hash == disabled_contract_hash
-        ),
-        "Expected invalid contract version, found {:?}",
-        error,
-    );
-
+        );
+    */
     builder
         .exec(session_call_hash_v2_request)
         .expect_success()

--- a/execution_engine_testing/tests/src/test/regression/gh_3097.rs
+++ b/execution_engine_testing/tests/src/test/regression/gh_3097.rs
@@ -66,11 +66,10 @@ fn should_run_regression() {
         RuntimeArgs::new(),
     )
     .build();
-
-    let direct_call_v2_request = ExecuteRequestBuilder::versioned_contract_call_by_name(
+    let direct_call_v2_request = ExecuteRequestBuilder::key_versioned_contract_call_by_name(
         *DEFAULT_ACCOUNT_ADDR,
         PACKAGE_HASH_NAME,
-        Some(2),
+        Some(EntityVersionKey::new(2, 2)),
         DO_SOMETHING_ENTRYPOINT,
         RuntimeArgs::new(),
     )
@@ -132,10 +131,10 @@ fn should_run_regression() {
     )
     .build();
 
-    let direct_call_v2_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
+    let direct_call_v2_request = ExecuteRequestBuilder::key_versioned_contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
         contract_package_hash,
-        Some(2),
+        Some(EntityVersionKey::new(2, 2)),
         DO_SOMETHING_ENTRYPOINT,
         RuntimeArgs::new(),
     )

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -1117,7 +1117,10 @@ fn should_correct_migrate_contract_when_invoked_by_package_name() {
 #[ignore]
 #[test]
 fn should_correctly_migrate_contract_when_invoked_by_name_and_version() {
+    /* TODO The current Execution Engine Testing framework doesn't support calling a specific package version
+     // we should reinstantiate this test once we add that possibility
     call_and_migrate_purse_holder_contract(MigrationScenario::ByPackageName(Some(INITIAL_VERSION)))
+    */
 }
 
 #[ignore]

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -1129,7 +1129,10 @@ fn should_correct_migrate_contract_when_invoked_by_package_hash() {
 #[ignore]
 #[test]
 fn should_correct_migrate_contract_when_invoked_by_package_hash_and_specific_version() {
+    /* TODO The current Execution Engine Testing framework doesn't support calling a specific package version
+     // we should reinstantiate this test once we add that possibility
     call_and_migrate_purse_holder_contract(MigrationScenario::ByPackageHash(Some(INITIAL_VERSION)))
+    */
 }
 
 #[ignore]

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -9,7 +9,18 @@ All notable changes to this project will be documented in this file.  The format
 [comment]: <> (Fixed:      any bug fixes)
 [comment]: <> (Security:   in case of vulnerabilities)
 
-## Unreleased (2.0.0)
+## [Unreleased]
+### Added
+* `TransactionInvocationTarget::ByPackageHash` has a new field `version_key`
+* `TransactionInvocationTarget::ByPackageName` has a new field `version_key`
+
+### Changed
+* Transaction::Deploy no longer supports using (in `payment` or `session`) when the `ExecutableDeployItem::StoredVersionedContractByHash` with field `version` (the field is retained for retro compatiblity but new transactions will be rejected by TransactionAcceptor). To execute a stored contract in a specific version please use Transaction::V1.
+* Transaction::Deploy no longer supports using (in `payment` or `session`) when the `ExecutableDeployItem::StoredVersionedContractByName` with field `version` (the field is retained for retro compatiblity but new transactions will be rejected by TransactionAcceptor). To execute a stored contract in a specific version please use Transaction::V1.
+* Transaction::V1 no longer supports using `TransactionInvocationTarget::ByPackageHash` variant with `version` defined (the field is retained for retro compatiblity but new transactions will be rejected by TransactionAcceptor). Please use `version_key` instead.
+* Transaction::V1 no longer supports using `TransactionInvocationTarget::ByPackageName` variant with `version` defined (the field is retained for retro compatiblity but new transactions will be rejected by TransactionAcceptor). Please use `version_key` instead.
+
+## 2.0.0
 
 ### Added
 * Add `BinaryPort` interface along with the relevant config entries.

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -561,7 +561,7 @@ impl TransactionAcceptor {
                         Error::InvalidTransaction(InvalidTransaction::Deploy(
                             InvalidDeploy::TargetingPackageVersionNotSupported,
                         )),
-                    );
+                    )
                 } else {
                     effect_builder
                         .get_package(*block_header.state_root_hash(), package_hash.value())

--- a/node/src/components/transaction_acceptor/error.rs
+++ b/node/src/components/transaction_acceptor/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use casper_binary_port::ErrorCode as BinaryPortErrorCode;
 use casper_types::{
-    AddressableEntityHash, BlockHash, BlockHeader, Digest, EntityVersion, InitiatorAddr,
+    AddressableEntityHash, BlockHash, BlockHeader, Digest, EntityVersionKey, InitiatorAddr,
     InvalidTransaction, PackageHash, Timestamp,
 };
 
@@ -145,14 +145,20 @@ pub(crate) enum ParameterFailure {
     #[error("package at {package_hash} does not exist")]
     NoSuchPackageAtHash { package_hash: PackageHash },
     /// Invalid contract at given version.
-    #[error("invalid entity at version: {entity_version}")]
-    InvalidEntityAtVersion { entity_version: EntityVersion },
+    #[error("invalid entity at version key: {entity_version_key}")]
+    InvalidEntityAtVersion {
+        entity_version_key: EntityVersionKey,
+    },
     /// Invalid contract at given version.
-    #[error("disabled entity at version: {entity_version}")]
-    DisabledEntityAtVersion { entity_version: EntityVersion },
+    #[error("disabled entity at version key: {entity_version_key}")]
+    DisabledEntityAtVersion {
+        entity_version_key: EntityVersionKey,
+    },
     /// Invalid contract at given version.
-    #[error("missing entity at version: {entity_version}")]
-    MissingEntityAtVersion { entity_version: EntityVersion },
+    #[error("missing entity at version key: {entity_version_key}")]
+    MissingEntityAtVersion {
+        entity_version_key: EntityVersionKey,
+    },
     /// Invalid associated keys.
     #[error("account authorization invalid")]
     InvalidAssociatedKeys,

--- a/node/src/components/transaction_acceptor/event.rs
+++ b/node/src/components/transaction_acceptor/event.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use serde::Serialize;
 
 use casper_types::{
-    AddressableEntity, AddressableEntityHash, BlockHeader, EntityVersion, Package, PackageHash,
+    AddressableEntity, AddressableEntityHash, BlockHeader, EntityVersionKey, Package, PackageHash,
     Timestamp, Transaction, U512,
 };
 
@@ -92,7 +92,7 @@ pub(crate) enum Event {
         block_header: Box<BlockHeader>,
         is_payment: bool,
         package_hash: PackageHash,
-        maybe_package_version: Option<EntityVersion>,
+        maybe_package_version_key: Option<EntityVersionKey>,
         maybe_package: Option<Box<Package>>,
     },
     /// The result of querying global state for an `EntryPoint` to verify the executable logic.

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -488,13 +488,15 @@ impl TestScenario {
                     ),
                     ContractPackageScenario::MissingPackageAtHash => {
                         Transaction::from(Deploy::random_with_missing_payment_package_by_hash(rng))
-                    },
+                    }
                     ContractPackageScenario::MissingContractVersion => {
-                        //Keeping this enum because the Transaction::V1 version of this test is still valid, 
-                        // still FromPeerCustomPaymentContractPackage(MissingContractVersion) and 
-                        // FromClientCustomPaymentContractPackage(MissingContractVersion) should not be called
+                        //Keeping this enum because the Transaction::V1 version of this test is
+                        // still valid,
+                        // still FromPeerCustomPaymentContractPackage(MissingContractVersion) and
+                        // FromClientCustomPaymentContractPackage(MissingContractVersion) should not
+                        // be called
                         todo!("This scenario is no longer valid and is not called")
-                    },
+                    }
                 }
             }
             TestScenario::FromPeerSessionContract(TxnType::Deploy, contract_scenario)
@@ -570,11 +572,12 @@ impl TestScenario {
                     Transaction::from(Deploy::random_with_missing_session_package_by_hash(rng))
                 }
                 ContractPackageScenario::MissingContractVersion => {
-                    //Keeping this enum because the Transaction::V1 version of this test is still valid, 
-                    // still FromPeerSessionContractPackage(MissingContractVersion) and 
+                    //Keeping this enum because the Transaction::V1 version of this test is still
+                    // valid,
+                    // still FromPeerSessionContractPackage(MissingContractVersion) and
                     // FromClientSessionContractPackage(MissingContractVersion) should not be called
-                        todo!("This scenario is no longer valid and is not called")      
-                },
+                    todo!("This scenario is no longer valid and is not called")
+                }
             },
             TestScenario::FromPeerSessionContractPackage(
                 TxnType::V1,
@@ -811,40 +814,60 @@ impl TestScenario {
             }
             TestScenario::V1ByPackageHashTargetsVersion => {
                 let txn = TransactionV1Builder::new_targeting_stored(
-                TransactionInvocationTarget::ByPackageHash { addr: [1; 32], version: Some(1), version_key: None },
-        "x",
-        TransactionRuntimeParams::VmCasperV1,
+                    TransactionInvocationTarget::ByPackageHash {
+                        addr: [1; 32],
+                        version: Some(1),
+                        version_key: None,
+                    },
+                    "x",
+                    TransactionRuntimeParams::VmCasperV1,
                 )
                 .with_chain_name("casper-example")
                 .with_secret_key(&secret_key)
                 .build()
                 .unwrap();
                 Transaction::from(txn)
-            },
+            }
             TestScenario::V1ByPackageNameTargetsVersion => {
                 let txn = TransactionV1Builder::new_targeting_stored(
-                    TransactionInvocationTarget::ByPackageName { name: "xyz".to_string(), version: Some(1), version_key: None },
-        "x",
-        TransactionRuntimeParams::VmCasperV1,
+                    TransactionInvocationTarget::ByPackageName {
+                        name: "xyz".to_string(),
+                        version: Some(1),
+                        version_key: None,
+                    },
+                    "x",
+                    TransactionRuntimeParams::VmCasperV1,
                 )
                 .with_chain_name("casper-example")
                 .with_secret_key(&secret_key)
                 .build()
                 .unwrap();
                 Transaction::from(txn)
-            },
+            }
             TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion => {
-                Transaction::from(Deploy::random_with_payment_package_version_by_hash(Some(10), rng))
-            },
-            TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion=> {
-                Transaction::from(Deploy::random_with_versioned_payment_package_by_name(Some(10), rng))
-            },
-             TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion=> {
-                Transaction::from(Deploy::random_with_versioned_session_package_by_hash(Some(10), rng))
-             },
-             TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion=> {
-                Transaction::from(Deploy::random_with_versioned_session_package_by_name(Some(10), rng))
-             },
+                Transaction::from(Deploy::random_with_payment_package_version_by_hash(
+                    Some(10),
+                    rng,
+                ))
+            }
+            TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion => {
+                Transaction::from(Deploy::random_with_versioned_payment_package_by_name(
+                    Some(10),
+                    rng,
+                ))
+            }
+            TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion => {
+                Transaction::from(Deploy::random_with_versioned_session_package_by_hash(
+                    Some(10),
+                    rng,
+                ))
+            }
+            TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion => {
+                Transaction::from(Deploy::random_with_versioned_session_package_by_name(
+                    Some(10),
+                    rng,
+                ))
+            }
         }
     }
 
@@ -910,8 +933,8 @@ impl TestScenario {
             | TestScenario::InvalidArgumentsKind
             | TestScenario::WasmTransactionWithTooBigPayment
             | TestScenario::WasmDeployWithTooBigPayment
-            | TestScenario::RedelegateExceedingMaximumDelegation {.. }
-            | TestScenario::DelegateExceedingMaximumDelegation {..} 
+            | TestScenario::RedelegateExceedingMaximumDelegation { .. }
+            | TestScenario::DelegateExceedingMaximumDelegation { .. }
             | TestScenario::V1ByPackageHashTargetsVersion
             | TestScenario::V1ByPackageNameTargetsVersion
             | TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion
@@ -2839,43 +2862,55 @@ async fn should_reject_transactions_targets_package_version_2() {
 
 #[tokio::test]
 async fn should_reject_transactions_targets_package_version_3() {
-    let result = run_transaction_acceptor(TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion).await;
+    let result = run_transaction_acceptor(
+        TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion,
+    )
+    .await;
     assert!(matches!(
         result,
-        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
-            InvalidDeploy::TargetingPackageVersionNotSupported
-        )))
+        Err(super::Error::InvalidTransaction(
+            InvalidTransaction::Deploy(InvalidDeploy::TargetingPackageVersionNotSupported)
+        ))
     ));
 }
 
 #[tokio::test]
 async fn should_reject_transactions_targets_package_version_4() {
-    let result = run_transaction_acceptor(TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion).await;
+    let result = run_transaction_acceptor(
+        TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion,
+    )
+    .await;
     assert!(matches!(
         result,
-        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
-            InvalidDeploy::TargetingPackageVersionNotSupported
-        )))
+        Err(super::Error::InvalidTransaction(
+            InvalidTransaction::Deploy(InvalidDeploy::TargetingPackageVersionNotSupported)
+        ))
     ));
 }
 
 #[tokio::test]
 async fn should_reject_transactions_targets_package_version_5() {
-    let result = run_transaction_acceptor(TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion).await;
+    let result = run_transaction_acceptor(
+        TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion,
+    )
+    .await;
     assert!(matches!(
         result,
-        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
-            InvalidDeploy::TargetingPackageVersionNotSupported
-        )))
+        Err(super::Error::InvalidTransaction(
+            InvalidTransaction::Deploy(InvalidDeploy::TargetingPackageVersionNotSupported)
+        ))
     ));
 }
 #[tokio::test]
 async fn should_reject_transactions_targets_package_version_6() {
-    let result = run_transaction_acceptor(TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion).await;
+    let result = run_transaction_acceptor(
+        TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion,
+    )
+    .await;
     assert!(matches!(
         result,
-        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
-            InvalidDeploy::TargetingPackageVersionNotSupported
-        )))
+        Err(super::Error::InvalidTransaction(
+            InvalidTransaction::Deploy(InvalidDeploy::TargetingPackageVersionNotSupported)
+        ))
     ));
 }

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -35,10 +35,10 @@ use casper_types::{
     global_state::TrieMerkleProof,
     testing::TestRng,
     Block, BlockV2, CLValue, Chainspec, ChainspecRawBytes, Contract, Deploy, EraId, HashAddr,
-    InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Key, PricingHandling, PricingMode,
-    ProtocolVersion, PublicKey, SecretKey, StoredValue, TestBlockBuilder, TimeDiff, Timestamp,
-    Transaction, TransactionArgs, TransactionConfig, TransactionRuntimeParams, TransactionV1, URef,
-    DEFAULT_BASELINE_MOTES_AMOUNT,
+    InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Key, PackageAddr, PricingHandling,
+    PricingMode, ProtocolVersion, PublicKey, SecretKey, StoredValue, TestBlockBuilder, TimeDiff,
+    Timestamp, Transaction, TransactionArgs, TransactionConfig, TransactionRuntimeParams,
+    TransactionV1, URef, DEFAULT_BASELINE_MOTES_AMOUNT,
 };
 
 use super::*;
@@ -226,6 +226,12 @@ enum TestScenario {
     WasmDeployWithTooBigPayment,
     RedelegateExceedingMaximumDelegation,
     DelegateExceedingMaximumDelegation,
+    V1ByPackageHashTargetsVersion,
+    V1ByPackageNameTargetsVersion,
+    DeployPaymentStoredVersionedContractByHashTargetsVersion,
+    DeployPaymentStoredVersionedContractByNameTargetsVersion,
+    DeploySessionStoredVersionedContractByHashTargetsVersion,
+    DeploySessionStoredVersionedContractByNameTargetsVersion,
 }
 
 impl TestScenario {
@@ -279,7 +285,15 @@ impl TestScenario {
             | TestScenario::WasmTransactionWithTooBigPayment
             | TestScenario::WasmDeployWithTooBigPayment
             | TestScenario::RedelegateExceedingMaximumDelegation
-            | TestScenario::DelegateExceedingMaximumDelegation => Source::Client,
+            | TestScenario::DelegateExceedingMaximumDelegation
+            | TestScenario::V1ByPackageHashTargetsVersion
+            | TestScenario::V1ByPackageNameTargetsVersion
+            | TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion
+            | TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion
+            | TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion
+            | TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion => {
+                Source::Client
+            }
         }
     }
 
@@ -428,7 +442,7 @@ impl TestScenario {
             TestScenario::TransactionWithPaymentOne => {
                 let timestamp = Timestamp::now()
                     + Config::default().timestamp_leeway
-                    + TimeDiff::from_millis(100);
+                    + TimeDiff::from_millis(1000);
                 let ttl = TimeDiff::from_seconds(300);
                 let txn = TransactionV1Builder::new_session(
                     false,
@@ -474,10 +488,13 @@ impl TestScenario {
                     ),
                     ContractPackageScenario::MissingPackageAtHash => {
                         Transaction::from(Deploy::random_with_missing_payment_package_by_hash(rng))
-                    }
-                    ContractPackageScenario::MissingContractVersion => Transaction::from(
-                        Deploy::random_with_nonexistent_contract_version_in_payment_package(rng),
-                    ),
+                    },
+                    ContractPackageScenario::MissingContractVersion => {
+                        //Keeping this enum because the Transaction::V1 version of this test is still valid, 
+                        // still FromPeerCustomPaymentContractPackage(MissingContractVersion) and 
+                        // FromClientCustomPaymentContractPackage(MissingContractVersion) should not be called
+                        todo!("This scenario is no longer valid and is not called")
+                    },
                 }
             }
             TestScenario::FromPeerSessionContract(TxnType::Deploy, contract_scenario)
@@ -552,9 +569,12 @@ impl TestScenario {
                 ContractPackageScenario::MissingPackageAtHash => {
                     Transaction::from(Deploy::random_with_missing_session_package_by_hash(rng))
                 }
-                ContractPackageScenario::MissingContractVersion => Transaction::from(
-                    Deploy::random_with_nonexistent_contract_version_in_session_package(rng),
-                ),
+                ContractPackageScenario::MissingContractVersion => {
+                    //Keeping this enum because the Transaction::V1 version of this test is still valid, 
+                    // still FromPeerSessionContractPackage(MissingContractVersion) and 
+                    // FromClientSessionContractPackage(MissingContractVersion) should not be called
+                        todo!("This scenario is no longer valid and is not called")      
+                },
             },
             TestScenario::FromPeerSessionContractPackage(
                 TxnType::V1,
@@ -595,7 +615,7 @@ impl TestScenario {
                 ContractPackageScenario::MissingContractVersion => {
                     let txn = TransactionV1Builder::new_targeting_package(
                         PackageHash::new(PackageAddr::default()),
-                        Some(6),
+                        Some(EntityVersionKey::new(2, 6)),
                         "call",
                         TransactionRuntimeParams::VmCasperV1,
                     )
@@ -641,7 +661,7 @@ impl TestScenario {
             TestScenario::FromClientFutureDatedTransaction(txn_type) => {
                 let timestamp = Timestamp::now()
                     + Config::default().timestamp_leeway
-                    + TimeDiff::from_millis(100);
+                    + TimeDiff::from_millis(1000);
                 let ttl = TimeDiff::from_seconds(300);
                 match txn_type {
                     TxnType::Deploy => Transaction::from(
@@ -714,7 +734,7 @@ impl TestScenario {
             TestScenario::InvalidArgumentsKind => {
                 let timestamp = Timestamp::now()
                     + Config::default().timestamp_leeway
-                    + TimeDiff::from_millis(100);
+                    + TimeDiff::from_millis(1000);
                 let ttl = TimeDiff::from_seconds(300);
                 let txn = TransactionV1Builder::new_session(
                     false,
@@ -789,6 +809,42 @@ impl TestScenario {
                 .unwrap();
                 Transaction::from(txn)
             }
+            TestScenario::V1ByPackageHashTargetsVersion => {
+                let txn = TransactionV1Builder::new_targeting_stored(
+                    TransactionInvocationTarget::ByPackageHash { addr: [1; 32], version: Some(1), version_key: None },
+        "x",
+        TransactionRuntimeParams::VmCasperV1,
+                )
+                .with_chain_name("casper-example")
+                .with_secret_key(&secret_key)
+                .build()
+                .unwrap();
+                Transaction::from(txn)
+            },
+            TestScenario::V1ByPackageNameTargetsVersion => {
+                let txn = TransactionV1Builder::new_targeting_stored(
+                    TransactionInvocationTarget::ByPackageName { name: "xyz".to_string(), version: Some(1), version_key: None },
+        "x",
+        TransactionRuntimeParams::VmCasperV1,
+                )
+                .with_chain_name("casper-example")
+                .with_secret_key(&secret_key)
+                .build()
+                .unwrap();
+                Transaction::from(txn)
+            },
+            TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion => {
+                Transaction::from(Deploy::random_with_payment_package_version_by_hash(Some(10), rng))
+            },
+            TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion=> {
+                Transaction::from(Deploy::random_with_versioned_payment_package_by_name(Some(10), rng))
+            },
+             TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion=> {
+                Transaction::from(Deploy::random_with_versioned_session_package_by_hash(Some(10), rng))
+             },
+             TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion=> {
+                Transaction::from(Deploy::random_with_versioned_session_package_by_name(Some(10), rng))
+             },
         }
     }
 
@@ -855,7 +911,13 @@ impl TestScenario {
             | TestScenario::WasmTransactionWithTooBigPayment
             | TestScenario::WasmDeployWithTooBigPayment
             | TestScenario::RedelegateExceedingMaximumDelegation {.. }
-            | TestScenario::DelegateExceedingMaximumDelegation {..} => false,
+            | TestScenario::DelegateExceedingMaximumDelegation {..} 
+            | TestScenario::V1ByPackageHashTargetsVersion
+            | TestScenario::V1ByPackageNameTargetsVersion
+            | TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion
+            | TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion
+            | TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion
+            | TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion=> false,
         }
     }
 
@@ -1430,7 +1492,13 @@ async fn run_transaction_acceptor_without_timeout(
             | TestScenario::WasmTransactionWithTooBigPayment
             | TestScenario::WasmDeployWithTooBigPayment
             | TestScenario::RedelegateExceedingMaximumDelegation { .. }
-            | TestScenario::DelegateExceedingMaximumDelegation { .. } => {
+            | TestScenario::DelegateExceedingMaximumDelegation { .. }
+            | TestScenario::V1ByPackageHashTargetsVersion
+            | TestScenario::V1ByPackageNameTargetsVersion
+            | TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion
+            | TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion
+            | TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion
+            | TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion => {
                 matches!(
                     event,
                     Event::TransactionAcceptorAnnouncement(
@@ -2037,21 +2105,6 @@ async fn should_reject_deploy_with_missing_payment_contract_package_at_hash_from
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_version_in_payment_contract_package_from_client() {
-    let test_scenario = TestScenario::FromClientCustomPaymentContractPackage(
-        ContractPackageScenario::MissingContractVersion,
-    );
-    let result = run_transaction_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::Parameters {
-            failure: ParameterFailure::MissingEntityAtVersion { .. },
-            ..
-        })
-    ))
-}
-
-#[tokio::test]
 async fn should_accept_deploy_with_valid_session_contract_from_client() {
     let test_scenario =
         TestScenario::FromClientSessionContract(TxnType::Deploy, ContractScenario::Valid);
@@ -2220,22 +2273,6 @@ async fn should_reject_transaction_v1_with_missing_session_contract_package_at_h
 }
 
 #[tokio::test]
-async fn should_reject_deploy_with_missing_version_in_session_contract_package_from_client() {
-    let test_scenario = TestScenario::FromClientSessionContractPackage(
-        TxnType::Deploy,
-        ContractPackageScenario::MissingContractVersion,
-    );
-    let result = run_transaction_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::Parameters {
-            failure: ParameterFailure::MissingEntityAtVersion { .. },
-            ..
-        })
-    ))
-}
-
-#[tokio::test]
 async fn should_reject_transaction_v1_with_missing_version_in_session_contract_package_from_client()
 {
     let test_scenario = TestScenario::FromClientSessionContractPackage(
@@ -2322,21 +2359,6 @@ async fn should_reject_deploy_with_missing_payment_contract_package_at_hash_from
         result,
         Err(super::Error::Parameters {
             failure: ParameterFailure::NoSuchPackageAtHash { .. },
-            ..
-        })
-    ))
-}
-
-#[tokio::test]
-async fn should_reject_deploy_with_missing_version_in_payment_contract_package_from_peer() {
-    let test_scenario = TestScenario::FromPeerCustomPaymentContractPackage(
-        ContractPackageScenario::MissingContractVersion,
-    );
-    let result = run_transaction_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::Parameters {
-            failure: ParameterFailure::MissingEntityAtVersion { .. },
             ..
         })
     ))
@@ -2498,22 +2520,6 @@ async fn should_reject_transaction_v1_with_missing_session_contract_package_at_h
         result,
         Err(super::Error::Parameters {
             failure: ParameterFailure::NoSuchPackageAtHash { .. },
-            ..
-        })
-    ))
-}
-
-#[tokio::test]
-async fn should_reject_deploy_with_missing_version_in_session_contract_package_from_peer() {
-    let test_scenario = TestScenario::FromPeerSessionContractPackage(
-        TxnType::Deploy,
-        ContractPackageScenario::MissingContractVersion,
-    );
-    let result = run_transaction_acceptor(test_scenario).await;
-    assert!(matches!(
-        result,
-        Err(super::Error::Parameters {
-            failure: ParameterFailure::MissingEntityAtVersion { .. },
             ..
         })
     ))
@@ -2807,6 +2813,69 @@ async fn should_reject_native_redelegate_with_exceeding_amount() {
         result,
         Err(super::Error::InvalidTransaction(InvalidTransaction::V1(
             InvalidTransactionV1::InvalidDelegationAmount { .. }
+        )))
+    ));
+}
+#[tokio::test]
+async fn should_reject_transactions_targets_package_version() {
+    let result = run_transaction_acceptor(TestScenario::V1ByPackageHashTargetsVersion).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidTransaction(InvalidTransaction::V1(
+            InvalidTransactionV1::TargetingPackageVersionNotSupported
+        )))
+    ));
+}
+#[tokio::test]
+async fn should_reject_transactions_targets_package_version_2() {
+    let result = run_transaction_acceptor(TestScenario::V1ByPackageNameTargetsVersion).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidTransaction(InvalidTransaction::V1(
+            InvalidTransactionV1::TargetingPackageVersionNotSupported
+        )))
+    ));
+}
+
+#[tokio::test]
+async fn should_reject_transactions_targets_package_version_3() {
+    let result = run_transaction_acceptor(TestScenario::DeployPaymentStoredVersionedContractByHashTargetsVersion).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
+            InvalidDeploy::TargetingPackageVersionNotSupported
+        )))
+    ));
+}
+
+#[tokio::test]
+async fn should_reject_transactions_targets_package_version_4() {
+    let result = run_transaction_acceptor(TestScenario::DeployPaymentStoredVersionedContractByNameTargetsVersion).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
+            InvalidDeploy::TargetingPackageVersionNotSupported
+        )))
+    ));
+}
+
+#[tokio::test]
+async fn should_reject_transactions_targets_package_version_5() {
+    let result = run_transaction_acceptor(TestScenario::DeploySessionStoredVersionedContractByHashTargetsVersion).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
+            InvalidDeploy::TargetingPackageVersionNotSupported
+        )))
+    ));
+}
+#[tokio::test]
+async fn should_reject_transactions_targets_package_version_6() {
+    let result = run_transaction_acceptor(TestScenario::DeploySessionStoredVersionedContractByNameTargetsVersion).await;
+    assert!(matches!(
+        result,
+        Err(super::Error::InvalidTransaction(InvalidTransaction::Deploy(
+            InvalidDeploy::TargetingPackageVersionNotSupported
         )))
     ));
 }

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -811,7 +811,7 @@ impl TestScenario {
             }
             TestScenario::V1ByPackageHashTargetsVersion => {
                 let txn = TransactionV1Builder::new_targeting_stored(
-                    TransactionInvocationTarget::ByPackageHash { addr: [1; 32], version: Some(1), version_key: None },
+                TransactionInvocationTarget::ByPackageHash { addr: [1; 32], version: Some(1), version_key: None },
         "x",
         TransactionRuntimeParams::VmCasperV1,
                 )

--- a/node/src/types/transaction/transaction_v1_builder.rs
+++ b/node/src/types/transaction/transaction_v1_builder.rs
@@ -10,7 +10,7 @@ use casper_types::{
 };
 #[cfg(test)]
 use casper_types::{
-    testing::TestRng, AddressableEntityHash, Approval, CLValueError, EntityVersion, PackageHash,
+    testing::TestRng, AddressableEntityHash, Approval, CLValueError, EntityVersionKey, PackageHash,
     PublicKey, TransactionConfig, TransactionInvocationTarget, TransferTarget, URef, U512,
 };
 use core::marker::PhantomData;
@@ -338,11 +338,11 @@ impl<'a> TransactionV1Builder<'a> {
     #[cfg(test)]
     pub(crate) fn new_targeting_package<E: Into<String>>(
         hash: PackageHash,
-        version: Option<EntityVersion>,
+        version_key: Option<EntityVersionKey>,
         entry_point: E,
         runtime: TransactionRuntimeParams,
     ) -> Self {
-        let id = TransactionInvocationTarget::new_package(hash, version);
+        let id = TransactionInvocationTarget::new_package_with_key(hash, version_key);
         Self::new_targeting_stored(id, entry_point, runtime)
     }
 
@@ -351,11 +351,11 @@ impl<'a> TransactionV1Builder<'a> {
     #[cfg(test)]
     pub(crate) fn new_targeting_package_via_alias<A: Into<String>, E: Into<String>>(
         alias: A,
-        version: Option<EntityVersion>,
+        version_key: Option<EntityVersionKey>,
         entry_point: E,
         runtime: TransactionRuntimeParams,
     ) -> Self {
-        let id = TransactionInvocationTarget::new_package_alias(alias.into(), version);
+        let id = TransactionInvocationTarget::new_package_alias_with_key(alias.into(), version_key);
         Self::new_targeting_stored(id, entry_point, runtime)
     }
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Added 
 - TransactionInvocationTarget::ByPackageHash::version_key field
 - TransactionInvocationTarget::ByPackageName::version_key field
+- New variant PackageIdentifier::HashWithVersion
+- New variant PackageIdentifier::NameWithVersion
 
 ## casper-types 5.0.0
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -9,7 +9,13 @@ All notable changes to this project will be documented in this file. The format 
 [comment]: <> (Fixed: any bug fixes)
 [comment]: <> (Security: in case of vulnerabilities)
 
-## [Unreleased] (node 2.0)
+## [UNRELEASED] casper-types 6.0.0
+
+### Added 
+- TransactionInvocationTarget::ByPackageHash::version_key field
+- TransactionInvocationTarget::ByPackageName::version_key field
+
+## casper-types 5.0.0
 
 ### Added
 

--- a/types/src/contracts.rs
+++ b/types/src/contracts.rs
@@ -218,7 +218,7 @@ pub const CONTRACT_INITIAL_VERSION: ContractVersion = 1;
 pub type ProtocolVersionMajor = u32;
 
 /// Major element of `ProtocolVersion` combined with `ContractVersion`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 pub struct ContractVersionKey(ProtocolVersionMajor, ContractVersion);

--- a/types/src/gens.rs
+++ b/types/src/gens.rs
@@ -1073,18 +1073,23 @@ pub fn transaction_invocation_target_arb() -> impl Strategy<Value = TransactionI
         Just(TransactionInvocationTarget::new_invocable_entity_alias(
             "abcd".to_string()
         )),
-        Just(TransactionInvocationTarget::new_package_alias(
+        Just(TransactionInvocationTarget::new_package_alias_with_key(
             "abcd".to_string(),
             None
         )),
-        Just(TransactionInvocationTarget::new_package_alias(
+        Just(TransactionInvocationTarget::new_package_alias_with_key(
             "abcd".to_string(),
-            Some(10)
+            Some(EntityVersionKey::new(2, 15))
         )),
-        u8_slice_32()
-            .prop_map(|addr| { TransactionInvocationTarget::new_package(addr.into(), None) }),
-        u8_slice_32()
-            .prop_map(|addr| { TransactionInvocationTarget::new_package(addr.into(), Some(150)) }),
+        u8_slice_32().prop_map(|addr| {
+            TransactionInvocationTarget::new_package_with_key(addr.into(), None)
+        }),
+        u8_slice_32().prop_map(|addr| {
+            TransactionInvocationTarget::new_package_with_key(
+                addr.into(),
+                Some(EntityVersionKey::new(1, 150)),
+            )
+        }),
     ]
 }
 

--- a/types/src/package.rs
+++ b/types/src/package.rs
@@ -11,6 +11,9 @@ use core::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+#[cfg(any(feature = "testing", feature = "gens", test))]
+use rand::{distributions::Standard, prelude::Distribution, Rng};
+
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
 #[cfg(feature = "json-schema")]
@@ -97,7 +100,7 @@ pub const ENTITY_INITIAL_VERSION: EntityVersion = 1;
 pub type ProtocolVersionMajor = u32;
 
 /// Major element of `ProtocolVersion` combined with `EntityVersion`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
 #[cfg_attr(feature = "json-schema", derive(JsonSchema))]
 pub struct EntityVersionKey {
@@ -173,6 +176,16 @@ impl FromBytes for EntityVersionKey {
 impl Display for EntityVersionKey {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}.{}", self.protocol_version_major, self.entity_version)
+    }
+}
+
+#[cfg(any(feature = "testing", feature = "gens", test))]
+impl Distribution<EntityVersionKey> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> EntityVersionKey {
+        EntityVersionKey {
+            protocol_version_major: rng.gen(),
+            entity_version: rng.gen(),
+        }
     }
 }
 

--- a/types/src/transaction/deploy.rs
+++ b/types/src/transaction/deploy.rs
@@ -868,37 +868,44 @@ impl Deploy {
     /// Returns a random `Deploy` with custom payment specified as a stored versioned contract by
     /// name.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
-    pub fn random_with_valid_custom_payment_package_by_name(rng: &mut TestRng) -> Self {
+    pub fn random_with_versioned_payment_package_by_name(
+        version: Option<u32>,
+        rng: &mut TestRng,
+    ) -> Self {
         let payment = ExecutableDeployItem::StoredVersionedContractByName {
             name: "Test".to_string(),
-            version: None,
+            version,
             entry_point: "call".to_string(),
             args: Default::default(),
         };
         Self::random_transfer_with_payment(rng, payment)
+    }
+
+    /// Returns a random `Deploy` with custom payment specified as a stored versioned contract by
+    /// name.
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
+    pub fn random_with_valid_custom_payment_package_by_name(rng: &mut TestRng) -> Self {
+        Self::random_with_versioned_payment_package_by_name(None, rng)
     }
 
     /// Returns a random invalid `Deploy` with custom payment specified as a stored versioned
     /// contract by hash, but missing the runtime args.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn random_with_missing_payment_package_by_hash(rng: &mut TestRng) -> Self {
-        let payment = ExecutableDeployItem::StoredVersionedContractByHash {
-            hash: Default::default(),
-            version: None,
-            entry_point: "call".to_string(),
-            args: Default::default(),
-        };
-        Self::random_transfer_with_payment(rng, payment)
+        Self::random_with_payment_package_version_by_hash(None, rng)
     }
 
     /// Returns a random invalid `Deploy` with custom payment specified as a stored versioned
-    /// contract by hash, but calling an invalid entry point.
+    /// contract by hash, but missing the runtime args.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
-    pub fn random_with_nonexistent_contract_version_in_payment_package(rng: &mut TestRng) -> Self {
+    pub fn random_with_payment_package_version_by_hash(
+        version: Option<u32>,
+        rng: &mut TestRng,
+    ) -> Self {
         let payment = ExecutableDeployItem::StoredVersionedContractByHash {
-            hash: [19; 32].into(),
-            version: Some(6u32),
-            entry_point: "non-existent-entry-point".to_string(),
+            hash: Default::default(),
+            version,
+            entry_point: "call".to_string(),
             args: Default::default(),
         };
         Self::random_transfer_with_payment(rng, payment)
@@ -971,9 +978,19 @@ impl Deploy {
     /// name.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn random_with_valid_session_package_by_name(rng: &mut TestRng) -> Self {
+        Self::random_with_versioned_session_package_by_name(None, rng)
+    }
+
+    /// Returns a random `Deploy` with custom session specified as a stored versioned contract by
+    /// name.
+    #[cfg(any(all(feature = "std", feature = "testing"), test))]
+    pub fn random_with_versioned_session_package_by_name(
+        version: Option<u32>,
+        rng: &mut TestRng,
+    ) -> Self {
         let session = ExecutableDeployItem::StoredVersionedContractByName {
             name: "Test".to_string(),
-            version: None,
+            version,
             entry_point: "call".to_string(),
             args: Default::default(),
         };
@@ -1032,23 +1049,18 @@ impl Deploy {
     /// contract by hash, but missing the runtime args.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
     pub fn random_with_missing_session_package_by_hash(rng: &mut TestRng) -> Self {
-        let session = ExecutableDeployItem::StoredVersionedContractByHash {
-            hash: Default::default(),
-            version: None,
-            entry_point: "call".to_string(),
-            args: Default::default(),
-        };
-        Self::random_transfer_with_session(rng, session)
+        Self::random_with_versioned_session_package_by_hash(None, rng)
     }
 
-    /// Returns a random invalid `Deploy` with custom session specified as a stored versioned
-    /// contract by hash, but calling an invalid entry point.
     #[cfg(any(all(feature = "std", feature = "testing"), test))]
-    pub fn random_with_nonexistent_contract_version_in_session_package(rng: &mut TestRng) -> Self {
+    pub fn random_with_versioned_session_package_by_hash(
+        version: Option<u32>,
+        rng: &mut TestRng,
+    ) -> Self {
         let session = ExecutableDeployItem::StoredVersionedContractByHash {
-            hash: [19; 32].into(),
-            version: Some(6u32),
-            entry_point: "non-existent-entry-point".to_string(),
+            hash: Default::default(),
+            version,
+            entry_point: "call".to_string(),
             args: Default::default(),
         };
         Self::random_transfer_with_session(rng, session)

--- a/types/src/transaction/deploy/error.rs
+++ b/types/src/transaction/deploy/error.rs
@@ -161,147 +161,151 @@ pub enum InvalidDeploy {
 
     /// Pricing mode not supported
     PricingModeNotSupported,
+
+    // Passing ExecutableDeployItem::StoredVersionedContractByHash::version not supported
+    TargetingPackageVersionNotSupported,
 }
 
 impl Display for InvalidDeploy {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
             InvalidDeploy::InvalidChainName { expected, got } => {
-                        write!(
-                            formatter,
-                            "invalid chain name: expected {}, got {}",
-                            expected, got
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "invalid chain name: expected {}, got {}",
+                                    expected, got
+                                )
+                            }
             InvalidDeploy::DependenciesNoLongerSupported => {
-                        write!(formatter, "dependencies no longer supported",)
-                    }
+                                write!(formatter, "dependencies no longer supported",)
+                            }
             InvalidDeploy::ExcessiveSize(error) => {
-                        write!(formatter, "deploy size too large: {}", error)
-                    }
+                                write!(formatter, "deploy size too large: {}", error)
+                            }
             InvalidDeploy::ExcessiveTimeToLive { max_ttl, got } => {
-                        write!(
-                            formatter,
-                            "time-to-live of {} exceeds limit of {}",
-                            got, max_ttl
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "time-to-live of {} exceeds limit of {}",
+                                    got, max_ttl
+                                )
+                            }
             InvalidDeploy::TimestampInFuture {
-                        validation_timestamp,
-                        timestamp_leeway,
-                        got,
-                    } => {
-                        write!(
-                            formatter,
-                            "timestamp of {} is later than node's timestamp of {} plus leeway of {}",
-                            got, validation_timestamp, timestamp_leeway
-                        )
-                    }
+                                validation_timestamp,
+                                timestamp_leeway,
+                                got,
+                            } => {
+                                write!(
+                                    formatter,
+                                    "timestamp of {} is later than node's timestamp of {} plus leeway of {}",
+                                    got, validation_timestamp, timestamp_leeway
+                                )
+                            }
             InvalidDeploy::InvalidBodyHash => {
-                        write!(
-                            formatter,
-                            "the provided body hash does not match the actual hash of the body"
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "the provided body hash does not match the actual hash of the body"
+                                )
+                            }
             InvalidDeploy::InvalidDeployHash => {
-                        write!(
-                            formatter,
-                            "the provided hash does not match the actual hash of the deploy"
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "the provided hash does not match the actual hash of the deploy"
+                                )
+                            }
             InvalidDeploy::EmptyApprovals => {
-                        write!(formatter, "the deploy has no approvals")
-                    }
+                                write!(formatter, "the deploy has no approvals")
+                            }
             InvalidDeploy::InvalidApproval { index, error } => {
-                        write!(
-                            formatter,
-                            "the approval at index {} is invalid: {}",
-                            index, error
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "the approval at index {} is invalid: {}",
+                                    index, error
+                                )
+                            }
             InvalidDeploy::ExcessiveSessionArgsLength { max_length, got } => {
-                        write!(
-                            formatter,
-                            "serialized session code runtime args of {} exceeds limit of {}",
-                            got, max_length
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "serialized session code runtime args of {} exceeds limit of {}",
+                                    got, max_length
+                                )
+                            }
             InvalidDeploy::ExcessivePaymentArgsLength { max_length, got } => {
-                        write!(
-                            formatter,
-                            "serialized payment code runtime args of {} exceeds limit of {}",
-                            got, max_length
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "serialized payment code runtime args of {} exceeds limit of {}",
+                                    got, max_length
+                                )
+                            }
             InvalidDeploy::MissingPaymentAmount => {
-                        write!(formatter, "missing payment 'amount' runtime argument")
-                    }
+                                write!(formatter, "missing payment 'amount' runtime argument")
+                            }
             InvalidDeploy::FailedToParsePaymentAmount => {
-                        write!(formatter, "failed to parse payment 'amount' as U512")
-                    }
+                                write!(formatter, "failed to parse payment 'amount' as U512")
+                            }
             InvalidDeploy::ExceededBlockGasLimit {
-                        block_gas_limit,
-                        got,
-                    } => {
-                        write!(
-                            formatter,
-                            "payment amount of {} exceeds the block gas limit of {}",
-                            got, block_gas_limit
-                        )
-                    }
+                                block_gas_limit,
+                                got,
+                            } => {
+                                write!(
+                                    formatter,
+                                    "payment amount of {} exceeds the block gas limit of {}",
+                                    got, block_gas_limit
+                                )
+                            }
             InvalidDeploy::MissingTransferAmount => {
-                        write!(formatter, "missing transfer 'amount' runtime argument")
-                    }
+                                write!(formatter, "missing transfer 'amount' runtime argument")
+                            }
             InvalidDeploy::FailedToParseTransferAmount => {
-                        write!(formatter, "failed to parse transfer 'amount' as U512")
-                    }
+                                write!(formatter, "failed to parse transfer 'amount' as U512")
+                            }
             InvalidDeploy::InsufficientTransferAmount { minimum, attempted } => {
-                        write!(
-                            formatter,
-                            "insufficient transfer amount; minimum: {} attempted: {}",
-                            minimum, attempted
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "insufficient transfer amount; minimum: {} attempted: {}",
+                                    minimum, attempted
+                                )
+                            }
             InvalidDeploy::ExcessiveApprovals {
-                        got,
-                        max_associated_keys,
-                    } => {
-                        write!(
-                            formatter,
-                            "number of approvals {} exceeds the maximum number of associated keys {}",
-                            got, max_associated_keys
-                        )
-                    }
+                                got,
+                                max_associated_keys,
+                            } => {
+                                write!(
+                                    formatter,
+                                    "number of approvals {} exceeds the maximum number of associated keys {}",
+                                    got, max_associated_keys
+                                )
+                            }
             InvalidDeploy::UnableToCalculateGasLimit => {
-                        write!(formatter, "unable to calculate gas limit",)
-                    }
+                                write!(formatter, "unable to calculate gas limit",)
+                            }
             InvalidDeploy::UnableToCalculateGasCost => {
-                        write!(formatter, "unable to calculate gas cost",)
-                    }
+                                write!(formatter, "unable to calculate gas cost",)
+                            }
             InvalidDeploy::GasLimitNotSupported => {
-                        write!(formatter, "gas limit is not supported in legacy deploys",)
-                    }
+                                write!(formatter, "gas limit is not supported in legacy deploys",)
+                            }
             InvalidDeploy::GasPriceToleranceTooLow { min_gas_price_tolerance, provided_gas_price_tolerance } => write!(
-                        formatter,
-                        "received a deploy with gas price tolerance {} but this chain will only go as low as {}",
-                        provided_gas_price_tolerance, min_gas_price_tolerance
-                    ),
+                                formatter,
+                                "received a deploy with gas price tolerance {} but this chain will only go as low as {}",
+                                provided_gas_price_tolerance, min_gas_price_tolerance
+                            ),
             InvalidDeploy::InvalidRuntime => {
-                        write!(formatter, "invalid runtime",)
-                    }
+                                write!(formatter, "invalid runtime",)
+                            }
             InvalidDeploy::NoLaneMatch => write!(formatter, "chainspec didnt have any wasm lanes defined which is required for wasm based deploys",),
             InvalidDeploy::ExceededLaneGasLimit {
-                        lane_gas_limit: wasm_lane_gas_limit,
-                        got,
-                    } => {
-                        write!(
-                            formatter,
-                            "payment amount of {} exceeds the largest wasm lane gas limit of {}",
-                            got, wasm_lane_gas_limit
-                        )
-                    }
+                                lane_gas_limit: wasm_lane_gas_limit,
+                                got,
+                            } => {
+                                write!(
+                                    formatter,
+                                    "payment amount of {} exceeds the largest wasm lane gas limit of {}",
+                                    got, wasm_lane_gas_limit
+                                )
+                            }
             InvalidDeploy::InvalidPaymentAmount => write!(formatter, "invalid payment amount",),
             InvalidDeploy::PricingModeNotSupported => write!(formatter, "pricing mode not supported",),
+            InvalidDeploy::TargetingPackageVersionNotSupported => write!(formatter, "passing `version` in payment and session Versioned variants is not supported",),
         }
     }
 }
@@ -342,7 +346,8 @@ impl StdError for InvalidDeploy {
             | InvalidDeploy::NoLaneMatch
             | InvalidDeploy::ExceededLaneGasLimit { .. }
             | InvalidDeploy::InvalidPaymentAmount
-            | InvalidDeploy::PricingModeNotSupported => None,
+            | InvalidDeploy::PricingModeNotSupported
+            | InvalidDeploy::TargetingPackageVersionNotSupported => None,
         }
     }
 }

--- a/types/src/transaction/deploy/executable_deploy_item.rs
+++ b/types/src/transaction/deploy/executable_deploy_item.rs
@@ -201,7 +201,7 @@ impl ExecutableDeployItem {
         }
     }
 
-    /// Returns a new `ExecutableDeployItem::StoredVersionedContractByName`.
+    /// Returns a new `ExecutableDeployItem::StoredVersionedKeyContractByName`.
     pub fn new_stored_versioned_contract_by_name(
         name: String,
         version: Option<ContractVersion>,
@@ -278,18 +278,18 @@ impl ExecutableDeployItem {
                     AddressableEntityIdentifier::Name(name.clone()),
                 )
             }
-            ExecutableDeployItem::StoredVersionedContractByHash { hash, version, .. } => {
-                ExecutableDeployItemIdentifier::Package(PackageIdentifier::Hash {
-                    package_hash: PackageHash::new(hash.value()),
-                    version: *version,
-                })
-            }
-            ExecutableDeployItem::StoredVersionedContractByName { name, version, .. } => {
-                ExecutableDeployItemIdentifier::Package(PackageIdentifier::Name {
-                    name: name.clone(),
-                    version: *version,
-                })
-            }
+            ExecutableDeployItem::StoredVersionedContractByHash {
+                hash, version: _, ..
+            } => ExecutableDeployItemIdentifier::Package(PackageIdentifier::HashWithVersion {
+                package_hash: PackageHash::new(hash.value()),
+                version_key: None,
+            }),
+            ExecutableDeployItem::StoredVersionedContractByName {
+                name, version: _, ..
+            } => ExecutableDeployItemIdentifier::Package(PackageIdentifier::NameWithVersion {
+                name: name.clone(),
+                version_key: None,
+            }),
             ExecutableDeployItem::Transfer { .. } => ExecutableDeployItemIdentifier::Transfer,
         }
     }
@@ -318,18 +318,18 @@ impl ExecutableDeployItem {
             | ExecutableDeployItem::StoredContractByName { .. }
             | ExecutableDeployItem::Transfer { .. } => None,
 
-            ExecutableDeployItem::StoredVersionedContractByHash { hash, version, .. } => {
-                Some(PackageIdentifier::Hash {
-                    package_hash: PackageHash::new(hash.value()),
-                    version: *version,
-                })
-            }
-            ExecutableDeployItem::StoredVersionedContractByName { name, version, .. } => {
-                Some(PackageIdentifier::Name {
-                    name: name.clone(),
-                    version: *version,
-                })
-            }
+            ExecutableDeployItem::StoredVersionedContractByHash {
+                hash, version: _, ..
+            } => Some(PackageIdentifier::HashWithVersion {
+                package_hash: PackageHash::new(hash.value()),
+                version_key: None,
+            }),
+            ExecutableDeployItem::StoredVersionedContractByName {
+                name, version: _, ..
+            } => Some(PackageIdentifier::NameWithVersion {
+                name: name.clone(),
+                version_key: None,
+            }),
         }
     }
 

--- a/types/src/transaction/deploy/executable_deploy_item.rs
+++ b/types/src/transaction/deploy/executable_deploy_item.rs
@@ -278,18 +278,18 @@ impl ExecutableDeployItem {
                     AddressableEntityIdentifier::Name(name.clone()),
                 )
             }
-            ExecutableDeployItem::StoredVersionedContractByHash {
-                hash, version: _, ..
-            } => ExecutableDeployItemIdentifier::Package(PackageIdentifier::HashWithVersion {
-                package_hash: PackageHash::new(hash.value()),
-                version_key: None,
-            }),
-            ExecutableDeployItem::StoredVersionedContractByName {
-                name, version: _, ..
-            } => ExecutableDeployItemIdentifier::Package(PackageIdentifier::NameWithVersion {
-                name: name.clone(),
-                version_key: None,
-            }),
+            ExecutableDeployItem::StoredVersionedContractByHash { hash, version, .. } => {
+                ExecutableDeployItemIdentifier::Package(PackageIdentifier::Hash {
+                    package_hash: PackageHash::new(hash.value()),
+                    version: *version,
+                })
+            }
+            ExecutableDeployItem::StoredVersionedContractByName { name, version, .. } => {
+                ExecutableDeployItemIdentifier::Package(PackageIdentifier::Name {
+                    name: name.clone(),
+                    version: *version,
+                })
+            }
             ExecutableDeployItem::Transfer { .. } => ExecutableDeployItemIdentifier::Transfer,
         }
     }

--- a/types/src/transaction/package_identifier.rs
+++ b/types/src/transaction/package_identifier.rs
@@ -42,12 +42,15 @@ pub enum PackageIdentifier {
         /// The hash of the contract package.
         package_hash: PackageHash,
         /// The version of the contract package.
+        ///
+        /// `None` implies latest version.
         version: Option<EntityVersion>,
     },
     /// The name and optional version identifying the contract package.
     Name {
         /// The name of the contract package.
         name: String,
+        /// The version of the contract package.
         ///
         /// `None` implies latest version.
         version: Option<EntityVersion>,
@@ -264,11 +267,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn json_serialization_roundtrip() {
+    fn bytesrepr_roundtrip() {
         let rng = &mut TestRng::new();
-        let p_id = PackageIdentifier::random(rng);
-        let json_str = serde_json::to_string(&p_id).unwrap();
-        let deserialized = serde_json::from_str::<PackageIdentifier>(&json_str).unwrap();
-        assert_eq!(p_id, deserialized);
+        bytesrepr::test_serialization_roundtrip(&PackageIdentifier::random(rng));
     }
 }

--- a/types/src/transaction/package_identifier.rs
+++ b/types/src/transaction/package_identifier.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "datasize")]
@@ -12,9 +12,17 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(any(feature = "testing", test))]
 use crate::testing::TestRng;
-use crate::{EntityVersionKey, PackageHash};
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    EntityVersion, EntityVersionKey, PackageHash,
+};
 #[cfg(doc)]
 use crate::{ExecutableDeployItem, TransactionTarget};
+
+const HASH_TAG: u8 = 0;
+const NAME_TAG: u8 = 1;
+const HASH_WITH_VERSION_TAG: u8 = 2;
+const NAME_WITH_VERSION_TAG: u8 = 3;
 
 /// Identifier for the package object within a [`TransactionTarget::Stored`] or an
 /// [`ExecutableDeployItem`].
@@ -29,6 +37,21 @@ use crate::{ExecutableDeployItem, TransactionTarget};
     )
 )]
 pub enum PackageIdentifier {
+    /// The hash and optional version identifying the contract package.
+    Hash {
+        /// The hash of the contract package.
+        package_hash: PackageHash,
+        /// The version of the contract package.
+        version: Option<EntityVersion>,
+    },
+    /// The name and optional version identifying the contract package.
+    Name {
+        /// The name of the contract package.
+        name: String,
+        ///
+        /// `None` implies latest version.
+        version: Option<EntityVersion>,
+    },
     /// The hash and optional version key identifying the contract package.
     HashWithVersion {
         /// The hash of the contract package.
@@ -53,10 +76,25 @@ impl PackageIdentifier {
     /// Returns the optional version of the contract package.
     ///
     /// `None` implies latest version.
+    #[deprecated(since = "5.0.1", note = "please use `version_key` instead")]
+    pub fn version(&self) -> Option<EntityVersion> {
+        match self {
+            PackageIdentifier::HashWithVersion { .. }
+            | PackageIdentifier::NameWithVersion { .. } => None,
+            PackageIdentifier::Hash { version, .. } | PackageIdentifier::Name { version, .. } => {
+                *version
+            }
+        }
+    }
+
+    /// Returns the optional version key of the contract package.
+    ///
+    /// `None` implies latest version.
     pub fn version_key(&self) -> Option<EntityVersionKey> {
         match self {
             PackageIdentifier::HashWithVersion { version_key, .. }
             | PackageIdentifier::NameWithVersion { version_key, .. } => *version_key,
+            PackageIdentifier::Hash { .. } | PackageIdentifier::Name { .. } => None,
         }
     }
 
@@ -81,6 +119,30 @@ impl PackageIdentifier {
 impl Display for PackageIdentifier {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
+            PackageIdentifier::Hash {
+                package_hash: contract_package_hash,
+                version: Some(ver),
+            } => write!(
+                formatter,
+                "package-id({}, version {})",
+                HexFmt(contract_package_hash),
+                ver
+            ),
+            PackageIdentifier::Hash {
+                package_hash: contract_package_hash,
+                ..
+            } => write!(
+                formatter,
+                "package-id({}, latest)",
+                HexFmt(contract_package_hash),
+            ),
+            PackageIdentifier::Name {
+                name,
+                version: Some(ver),
+            } => write!(formatter, "package-id({}, version {})", name, ver),
+            PackageIdentifier::Name { name, .. } => {
+                write!(formatter, "package-id({}, latest)", name)
+            }
             PackageIdentifier::HashWithVersion {
                 package_hash,
                 version_key,
@@ -95,6 +157,104 @@ impl Display for PackageIdentifier {
             PackageIdentifier::NameWithVersion { name, version_key } => {
                 write!(formatter, "package-id({}, {:?})", name, version_key)
             }
+        }
+    }
+}
+
+impl ToBytes for PackageIdentifier {
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        match self {
+            PackageIdentifier::Hash {
+                package_hash,
+                version,
+            } => {
+                HASH_TAG.write_bytes(writer)?;
+                package_hash.write_bytes(writer)?;
+                version.write_bytes(writer)
+            }
+            PackageIdentifier::HashWithVersion {
+                package_hash,
+                version_key,
+            } => {
+                HASH_WITH_VERSION_TAG.write_bytes(writer)?;
+                package_hash.write_bytes(writer)?;
+                version_key.write_bytes(writer)
+            }
+            PackageIdentifier::Name { name, version } => {
+                NAME_TAG.write_bytes(writer)?;
+                name.write_bytes(writer)?;
+                version.write_bytes(writer)
+            }
+            PackageIdentifier::NameWithVersion { name, version_key } => {
+                NAME_WITH_VERSION_TAG.write_bytes(writer)?;
+                name.write_bytes(writer)?;
+                version_key.write_bytes(writer)
+            }
+        }
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut buffer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
+            + match self {
+                PackageIdentifier::Hash {
+                    package_hash,
+                    version,
+                } => package_hash.serialized_length() + version.serialized_length(),
+                PackageIdentifier::Name { name, version } => {
+                    name.serialized_length() + version.serialized_length()
+                }
+                PackageIdentifier::HashWithVersion {
+                    package_hash,
+                    version_key,
+                } => package_hash.serialized_length() + version_key.serialized_length(),
+                PackageIdentifier::NameWithVersion { name, version_key } => {
+                    name.serialized_length() + version_key.serialized_length()
+                }
+            }
+    }
+}
+
+impl FromBytes for PackageIdentifier {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, remainder) = u8::from_bytes(bytes)?;
+        match tag {
+            HASH_TAG => {
+                let (package_hash, remainder) = PackageHash::from_bytes(remainder)?;
+                let (version, remainder) = Option::<EntityVersion>::from_bytes(remainder)?;
+                let id = PackageIdentifier::Hash {
+                    package_hash,
+                    version,
+                };
+                Ok((id, remainder))
+            }
+            NAME_TAG => {
+                let (name, remainder) = String::from_bytes(remainder)?;
+                let (version, remainder) = Option::<EntityVersion>::from_bytes(remainder)?;
+                let id = PackageIdentifier::Name { name, version };
+                Ok((id, remainder))
+            }
+            HASH_WITH_VERSION_TAG => {
+                let (package_hash, remainder) = PackageHash::from_bytes(remainder)?;
+                let (version_key, remainder) = Option::<EntityVersionKey>::from_bytes(remainder)?;
+                let id = PackageIdentifier::HashWithVersion {
+                    package_hash,
+                    version_key,
+                };
+                Ok((id, remainder))
+            }
+            NAME_WITH_VERSION_TAG => {
+                let (name, remainder) = String::from_bytes(remainder)?;
+                let (version_key, remainder) = Option::<EntityVersionKey>::from_bytes(remainder)?;
+                let id = PackageIdentifier::NameWithVersion { name, version_key };
+                Ok((id, remainder))
+            }
+            _ => Err(bytesrepr::Error::Formatting),
         }
     }
 }

--- a/types/src/transaction/transaction_invocation_target.rs
+++ b/types/src/transaction/transaction_invocation_target.rs
@@ -55,24 +55,28 @@ pub enum TransactionInvocationTarget {
             schemars(with = "String", description = "Hex-encoded address of the package.")
         )]
         addr: PackageAddr,
-        /// This field is considered unused, it needs to stay in the type definition for backwards compatibility
+        /// This field is considered unused, it needs to stay in the type definition for backwards
+        /// compatibility
         version: Option<EntityVersion>,
         /// The package version key.
         ///
-        /// If `None`, the latest enabled version is implied. From a serializatoin point of view `None`
-        /// means that this field should NOT have an entry in the calltable serialization representation
+        /// If `None`, the latest enabled version is implied. From a serializatoin point of view
+        /// `None` means that this field should NOT have an entry in the calltable
+        /// serialization representation
         version_key: Option<EntityVersionKey>,
     },
     /// The alias and optional version identifying the package.
     ByPackageName {
         /// The package name.
         name: String,
-        /// This field is considered unused, it needs to stay in the type definition for backwards compatibility
+        /// This field is considered unused, it needs to stay in the type definition for backwards
+        /// compatibility
         version: Option<EntityVersion>,
         /// The package version key.
         ///
-        /// If `None`, the latest enabled version is implied. From a serializatoin point of view `None`
-        /// means that this field should NOT have an entry in the calltable serialization representation
+        /// If `None`, the latest enabled version is implied. From a serializatoin point of view
+        /// `None` means that this field should NOT have an entry in the calltable
+        /// serialization representation
         version_key: Option<EntityVersionKey>,
     },
 }
@@ -271,8 +275,9 @@ impl ToBytes for TransactionInvocationTarget {
                         .add_field(BY_PACKAGE_HASH_ADDR_INDEX, &addr)?
                         .add_field(BY_PACKAGE_HASH_VERSION_INDEX, &version)?;
                 if let Some(version_key) = version_key {
-                    //We do this to support transactions that were created before the `version_key` fix.
-                    // The pre-fix transactions will not have a BY_PACKAGE_HASH_VERSION_KEY_INDEX entry and
+                    //We do this to support transactions that were created before the `version_key`
+                    // fix. The pre-fix transactions will not have a
+                    // BY_PACKAGE_HASH_VERSION_KEY_INDEX entry and
                     builder = builder.add_field(BY_PACKAGE_HASH_VERSION_KEY_INDEX, &version_key)?;
                 }
                 builder.binary_payload_bytes()
@@ -288,7 +293,8 @@ impl ToBytes for TransactionInvocationTarget {
                         .add_field(BY_PACKAGE_NAME_NAME_INDEX, &name)?
                         .add_field(BY_PACKAGE_NAME_VERSION_INDEX, &version)?;
                 if let Some(version_key) = version_key {
-                    //We do this hooplah to support transactions that were created before the `version_key` fix
+                    //We do this hooplah to support transactions that were created before the
+                    // `version_key` fix
                     builder = builder.add_field(BY_PACKAGE_NAME_VERSION_KEY_INDEX, &version_key)?;
                 }
                 builder.binary_payload_bytes()
@@ -499,7 +505,8 @@ mod tests {
             version_key: None,
         };
         let expected_bytes = expected.to_bytes().unwrap();
-        assert_eq!(bytes, expected_bytes); //We want the "legacy" binary representation and current representation without version_key equal
+        assert_eq!(bytes, expected_bytes); //We want the "legacy" binary representation and current representation without version_key
+                                           // equal
 
         let (got, remainder) = TransactionInvocationTarget::from_bytes(&bytes).unwrap();
         assert_eq!(expected, got);
@@ -531,7 +538,8 @@ mod tests {
             version_key: None,
         };
         let expected_bytes = expected.to_bytes().unwrap();
-        assert_eq!(bytes, expected_bytes); //We want the "legacy" binary representation and current representation without version_key equal
+        assert_eq!(bytes, expected_bytes); //We want the "legacy" binary representation and current representation without version_key
+                                           // equal
 
         let (got, remainder) = TransactionInvocationTarget::from_bytes(&bytes).unwrap();
         assert_eq!(expected, got);
@@ -547,7 +555,8 @@ mod tests {
         };
         let bytes = target.to_bytes().unwrap();
         let (number_of_fields, _) = u32::from_bytes(&bytes).unwrap();
-        assert_eq!(number_of_fields, 4); //We want the enum tag, addr, version (even if it's None) and version_key to have been serialized
+        assert_eq!(number_of_fields, 4); //We want the enum tag, addr, version (even if it's None) and version_key to have been
+                                         // serialized
         let (got, remainder) = TransactionInvocationTarget::from_bytes(&bytes).unwrap();
         assert_eq!(target, got);
         assert!(remainder.is_empty());
@@ -562,7 +571,8 @@ mod tests {
         };
         let bytes = target.to_bytes().unwrap();
         let (number_of_fields, _) = u32::from_bytes(&bytes).unwrap();
-        assert_eq!(number_of_fields, 4); //We want the enum tag, addr, version (even if it's None) and version_key to have been serialized
+        assert_eq!(number_of_fields, 4); //We want the enum tag, addr, version (even if it's None) and version_key to have been
+                                         // serialized
         let (got, remainder) = TransactionInvocationTarget::from_bytes(&bytes).unwrap();
         assert_eq!(target, got);
         assert!(remainder.is_empty());

--- a/types/src/transaction/transaction_invocation_target.rs
+++ b/types/src/transaction/transaction_invocation_target.rs
@@ -93,11 +93,34 @@ impl TransactionInvocationTarget {
     }
 
     /// Returns a new `TransactionInvocationTarget::Package`.
+    #[deprecated(since = "5.0.1", note = "please use `new_package_with_key` instead")]
+    pub fn new_package(hash: PackageHash, version: Option<EntityVersion>) -> Self {
+        TransactionInvocationTarget::ByPackageHash {
+            addr: hash.value(),
+            version,
+            version_key: None,
+        }
+    }
+
+    /// Returns a new `TransactionInvocationTarget::Package`.
     pub fn new_package_with_key(hash: PackageHash, version_key: Option<EntityVersionKey>) -> Self {
         TransactionInvocationTarget::ByPackageHash {
             addr: hash.value(),
             version: None,
             version_key,
+        }
+    }
+
+    /// Returns a new `TransactionInvocationTarget::PackageAlias`.
+    #[deprecated(
+        since = "5.0.1",
+        note = "please use `new_package_alias_with_key` instead"
+    )]
+    pub fn new_package_alias(alias: String, version: Option<EntityVersion>) -> Self {
+        TransactionInvocationTarget::ByPackageName {
+            name: alias,
+            version,
+            version_key: None,
         }
     }
 

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -276,7 +276,8 @@ pub enum InvalidTransaction {
         attempted: U512,
     },
 
-    // Passing TransactionInvocationTarget::ByPackageHash::version or TransactionInvocationTarget::ByPackageName::version is no longer supported
+    // Passing TransactionInvocationTarget::ByPackageHash::version or
+    // TransactionInvocationTarget::ByPackageName::version is no longer supported
     TargetingPackageVersionNotSupported,
 }
 

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -275,239 +275,243 @@ pub enum InvalidTransaction {
         /// The attempted amount.
         attempted: U512,
     },
+
+    // Passing TransactionInvocationTarget::ByPackageHash::version or TransactionInvocationTarget::ByPackageName::version is no longer supported
+    TargetingPackageVersionNotSupported,
 }
 
 impl Display for InvalidTransaction {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
             InvalidTransaction::InvalidChainName { expected, got } => {
-                                write!(
-                                    formatter,
-                                    "invalid chain name: expected {expected}, got {got}"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "invalid chain name: expected {expected}, got {got}"
+                                        )
+                                    }
             InvalidTransaction::ExcessiveSize(error) => {
-                                write!(formatter, "transaction size too large: {error}")
-                            }
+                                        write!(formatter, "transaction size too large: {error}")
+                                    }
             InvalidTransaction::ExcessiveTimeToLive { max_ttl, got } => {
-                                write!(
-                                    formatter,
-                                    "time-to-live of {got} exceeds limit of {max_ttl}"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "time-to-live of {got} exceeds limit of {max_ttl}"
+                                        )
+                                    }
             InvalidTransaction::TimestampInFuture {
-                                validation_timestamp,
-                                timestamp_leeway,
-                                got,
-                            } => {
-                                write!(
-                                    formatter,
-                                    "timestamp of {got} is later than node's validation timestamp of \
+                                        validation_timestamp,
+                                        timestamp_leeway,
+                                        got,
+                                    } => {
+                                        write!(
+                                            formatter,
+                                            "timestamp of {got} is later than node's validation timestamp of \
                     {validation_timestamp} plus leeway of {timestamp_leeway}"
-                                )
-                            }
+                                        )
+                                    }
             InvalidTransaction::InvalidBodyHash => {
-                                write!(
-                                    formatter,
-                                    "the provided hash does not match the actual hash of the transaction body"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "the provided hash does not match the actual hash of the transaction body"
+                                        )
+                                    }
             InvalidTransaction::InvalidTransactionHash => {
-                                write!(
-                                    formatter,
-                                    "the provided hash does not match the actual hash of the transaction"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "the provided hash does not match the actual hash of the transaction"
+                                        )
+                                    }
             InvalidTransaction::EmptyApprovals => {
-                                write!(formatter, "the transaction has no approvals")
-                            }
+                                        write!(formatter, "the transaction has no approvals")
+                                    }
             InvalidTransaction::InvalidApproval { index, error } => {
-                                write!(
-                                    formatter,
-                                    "the transaction approval at index {index} is invalid: {error}"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "the transaction approval at index {index} is invalid: {error}"
+                                        )
+                                    }
             InvalidTransaction::ExcessiveArgsLength { max_length, got } => {
-                                write!(
-                                    formatter,
-                                    "serialized transaction runtime args of {got} bytes exceeds limit of \
+                                        write!(
+                                            formatter,
+                                            "serialized transaction runtime args of {got} bytes exceeds limit of \
                     {max_length} bytes"
-                                )
-                            }
+                                        )
+                                    }
             InvalidTransaction::ExcessiveApprovals {
-                                max_associated_keys,
-                                got,
-                            } => {
-                                write!(
-                                    formatter,
-                                    "number of transaction approvals {got} exceeds the maximum number of \
+                                        max_associated_keys,
+                                        got,
+                                    } => {
+                                        write!(
+                                            formatter,
+                                            "number of transaction approvals {got} exceeds the maximum number of \
                     associated keys {max_associated_keys}",
-                                )
-                            }
+                                        )
+                                    }
             InvalidTransaction::ExceedsBlockGasLimit {
-                                block_gas_limit,
-                                got,
-                            } => {
-                                write!(
-                                    formatter,
-                                    "payment amount of {got} exceeds the block gas limit of {block_gas_limit}"
-                                )
-                            }
+                                        block_gas_limit,
+                                        got,
+                                    } => {
+                                        write!(
+                                            formatter,
+                                            "payment amount of {got} exceeds the block gas limit of {block_gas_limit}"
+                                        )
+                                    }
             InvalidTransaction::MissingArg { arg_name } => {
-                                write!(formatter, "missing required runtime argument '{arg_name}'")
-                            }
+                                        write!(formatter, "missing required runtime argument '{arg_name}'")
+                                    }
             InvalidTransaction::UnexpectedArgType {
-                                arg_name,
-                                expected,
-                                got,
-                            } => {
-                                write!(
-                                    formatter,
-                                    "expected type of '{arg_name}' runtime argument to be one of {}, but got {got}",
-                                    DisplayIter::new(expected)
-                                )
-                            }
+                                        arg_name,
+                                        expected,
+                                        got,
+                                    } => {
+                                        write!(
+                                            formatter,
+                                            "expected type of '{arg_name}' runtime argument to be one of {}, but got {got}",
+                                            DisplayIter::new(expected)
+                                        )
+                                    }
             InvalidTransaction::InvalidArg { arg_name, error } => {
-                                write!(formatter, "invalid runtime argument '{arg_name}': {error}")
-                            }
+                                        write!(formatter, "invalid runtime argument '{arg_name}': {error}")
+                                    }
             InvalidTransaction::InsufficientTransferAmount { minimum, attempted } => {
-                                write!(
-                                    formatter,
-                                    "insufficient transfer amount; minimum: {minimum} attempted: {attempted}"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "insufficient transfer amount; minimum: {minimum} attempted: {attempted}"
+                                        )
+                                    }
             InvalidTransaction::EntryPointCannotBeCall => {
-                                write!(formatter, "entry point cannot be call")
-                            }
+                                        write!(formatter, "entry point cannot be call")
+                                    }
             InvalidTransaction::EntryPointCannotBeCustom { entry_point } => {
-                                write!(formatter, "entry point cannot be custom: {entry_point}")
-                            }
+                                        write!(formatter, "entry point cannot be custom: {entry_point}")
+                                    }
             InvalidTransaction::EntryPointMustBeCustom { entry_point } => {
-                                write!(formatter, "entry point must be custom: {entry_point}")
-                            }
+                                        write!(formatter, "entry point must be custom: {entry_point}")
+                                    }
             InvalidTransaction::EmptyModuleBytes => {
-                                write!(formatter, "the transaction has empty module bytes")
-                            }
+                                        write!(formatter, "the transaction has empty module bytes")
+                                    }
             InvalidTransaction::GasPriceConversion { amount, gas_price } => {
-                                write!(
-                                    formatter,
-                                    "failed to divide the amount {} by the gas price {}",
-                                    amount, gas_price
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "failed to divide the amount {} by the gas price {}",
+                                            amount, gas_price
+                                        )
+                                    }
             InvalidTransaction::UnableToCalculateGasLimit => {
-                                write!(formatter, "unable to calculate gas limit", )
-                            }
+                                        write!(formatter, "unable to calculate gas limit", )
+                                    }
             InvalidTransaction::UnableToCalculateGasCost => {
-                                write!(formatter, "unable to calculate gas cost", )
-                            }
+                                        write!(formatter, "unable to calculate gas cost", )
+                                    }
             InvalidTransaction::InvalidPricingMode { price_mode } => {
-                                write!(
-                                    formatter,
-                                    "received a transaction with an invalid mode {price_mode}"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "received a transaction with an invalid mode {price_mode}"
+                                        )
+                                    }
             InvalidTransaction::InvalidTransactionLane(kind) => {
-                                write!(
-                                    formatter,
-                                    "received a transaction with an invalid kind {kind}"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "received a transaction with an invalid kind {kind}"
+                                        )
+                                    }
             InvalidTransaction::GasPriceToleranceTooLow {
-                                min_gas_price_tolerance,
-                                provided_gas_price_tolerance,
-                            } => {
-                                write!(
-                                    formatter,
-                                    "received a transaction with gas price tolerance {} but this chain will only go as low as {}",
-                                    provided_gas_price_tolerance, min_gas_price_tolerance
-                                )
-                            }
+                                        min_gas_price_tolerance,
+                                        provided_gas_price_tolerance,
+                                    } => {
+                                        write!(
+                                            formatter,
+                                            "received a transaction with gas price tolerance {} but this chain will only go as low as {}",
+                                            provided_gas_price_tolerance, min_gas_price_tolerance
+                                        )
+                                    }
             InvalidTransaction::CouldNotDeserializeField { error } => {
-                                match error {
-                                    FieldDeserializationError::IndexNotExists { index } => write!(
-                                        formatter,
-                                        "tried to deserialize a field under index {} but it is not present in the payload",
-                                        index
-                                    ),
-                                    FieldDeserializationError::FromBytesError { index, error } => write!(
-                                        formatter,
-                                        "tried to deserialize a field under index {} but it failed with error: {}",
-                                        index,
-                                        error
-                                    ),
-                                    FieldDeserializationError::LingeringBytesInField { index } => write!(
-                                        formatter,
-                                        "tried to deserialize a field under index {} but after deserialization there were still bytes left",
-                                        index,
-                                    ),
-                                }
-                            }
+                                        match error {
+                                            FieldDeserializationError::IndexNotExists { index } => write!(
+                                                formatter,
+                                                "tried to deserialize a field under index {} but it is not present in the payload",
+                                                index
+                                            ),
+                                            FieldDeserializationError::FromBytesError { index, error } => write!(
+                                                formatter,
+                                                "tried to deserialize a field under index {} but it failed with error: {}",
+                                                index,
+                                                error
+                                            ),
+                                            FieldDeserializationError::LingeringBytesInField { index } => write!(
+                                                formatter,
+                                                "tried to deserialize a field under index {} but after deserialization there were still bytes left",
+                                                index,
+                                            ),
+                                        }
+                                    }
             InvalidTransaction::CannotCalculateFieldsHash => write!(
-                                formatter,
-                                "cannot calculate a hash digest for the transaction"
-                            ),
+                                        formatter,
+                                        "cannot calculate a hash digest for the transaction"
+                                    ),
             InvalidTransaction::EntryPointMustBeCall { entry_point } => {
-                        write!(formatter, "entry point must be call: {entry_point}")
-                    }
+                                write!(formatter, "entry point must be call: {entry_point}")
+                            }
             InvalidTransaction::NoLaneMatch => write!(formatter, "Could not match any lane to the specified transaction"),
             InvalidTransaction::UnexpectedTransactionFieldEntries => write!(formatter, "There were entries in the fields map of the payload that could not be matched"),
             InvalidTransaction::ExpectedNamedArguments => {
-                                write!(formatter, "transaction requires named arguments")
-                            }
+                                        write!(formatter, "transaction requires named arguments")
+                                    }
             InvalidTransaction::ExpectedBytesArguments => {
-                                write!(formatter, "transaction requires bytes arguments")
-                            }
+                                        write!(formatter, "transaction requires bytes arguments")
+                                    }
             InvalidTransaction::InvalidTransactionRuntime { expected } => {
-                                write!(
-                                    formatter,
-                                    "invalid transaction runtime: expected {expected}"
-                                )
-                            }
+                                        write!(
+                                            formatter,
+                                            "invalid transaction runtime: expected {expected}"
+                                        )
+                                    }
             InvalidTransaction::MissingSeed => {
-                                write!(formatter, "missing seed for install or upgrade")
-                            }
+                                        write!(formatter, "missing seed for install or upgrade")
+                                    }
             InvalidTransaction::PricingModeNotSupported => {
-                                write!(formatter, "Pricing mode not supported")
-                            }
+                                        write!(formatter, "Pricing mode not supported")
+                                    }
             InvalidTransaction::InvalidPaymentAmount => {
-                                write!(formatter, "invalid payment amount")
-                            }
+                                        write!(formatter, "invalid payment amount")
+                                    }
             InvalidTransaction::UnexpectedEntryPoint {
-                                entry_point, lane_id
-                            } => {
-                                write!(formatter, "unexpected entry_point {} lane_id {}", entry_point, lane_id)
-                            }
+                                        entry_point, lane_id
+                                    } => {
+                                        write!(formatter, "unexpected entry_point {} lane_id {}", entry_point, lane_id)
+                                    }
             InvalidTransaction::InsufficientBurnAmount { minimum, attempted } => {
-                                write!(formatter, "insufficient burn amount: {minimum} {attempted}")
-                            }
+                                        write!(formatter, "insufficient burn amount: {minimum} {attempted}")
+                                    }
             InvalidTransaction::CouldNotSerializeTransaction => write!(formatter, "Could not serialize transaction."),
             InvalidTransaction::InsufficientAmount { attempted } => {
-                        write!(
-                            formatter,
-                            "the value provided for the argument ({attempted}) named amount is too low.",
-                        )
-                    }
+                                write!(
+                                    formatter,
+                                    "the value provided for the argument ({attempted}) named amount is too low.",
+                                )
+                            }
             InvalidTransaction::InvalidMinimumDelegationAmount { floor, attempted } => {
-                        write!(
-                            formatter,
-                            "the value provided for the minimum delegation amount ({attempted}) cannot be lower than {floor}.",
-                        )}
+                                write!(
+                                    formatter,
+                                    "the value provided for the minimum delegation amount ({attempted}) cannot be lower than {floor}.",
+                                )}
             InvalidTransaction::InvalidMaximumDelegationAmount { ceiling, attempted } => {
-                        write!(
-                            formatter,
-                            "the value provided for the maximum delegation amount ({ceiling}) cannot be higher than {attempted}.",
-                        )}
+                                write!(
+                                    formatter,
+                                    "the value provided for the maximum delegation amount ({ceiling}) cannot be higher than {attempted}.",
+                                )}
             InvalidTransaction::InvalidReservedSlots { ceiling, attempted } => {
-                        write!(
-                            formatter,
-                            "the value provided for reserved slots ({ceiling}) cannot be higher than {attempted}.",
-                        )}
+                                write!(
+                                    formatter,
+                                    "the value provided for reserved slots ({ceiling}) cannot be higher than {attempted}.",
+                                )}
             InvalidTransaction::InvalidDelegationAmount { ceiling, attempted } => {
-                write!(
-                formatter,
-                "the value provided for the delegation amount ({attempted}) cannot be higher than {ceiling}.",
-                )}
+                        write!(
+                        formatter,
+                        "the value provided for the delegation amount ({attempted}) cannot be higher than {ceiling}.",
+                        )}
+            InvalidTransaction::TargetingPackageVersionNotSupported =>  write!(formatter, "passing `version` in TransactionInvocationTarget::ByPackageHash or TransactionInvocationTarget::ByPackageName is not supported",),
         }
     }
 }
@@ -569,7 +573,8 @@ impl StdError for InvalidTransaction {
             | InvalidTransaction::InvalidMinimumDelegationAmount { .. }
             | InvalidTransaction::InvalidMaximumDelegationAmount { .. }
             | InvalidTransaction::InvalidReservedSlots { .. }
-            | InvalidTransaction::InvalidDelegationAmount { .. } => None,
+            | InvalidTransaction::InvalidDelegationAmount { .. }
+            | InvalidTransaction::TargetingPackageVersionNotSupported => None,
         }
     }
 }


### PR DESCRIPTION
…onInvocationTarget::ByPackageName::version; ExecutableDeployItem::StoredVersionedContractByHash::version; ExecutableDeployItem::StoredVersionedContractByName::version fields obsolete. Also added `version_key` to TransactionInvocationTarget::ByPackageHash; TransactionInvocationTarget::ByPackageName

This change will have an effect on:
* casper-sidecar
* casper-client-rs
