### PR TITLE
Rename trap flag

### DIFF
--- a/execution_engine/src/engine_state/engine_config.rs
+++ b/execution_engine/src/engine_state/engine_config.rs
@@ -53,7 +53,7 @@ pub const DEFAULT_BALANCE_HOLD_INTERVAL: TimeDiff = TimeDiff::from_seconds(24 * 
 /// Default entity flag.
 pub const DEFAULT_ENABLE_ENTITY: bool = false;
 
-pub(crate) const DEFAULT_RETURN_ERROR_ON_COLLISION: bool = false;
+pub(crate) const DEFAULT_TRAP_ON_AMBIGUOUS_ENTITY_VERSION: bool = false;
 
 /// The runtime configuration of the execution engine
 #[derive(Debug, Clone)]
@@ -92,7 +92,7 @@ pub struct EngineConfig {
     /// Compute auction rewards.
     pub(crate) compute_rewards: bool,
     pub(crate) enable_entity: bool,
-    pub(crate) return_error_on_collision: bool,
+    pub(crate) trap_on_ambiguous_entity_version: bool,
     storage_costs: StorageCosts,
 }
 
@@ -117,7 +117,7 @@ impl Default for EngineConfig {
             compute_rewards: DEFAULT_COMPUTE_REWARDS,
             protocol_version: DEFAULT_PROTOCOL_VERSION,
             enable_entity: DEFAULT_ENABLE_ENTITY,
-            return_error_on_collision: DEFAULT_RETURN_ERROR_ON_COLLISION,
+            trap_on_ambiguous_entity_version: DEFAULT_TRAP_ON_AMBIGUOUS_ENTITY_VERSION,
             storage_costs: Default::default(),
         }
     }
@@ -219,9 +219,9 @@ impl EngineConfig {
         self.compute_rewards
     }
 
