### PR TITLE
Correct typo for script.

### DIFF
--- a/.github/workflows/publish-release-and-crates.yml
+++ b/.github/workflows/publish-release-and-crates.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_TOKEN: ${{ secrets.crates_io_token }}
-        run: ./ci/publish_to_crates.io
+        run: ./ci/publish_to_crates_io.sh
 
       # Add config.tar.gz, bin.tar.gz to release
       - name: Upload files to release


### PR DESCRIPTION
Fix typo in path to crates publish script.
