### PR TITLE
Add keccak256 support to casper_generic_hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "hostname",
  "humantime",
  "itertools 0.10.5",
+ "keccak-hash",
  "linked-hash-map",
  "log",
  "num",
@@ -852,7 +853,7 @@ dependencies = [
  "thiserror 1.0.69",
  "toml 0.8.23",
  "tracing",
- "uint",
+ "uint 0.9.5",
  "walrus",
  "wat",
 ]
@@ -1042,7 +1043,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "uint",
+ "uint 0.9.5",
  "uuid 0.8.2",
  "warp",
  "wheelbuf",
@@ -1127,7 +1128,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
- "uint",
+ "uint 0.9.5",
  "untrusted 0.7.1",
  "url",
  "version-sync",
@@ -2661,6 +2662,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3683,16 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
+]
+
+[[package]]
+name = "keccak-hash"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
+dependencies = [
+ "primitive-types",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -4720,6 +4740,16 @@ checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -6387,6 +6417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6966,6 +7005,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
  "hostname",
  "humantime",
  "itertools 0.10.5",
- "keccak-hash",
+ "keccak-asm",
  "linked-hash-map",
  "log",
  "num",
@@ -853,7 +853,7 @@ dependencies = [
  "thiserror 1.0.69",
  "toml 0.8.23",
  "tracing",
- "uint 0.9.5",
+ "uint",
  "walrus",
  "wat",
 ]
@@ -1043,7 +1043,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "uint 0.9.5",
+ "uint",
  "uuid 0.8.2",
  "warp",
  "wheelbuf",
@@ -1128,7 +1128,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
- "uint 0.9.5",
+ "uint",
  "untrusted 0.7.1",
  "url",
  "version-sync",
@@ -2662,15 +2662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3686,13 +3677,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-hash"
-version = "0.11.0"
+name = "keccak-asm"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
- "primitive-types",
- "tiny-keccak",
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -4740,16 +4731,6 @@ checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
-dependencies = [
- "fixed-hash",
- "uint 0.10.0",
 ]
 
 [[package]]
@@ -5922,6 +5903,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.1",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6414,15 +6405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if 1.0.1",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -7005,18 +6987,6 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
-name = "uint"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -17,6 +17,7 @@ bincode = "1.3.1"
 blake2 = { version = "0.10.6", default-features = false }
 blake3 = { version = "1.5.0", default-features = false, features = ["pure"] }
 sha2 = { version = "0.10.8", default-features = false }
+keccak-hash = { version = "0.11.0", default-features = false }
 casper-storage = { version = "2.1.1", path = "../storage", default-features = true }
 casper-types = { version = "6.0.1", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema", "std"] }
 casper-wasm = { version = "1.0.0", default-features = false, features = ["sign_ext", "call_indirect_overlong"] }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -17,7 +17,7 @@ bincode = "1.3.1"
 blake2 = { version = "0.10.6", default-features = false }
 blake3 = { version = "1.5.0", default-features = false, features = ["pure"] }
 sha2 = { version = "0.10.8", default-features = false }
-keccak-hash = { version = "0.11.0", default-features = false }
+keccak-asm = { version = "0.1.4", default-features = false }
 casper-storage = { version = "2.1.1", path = "../storage", default-features = true }
 casper-types = { version = "6.0.1", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema", "std"] }
 casper-wasm = { version = "1.0.0", default-features = false, features = ["sign_ext", "call_indirect_overlong"] }

--- a/execution_engine/src/runtime/cryptography.rs
+++ b/execution_engine/src/runtime/cryptography.rs
@@ -6,7 +6,7 @@ use blake2::{
     Blake2bVar,
 };
 use keccak_asm::Digest as KeccakDigest;
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 
 /// The number of bytes in a hash.
 /// All hash functions in this module have a digest length of 32.

--- a/execution_engine/src/runtime/cryptography.rs
+++ b/execution_engine/src/runtime/cryptography.rs
@@ -5,6 +5,7 @@ use blake2::{
     digest::{Update, VariableOutput},
     Blake2bVar,
 };
+use keccak_asm::Digest as KeccakDigest;
 use sha2::{Digest, Sha256};
 
 /// The number of bytes in a hash.
@@ -44,5 +45,12 @@ pub fn sha256<T: AsRef<[u8]>>(data: T) -> [u8; DIGEST_LENGTH] {
 
 /// The 32-byte digest keccak256 hash function
 pub fn keccak256<T: AsRef<[u8]>>(data: T) -> [u8; DIGEST_LENGTH] {
-    keccak_hash::keccak(data).to_fixed_bytes()
+    use keccak_asm::Keccak256;
+
+    let mut h = Keccak256::new();
+    KeccakDigest::update(&mut h, &data);
+    let mut out = [0u8; 32];
+    let result = KeccakDigest::finalize(h);
+    out.copy_from_slice(&result);
+    out
 }

--- a/execution_engine/src/runtime/cryptography.rs
+++ b/execution_engine/src/runtime/cryptography.rs
@@ -41,3 +41,8 @@ pub fn blake3<T: AsRef<[u8]>>(data: T) -> [u8; DIGEST_LENGTH] {
 pub fn sha256<T: AsRef<[u8]>>(data: T) -> [u8; DIGEST_LENGTH] {
     Sha256::digest(data).into()
 }
+
+/// The 32-byte digest keccak256 hash function
+pub fn keccak256<T: AsRef<[u8]>>(data: T) -> [u8; DIGEST_LENGTH] {
+    keccak_hash::keccak(data).to_fixed_bytes()
+}

--- a/execution_engine/src/runtime/externals.rs
+++ b/execution_engine/src/runtime/externals.rs
@@ -1408,6 +1408,7 @@ where
                             HashAlgorithm::Blake2b => cryptography::blake2b(input),
                             HashAlgorithm::Blake3 => cryptography::blake3(input),
                             HashAlgorithm::Sha256 => cryptography::sha256(input),
+                            HashAlgorithm::Keccak256 => cryptography::keccak256(input),
                         }
                     })?;
 

--- a/execution_engine_testing/tests/src/test/contract_api/generic_hash.rs
+++ b/execution_engine_testing/tests/src/test/contract_api/generic_hash.rs
@@ -67,3 +67,24 @@ fn should_run_generic_hash_sha256() {
         .expect_success()
         .commit();
 }
+
+#[ignore]
+#[test]
+fn should_run_generic_hash_keccak256() {
+    LmdbWasmTestBuilder::default()
+        .run_genesis(LOCAL_GENESIS_REQUEST.clone())
+        .exec(
+            ExecuteRequestBuilder::standard(
+                *DEFAULT_ACCOUNT_ADDR,
+                GENERIC_HASH_WASM,
+                runtime_args! {
+                    "data" => "keccak256 hash test",
+                    "algorithm" => HashAlgorithm::Keccak256 as u8,
+                    "expected" => [0x12, 0x7E, 0x0A, 0x91, 0x17, 0x10, 0x3B, 0xA8, 0xD9, 0xCE, 0x0C, 0xC4, 0x5F, 0xD9, 0x3C, 0x0B, 0xBF, 0x5F, 0xB9, 0xC2, 0x1B, 0x16, 0x09, 0xD1, 0x25, 0x50, 0xBC, 0x81, 0xB3, 0xA2, 0x62, 0x14]
+                },
+            )
+            .build(),
+        )
+        .expect_success()
+        .commit();
+}

--- a/types/src/crypto.rs
+++ b/types/src/crypto.rs
@@ -46,6 +46,8 @@ pub enum HashAlgorithm {
     Blake3 = 1,
     /// Sha256,
     Sha256 = 2,
+    /// Keccak256
+    Keccak256 = 3,
 }
 
 impl TryFrom<u8> for HashAlgorithm {


### PR DESCRIPTION
Adds Keccak256 support to the ``casper_generic_hash`` FFI.