-    /// Returns the flag is the runtime should error on multiple entity version collisions.
-    pub fn return_error_on_collision(&self) -> bool {
-        self.return_error_on_collision
+    /// Returns the `trap_on_ambiguous_entity_version` flag.
+    pub fn trap_on_ambiguous_entity_version(&self) -> bool {
+        self.trap_on_ambiguous_entity_version
     }
 
     /// Sets the protocol version of the config.
@@ -266,7 +266,7 @@ pub struct EngineConfigBuilder {
     compute_rewards: Option<bool>,
     balance_hold_interval: Option<TimeDiff>,
     enable_entity: Option<bool>,
-    return_error_on_collision: Option<bool>,
+    trap_on_ambiguous_entity_version: Option<bool>,
     storage_costs: Option<StorageCosts>,
 }
 
@@ -422,8 +422,11 @@ impl EngineConfigBuilder {
     }
 
     /// Sets the flag if the runtime returns an error on entity version collision.
-    pub fn with_return_error_on_collision(mut self, return_error_on_collision: bool) -> Self {
-        self.return_error_on_collision = Some(return_error_on_collision);
+    pub fn with_trap_on_ambiguous_entity_version(
+        mut self,
+        trap_on_ambiguous_entity_version: bool,
+    ) -> Self {
+        self.trap_on_ambiguous_entity_version = Some(trap_on_ambiguous_entity_version);
         self
     }
 
@@ -480,9 +483,9 @@ impl EngineConfigBuilder {
             .unwrap_or(DEFAULT_MAX_DELEGATORS_PER_VALIDATOR);
         let compute_rewards = self.compute_rewards.unwrap_or(DEFAULT_COMPUTE_REWARDS);
         let enable_entity = self.enable_entity.unwrap_or(DEFAULT_ENABLE_ENTITY);
-        let return_error_on_collision = self
-            .return_error_on_collision
-            .unwrap_or(DEFAULT_RETURN_ERROR_ON_COLLISION);
+        let trap_on_ambiguous_entity_version = self
+            .trap_on_ambiguous_entity_version
+            .unwrap_or(DEFAULT_TRAP_ON_AMBIGUOUS_ENTITY_VERSION);
         let storage_costs = self.storage_costs.unwrap_or_default();
 
         EngineConfig {
@@ -504,7 +507,7 @@ impl EngineConfigBuilder {
             max_delegators_per_validator,
             compute_rewards,
             enable_entity,
-            return_error_on_collision,
+            trap_on_ambiguous_entity_version,
             storage_costs,
         }
     }

--- a/execution_engine/src/execution/error.rs
+++ b/execution_engine/src/execution/error.rs
@@ -195,9 +195,9 @@ pub enum Error {
     /// No matching entity version key.
     #[error("No matching entity version key")]
     NoMatchingEntityVersionKey,
-    /// Multiple entries for one entity version.
-    #[error("Multiple entries for one entity version")]
-    CollisionInEntityVersion,
+    /// Ambiguous entity version and unable to determine entity version key.
+    #[error("Ambiguous entity version")]
+    AmbiguousEntityVersion,
 }
 
 impl From<PreprocessingError> for Error {

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -1534,8 +1534,13 @@ where
             return Err(ExecError::NoMatchingEntityVersionKey);
         }
 
-        if possible_versions.len() > 1 && self.context.engine_config().return_error_on_collision {
-            return Err(ExecError::CollisionInEntityVersion);
+        if possible_versions.len() > 1
+            && self
+                .context
+                .engine_config()
+                .trap_on_ambiguous_entity_version
+        {
+            return Err(ExecError::AmbiguousEntityVersion);
         }
 
         // If possible versions has more than one, then the element to be popped

--- a/execution_engine_testing/test_support/src/execute_request_builder.rs
+++ b/execution_engine_testing/test_support/src/execute_request_builder.rs
@@ -417,6 +417,12 @@ impl ExecuteRequestBuilder {
         self
     }
 
+    /// Sets the protocol version for the execution request
+    pub fn with_protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.protocol_version = protocol_version;
+        self
+    }
+
     /// Consumes self and returns an `ExecuteRequest`.
     pub fn build(self) -> ExecuteRequest {
         let ExecuteRequestBuilder {

--- a/execution_engine_testing/tests/src/test/calling_packages_by_version_query.rs
+++ b/execution_engine_testing/tests/src/test/calling_packages_by_version_query.rs
@@ -354,7 +354,7 @@ fn when_disamiguous_calls_are_disabled_then_ambiguous_call_by_hash_will_fail() {
         .clone();
     assert!(matches!(
         error,
-        Error::Exec(ExecError::CollisionInEntityVersion)
+        Error::Exec(ExecError::AmbiguousEntityVersion)
     ))
 }
 
@@ -388,7 +388,7 @@ fn when_disamiguous_calls_are_disabled_then_ambiguous_call_by_name_will_fail() {
         .clone();
     assert!(matches!(
         error,
-        Error::Exec(ExecError::CollisionInEntityVersion)
+        Error::Exec(ExecError::AmbiguousEntityVersion)
     ))
 }
 
@@ -617,7 +617,7 @@ fn exec_put_key_by_package_hash(
 fn upgrade_version(
     builder: &mut LmdbWasmTestBuilder,
     new_protocol_version_major: ProtocolVersionMajor,
-    should_return_error_on_collision: bool,
+    should_trap_on_ambiguous_entity_version: bool,
 ) {
     if new_protocol_version_major <= 1 {
         panic!("Can't upgrade to 1 or 0 major version");
@@ -637,7 +637,7 @@ fn upgrade_version(
         .with_enable_addressable_entity(false)
         .build();
     let config = EngineConfigBuilder::new()
-        .with_return_error_on_collision(should_return_error_on_collision)
+        .with_trap_on_ambiguous_entity_version(should_trap_on_ambiguous_entity_version)
         .build();
     builder
         .with_block_time(Timestamp::now().into())

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -1627,9 +1627,6 @@ fn should_not_require_monotonic_cases(trap: bool) {
         .expect("must get package as stored value")
         .into_contract_package()
         .expect("must get package");
-
-    let versions = contract_package.versions();
-
     let current_version = contract_package
         .current_contract_version()
         .expect("must have the latest current version");

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -1229,7 +1229,7 @@ fn should_correctly_retain_disabled_contract_version() {
 }
 
 fn setup_state_for_version_tests(
-    should_return_error_on_collision: bool,
+    should_trap_on_ambiguous_entity_version: bool,
 ) -> (LmdbWasmTestBuilder, ContractPackageHash) {
     const THREE_VERSION_FIXTURE: &str = "three_version_fixture";
 
@@ -1253,10 +1253,8 @@ fn setup_state_for_version_tests(
         .build();
 
     let config = EngineConfigBuilder::new()
-        .with_return_error_on_collision(should_return_error_on_collision)
+        .with_trap_on_ambiguous_entity_version(should_trap_on_ambiguous_entity_version)
         .build();
-
-    println!("{:?}", config);
 
     builder
         .with_block_time(Timestamp::now().into())
@@ -1283,15 +1281,17 @@ fn setup_state_for_version_tests(
     (builder, contract_package_hash)
 }
 
-fn execute_no_major_some_entity_version_calls(should_return_error_on_collision: bool) {
+fn execute_no_major_some_entity_version_calls(trap_on_ambiguous_entity_version: bool) {
     let (mut builder, contract_package_hash) =
-        setup_state_for_version_tests(should_return_error_on_collision);
+        setup_state_for_version_tests(trap_on_ambiguous_entity_version);
 
     let config = builder.engine_config();
-    println!("{:?}", config);
 
-    let actual_return_err_flag = config.return_error_on_collision();
-    assert_eq!(should_return_error_on_collision, actual_return_err_flag);
+    let actual_trap_on_ambiguous_entity_version = config.trap_on_ambiguous_entity_version();
+    assert_eq!(
+        trap_on_ambiguous_entity_version,
+        actual_trap_on_ambiguous_entity_version
+    );
 
     let runtime_args = runtime_args! {
         "contract_package_hash" => contract_package_hash,
@@ -1361,9 +1361,9 @@ fn execute_no_major_some_entity_version_calls(should_return_error_on_collision: 
         ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, &contract_name, runtime_args)
             .build();
 
-    if actual_return_err_flag {
+    if actual_trap_on_ambiguous_entity_version {
         builder.exec(exec_request).expect_failure();
-        let expected_error = Error::Exec(ExecError::CollisionInEntityVersion);
+        let expected_error = Error::Exec(ExecError::AmbiguousEntityVersion);
         builder.assert_error(expected_error);
         return;
     }
@@ -1574,4 +1574,101 @@ fn should_correctly_invoke_version_in_package_when_no_versions_are_specified() {
             .build();
 
     builder.exec(exec_request).expect_success().commit();
+}
+
+fn should_not_require_monotonic_cases(trap: bool) {
+    let (mut builder, contract_package_hash) = setup_state_for_version_tests(trap);
+
+    let previous_protocol_version = builder.engine_config().protocol_version();
+
+    let new_protocol_version =
+        ProtocolVersion::from_parts(previous_protocol_version.value().major + 1, 0, 0);
+
+    let activation_point = EraId::new(0u64);
+
+    let mut upgrade_request = UpgradeRequestBuilder::new()
+        .with_current_protocol_version(previous_protocol_version)
+        .with_new_protocol_version(new_protocol_version)
+        .with_activation_point(activation_point)
+        .with_new_gas_hold_handling(HoldBalanceHandling::Accrued)
+        .with_new_gas_hold_interval(24 * 60 * 60 * 60)
+        .with_enable_addressable_entity(false)
+        .build();
+
+    builder
+        .with_block_time(Timestamp::now().into())
+        .upgrade_using_scratch(&mut upgrade_request)
+        .expect_upgrade_success();
+
+    let config = EngineConfigBuilder::new()
+        .with_protocol_version(new_protocol_version)
+        .with_trap_on_ambiguous_entity_version(trap)
+        .build();
+
+    builder.with_engine_config(config);
+
+    let config = builder.engine_config();
+    let protocol_version = config.protocol_version();
+
+    let runtime_args = runtime_args! {
+        "contract_package" => contract_package_hash
+    };
+    let exec_request = {
+        let contract_name = format!("{}.wasm", "purse_holder_stored_upgrader_v2_2");
+        ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, &contract_name, runtime_args)
+            .with_protocol_version(protocol_version)
+            .build()
+    };
+
+    builder.exec(exec_request).expect_success().commit();
+
+    let contract_package = builder
+        .query(None, Key::Hash(contract_package_hash.value()), &[])
+        .expect("must get package as stored value")
+        .into_contract_package()
+        .expect("must get package");
+
+    let versions = contract_package.versions();
+
+    let current_version = contract_package
+        .current_contract_version()
+        .expect("must have the latest current version");
+
+    assert_eq!(current_version.protocol_version_major(), 3);
+
+    let runtime_args = runtime_args! {
+        "contract_package_hash" => contract_package_hash,
+        "version" => Some(1),
+        "major_version" => None::<u32>,
+        "entry_point" => "delegate".to_string(),
+        "purse_name" => "v_1_1_purse",
+    };
+
+    let contract_name = format!("{}.wasm", "call_package_version_by_hash");
+    let exec_request =
+        ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, &contract_name, runtime_args)
+            .with_protocol_version(protocol_version)
+            .build();
+
+    if trap {
+        builder.exec(exec_request).expect_failure();
+        let expected_error = Error::Exec(ExecError::AmbiguousEntityVersion);
+        builder.assert_error(expected_error);
+    } else {
+        builder.exec(exec_request).expect_success().commit();
+    }
+}
+
+#[ignore]
+#[test]
+fn should_not_require_monotonic_increasing_versions_to_correctly_identify_version_key_with_trap_set(
+) {
+    should_not_require_monotonic_cases(true)
+}
+
+#[ignore]
+#[test]
+fn should_not_require_monotonic_increasing_versions_to_correctly_identify_version_key_with_trap_unset(
+) {
+    should_not_require_monotonic_cases(false)
 }

--- a/execution_engine_testing/tests/src/test/upgrade.rs
+++ b/execution_engine_testing/tests/src/test/upgrade.rs
@@ -1576,7 +1576,7 @@ fn should_correctly_invoke_version_in_package_when_no_versions_are_specified() {
     builder.exec(exec_request).expect_success().commit();
 }
 
-fn should_not_require_monotonic_cases(trap: bool) {
+fn should_not_require_subsequent_cases(trap: bool) {
     let (mut builder, contract_package_hash) = setup_state_for_version_tests(trap);
 
     let previous_protocol_version = builder.engine_config().protocol_version();
@@ -1658,14 +1658,14 @@ fn should_not_require_monotonic_cases(trap: bool) {
 
 #[ignore]
 #[test]
-fn should_not_require_monotonic_increasing_versions_to_correctly_identify_version_key_with_trap_set(
+fn should_not_require_subsequent_increasing_versions_to_correctly_identify_version_key_with_trap_set(
 ) {
-    should_not_require_monotonic_cases(true)
+    should_not_require_subsequent_cases(true)
 }
 
 #[ignore]
 #[test]
-fn should_not_require_monotonic_increasing_versions_to_correctly_identify_version_key_with_trap_unset(
+fn should_not_require_subsequent_increasing_versions_to_correctly_identify_version_key_with_trap_unset(
 ) {
-    should_not_require_monotonic_cases(false)
+    should_not_require_subsequent_cases(false)
 }

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -150,7 +150,9 @@ impl ContractRuntime {
             .with_refund_handling(chainspec.core_config.refund_handling)
             .with_fee_handling(chainspec.core_config.fee_handling)
             .with_enable_entity(enable_addressable_entity)
-            .with_enable_entity(chainspec.core_config.return_error_on_collision)
+            .with_trap_on_ambiguous_entity_version(
+                chainspec.core_config.trap_on_ambiguous_entity_version,
+            )
             .with_protocol_version(chainspec.protocol_version())
             .with_storage_costs(chainspec.storage_costs)
             .build();

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -170,8 +170,8 @@ enable_addressable_entity = false
 
 # This value is used as the penalty payment amount, the lowest cost, and the minimum balance amount.
 baseline_motes_amount = 2_500_000_000
-# Flag on whether collision of multiple entity versions returns an execution error.
-return_error_on_collision = false
+# Flag on whether ambiguous entity versions returns an execution error.
+trap_on_ambiguous_entity_version = false
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -175,8 +175,8 @@ administrators = []
 enable_addressable_entity = false
 # This value is used as the penalty payment amount, the lowest cost, and the minimum balance amount.
 baseline_motes_amount = 2_500_000_000
-# Flag on whether collision of multiple entity versions returns an execution error.
-return_error_on_collision = false
+# Flag on whether ambiguous entity versions returns an execution error.
+trap_on_ambiguous_entity_version = false
 
 [highway]
 # Highway dynamically chooses its round length, between minimum_block_time and maximum_round_length.

--- a/types/src/chainspec/core_config.rs
+++ b/types/src/chainspec/core_config.rs
@@ -189,7 +189,7 @@ pub struct CoreConfig {
     pub baseline_motes_amount: u64,
     /// The flag on whether the engine will return an error for multiple
     /// entity versions.
-    pub return_error_on_collision: bool,
+    pub trap_on_ambiguous_entity_version: bool,
 }
 
 impl CoreConfig {
@@ -334,7 +334,7 @@ impl CoreConfig {
             validator_credit_cap,
             enable_addressable_entity: DEFAULT_ENABLE_ENTITY,
             baseline_motes_amount: DEFAULT_BASELINE_MOTES_AMOUNT,
-            return_error_on_collision: false,
+            trap_on_ambiguous_entity_version: false,
         }
     }
 }
@@ -381,7 +381,7 @@ impl Default for CoreConfig {
             validator_credit_cap: Ratio::new(1, 5),
             enable_addressable_entity: DEFAULT_ENABLE_ENTITY,
             baseline_motes_amount: DEFAULT_BASELINE_MOTES_AMOUNT,
-            return_error_on_collision: false,
+            trap_on_ambiguous_entity_version: false,
         }
     }
 }
@@ -430,7 +430,7 @@ impl ToBytes for CoreConfig {
         buffer.extend(self.validator_credit_cap.to_bytes()?);
         buffer.extend(self.enable_addressable_entity.to_bytes()?);
         buffer.extend(self.baseline_motes_amount.to_bytes()?);
-        buffer.extend(self.return_error_on_collision.to_bytes()?);
+        buffer.extend(self.trap_on_ambiguous_entity_version.to_bytes()?);
         Ok(buffer)
     }
 
@@ -475,7 +475,7 @@ impl ToBytes for CoreConfig {
             + self.validator_credit_cap.serialized_length()
             + self.enable_addressable_entity.serialized_length()
             + self.baseline_motes_amount.serialized_length()
-            + self.return_error_on_collision.serialized_length()
+            + self.trap_on_ambiguous_entity_version.serialized_length()
     }
 }
 
@@ -520,7 +520,7 @@ impl FromBytes for CoreConfig {
         let (validator_credit_cap, remainder) = Ratio::from_bytes(remainder)?;
         let (enable_addressable_entity, remainder) = FromBytes::from_bytes(remainder)?;
         let (baseline_motes_amount, remainder) = u64::from_bytes(remainder)?;
-        let (return_error_on_collision, remainder) = bool::from_bytes(remainder)?;
+        let (trap_on_ambiguous_entity_version, remainder) = bool::from_bytes(remainder)?;
         let config = CoreConfig {
             era_duration,
             minimum_era_height,
@@ -560,7 +560,7 @@ impl FromBytes for CoreConfig {
             validator_credit_cap,
             enable_addressable_entity,
             baseline_motes_amount,
-            return_error_on_collision,
+            trap_on_ambiguous_entity_version,
         };
         Ok((config, remainder))
     }


### PR DESCRIPTION
CHANGELOG:

- Rename flag in chainspec to trap on when the entity version is ambiguous
- Rename exec error to be more clear