### PR TITLE
Fix: Update logo display and Discord URL README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![LOGO](https://raw.githubusercontent.com/casper-network/casper-node/master/images/casper-association-logo-new.svg)](https://casper.network/)
+<a href="https://casper.network/"><img src="images/Casper-association-logo-new.svg" alt="Casper Network Logo" width="300" height="100"></a>
 
 # casper-node
 
@@ -33,7 +33,7 @@ The Casper MainNet is live.
 
 ### Community
 
-- [Discord Server](https://discord.gg/mpZ9AYD)
+- [Discord Server](https://discord.gg/caspernetwork)
 - [Telegram Channel](https://t.me/casperofficialann)
 
 


### PR DESCRIPTION
 Changes Made
- Fixed logo display by updating the image path to use the correct `/images` folder location
- Added HTML formatting to control logo dimensions (width and height)
- Updated Discord URL to the latest version

Technical Details
- Replaced Markdown image syntax with HTML `<img>` tag for better size control
- Image is now properly linked to the Casper Network website
- Logo dimensions can be easily adjusted by modifying the width and height attributes

Testing
- Verified logo displays correctly in the documentation
- Confirmed image is properly linked to casper.network
- Tested Discord URL functionality 