### PR TITLE
Casper-node to 2.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "2.1.0"
+version = "2.0.2"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "2.1.0" # when updating, also update 'html_root_url' in lib.rs
+version = "2.0.2" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Ed Hastings <ed@casper.network>", "Karan Dhareshwar <karan@casper.network>"]
 edition = "2021"
 description = "The Casper blockchain node"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/2.1.0")]
+#![doc(html_root_url = "https://docs.rs/casper-node/2.0.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon_48.png",
     html_logo_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon.png",


### PR DESCRIPTION
Setting casper-node at 2.0.2 for next release.