### PR TITLE
[VM2] Fix sandboxed execution naming consistency, missing config field

### DIFF
--- a/binary_port/src/response_type.rs
+++ b/binary_port/src/response_type.rs
@@ -302,7 +302,7 @@ impl fmt::Display for ResponseType {
             ResponseType::BidsInformation => {
                 write!(f, "BidsInformation")
             }
-            ResponseType::SandboxedExecutionResult => write!(f, "CallRestrictedResult"),
+            ResponseType::SandboxedExecutionResult => write!(f, "CallSandboxedResult"),
         }
     }
 }

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -170,7 +170,7 @@ struct BinaryRequestTerminationDelayValues {
     get_trie: TimeDiff,
     accept_transaction: TimeDiff,
     speculative_exec: TimeDiff,
-    call_restricted_request: TimeDiff,
+    sandboxed_execution_request: TimeDiff,
 }
 
 impl BinaryRequestTerminationDelayValues {
@@ -182,7 +182,7 @@ impl BinaryRequestTerminationDelayValues {
             get_trie: config.get_trie_request_termination_delay,
             accept_transaction: config.accept_transaction_request_termination_delay,
             speculative_exec: config.speculative_exec_request_termination_delay,
-            call_restricted_request: config.try_call_restricted_request_termination_delay,
+            sandboxed_execution_request: config.try_sandboxed_execution_request_termination_delay,
         }
     }
     fn get_life_termination_delay(&self, request: &Command) -> TimeDiff {
@@ -193,7 +193,7 @@ impl BinaryRequestTerminationDelayValues {
             Command::Get(GetRequest::Trie { .. }) => self.get_trie,
             Command::TryAcceptTransaction { .. } => self.accept_transaction,
             Command::TrySpeculativeExec { .. } => self.speculative_exec,
-            Command::TrySandboxedExecution { .. } => self.call_restricted_request,
+            Command::TrySandboxedExecution { .. } => self.sandboxed_execution_request,
         }
     }
 }
@@ -239,19 +239,16 @@ where
             }
             try_speculative_execution(effect_builder, transaction).await
         }
-        Command::TrySandboxedExecution {
-            request: call_restricted_request,
-        } => {
-            metrics.binary_port_try_call_restricted_count.inc();
+        Command::TrySandboxedExecution { request } => {
+            metrics.binary_port_try_sandboxed_execution_count.inc();
             let enable_for_peer = config
-                .call_restricted_allowed_ips
+                .sandboxed_execution_allowed_ips
                 .iter()
                 .any(|ip| ip == "*" || ip == &peer_ip.to_string());
             if !enable_for_peer {
                 return BinaryResponse::new_error(ErrorCode::FunctionDisabled);
             }
-            // let request = casper_executor_wasm_interface::Ca
-            try_sandboxed_execution(effect_builder, call_restricted_request).await
+            try_sandboxed_execution(effect_builder, request).await
         }
         Command::Get(get_req) => {
             handle_get_request(get_req, effect_builder, config, metrics, protocol_version).await

--- a/node/src/components/binary_port/config.rs
+++ b/node/src/components/binary_port/config.rs
@@ -34,8 +34,8 @@ const DEFAULT_ACCEPT_TRANSACTION_REQUEST_TERMINATION_DELAY: &str = "24 seconds";
 const DEFAULT_SPECULATIVE_EXEC_REQUEST_TERMINATION_DELAY: &str = "0 seconds";
 
 // Default amount of time which is given to a connection to extend it's lifetime when a valid
-// [`Command::TryCallRestricted`] is sent to the node
-const DEFAULT_TRY_CALL_RESTRICTED_REQUEST_TERMINATION_DELAY: &str = "30 seconds";
+// [`Command::TrySandboxedExecution`] is sent to the node
+const DEFAULT_TRY_SANDBOXED_EXECUTION_REQUEST_TERMINATION_DELAY: &str = "30 seconds";
 
 /// Binary port server configuration.
 #[derive(Clone, DataSize, Debug, Deserialize, Serialize)]
@@ -54,9 +54,9 @@ pub struct Config {
     pub allow_request_get_trie: bool,
     /// Flag used to enable/disable the [`TrySpeculativeExec`] request.
     pub allow_request_speculative_exec: bool,
-    /// IP addresses allowed to make [`TryCallRestricted`] requests. Empty list means no access
+    /// IP addresses allowed to make [`TrySandboxedExecution`] requests. Empty list means no access
     /// allowed. Supports IP address strings like "127.0.0.1" or "::1".
-    pub call_restricted_allowed_ips: Vec<String>,
+    pub sandboxed_execution_allowed_ips: Vec<String>,
     /// Maximum size of the binary port message.
     pub max_message_size_bytes: u32,
     /// Maximum number of connections to the server.
@@ -83,10 +83,9 @@ pub struct Config {
     // The amount of time which is given to a connection to extend it's lifetime when a valid
     // [`Command::TrySpeculativeExec`] is sent to the node
     pub speculative_exec_request_termination_delay: TimeDiff,
-
     // The amount of time which is given to a connection to extend it's lifetime when a valid
-    // [`Command::TryCallRestricted`] is sent to the node
-    pub try_call_restricted_request_termination_delay: TimeDiff,
+    // [`Command::TrySandboxedExecution`] is sent to the node
+    pub try_sandboxed_execution_request_termination_delay: TimeDiff,
 }
 
 impl Config {
@@ -98,7 +97,7 @@ impl Config {
             allow_request_get_all_values: false,
             allow_request_get_trie: false,
             allow_request_speculative_exec: false,
-            call_restricted_allowed_ips: Vec::new(),
+            sandboxed_execution_allowed_ips: Vec::new(),
             max_message_size_bytes: DEFAULT_MAX_MESSAGE_SIZE,
             max_connections: DEFAULT_MAX_CONNECTIONS,
             qps_limit: DEFAULT_QPS_LIMIT,
@@ -129,8 +128,8 @@ impl Config {
             )
             .unwrap(),
 
-            try_call_restricted_request_termination_delay: TimeDiff::from_str(
-                DEFAULT_TRY_CALL_RESTRICTED_REQUEST_TERMINATION_DELAY,
+            try_sandboxed_execution_request_termination_delay: TimeDiff::from_str(
+                DEFAULT_TRY_SANDBOXED_EXECUTION_REQUEST_TERMINATION_DELAY,
             )
             .unwrap(),
         }

--- a/node/src/components/binary_port/metrics.rs
+++ b/node/src/components/binary_port/metrics.rs
@@ -29,9 +29,10 @@ const BINARY_PORT_CONNECTIONS_COUNT_HELP: &str =
 const BINARY_PORT_TRIE_COUNT_NAME: &str = "binary_port_get_trie_count";
 const BINARY_PORT_TRIE_COUNT_HELP: &str = "number of Get queries received for the trie state";
 
-const BINARY_PORT_TRY_CALL_RESTRICTED_COUNT_NAME: &str = "binary_port_try_call_restricted_count";
-const BINARY_PORT_TRY_CALL_RESTRICTED_COUNT_HELP: &str =
-    "number of TryCallRestricted queries received";
+const BINARY_PORT_TRY_SANDBOXED_EXECUTION_COUNT_NAME: &str =
+    "binary_port_try_sandboxed_execution_count";
+const BINARY_PORT_TRY_SANDBOXED_EXECUTION_COUNT_HELP: &str =
+    "number of TrySandboxedExecution queries received";
 
 /// Metrics.
 #[derive(Debug)]
@@ -50,8 +51,8 @@ pub(crate) struct Metrics {
     pub(super) binary_port_connections_count: IntCounter,
     /// Number of `Get::Trie` queries received.
     pub(super) binary_port_get_trie_count: IntCounter,
-    /// Number of `TryCallRestricted` queries received.
-    pub(super) binary_port_try_call_restricted_count: IntCounter,
+    /// Number of `TrySandboxedExecution` queries received.
+    pub(super) binary_port_try_sandboxed_execution_count: IntCounter,
 
     registry: Registry,
 }
@@ -94,9 +95,9 @@ impl Metrics {
             BINARY_PORT_TRIE_COUNT_HELP.to_string(),
         )?;
 
-        let binary_port_try_call_restricted_count = IntCounter::new(
-            BINARY_PORT_TRY_CALL_RESTRICTED_COUNT_NAME.to_string(),
-            BINARY_PORT_TRY_CALL_RESTRICTED_COUNT_HELP.to_string(),
+        let binary_port_try_sandboxed_execution_count = IntCounter::new(
+            BINARY_PORT_TRY_SANDBOXED_EXECUTION_COUNT_NAME.to_string(),
+            BINARY_PORT_TRY_SANDBOXED_EXECUTION_COUNT_HELP.to_string(),
         )?;
 
         registry.register(Box::new(binary_port_try_accept_transaction_count.clone()))?;
@@ -106,7 +107,7 @@ impl Metrics {
         registry.register(Box::new(binary_port_get_state_count.clone()))?;
         registry.register(Box::new(binary_port_connections_count.clone()))?;
         registry.register(Box::new(binary_port_get_trie_count.clone()))?;
-        registry.register(Box::new(binary_port_try_call_restricted_count.clone()))?;
+        registry.register(Box::new(binary_port_try_sandboxed_execution_count.clone()))?;
 
         Ok(Metrics {
             binary_port_try_accept_transaction_count,
@@ -116,7 +117,7 @@ impl Metrics {
             binary_port_get_state_count,
             binary_port_connections_count,
             binary_port_get_trie_count,
-            binary_port_try_call_restricted_count,
+            binary_port_try_sandboxed_execution_count,
             registry: registry.clone(),
         })
     }

--- a/node/src/components/binary_port/tests.rs
+++ b/node/src/components/binary_port/tests.rs
@@ -61,7 +61,7 @@ struct TestCase {
     allow_request_get_all_values: bool,
     allow_request_get_trie: bool,
     allow_request_speculative_exec: bool,
-    call_restricted_allowed_ips: Vec<String>,
+    sandboxed_execution_allowed_ips: Vec<String>,
     request_generator: Either<fn(&mut TestRng) -> Command, Command>,
 }
 
@@ -73,7 +73,7 @@ async fn should_enqueue_requests_for_enabled_functions() {
         allow_request_get_all_values: ENABLED,
         allow_request_get_trie: rng.gen(),
         allow_request_speculative_exec: rng.gen(),
-        call_restricted_allowed_ips: WHITELIST_EMPTY,
+        sandboxed_execution_allowed_ips: WHITELIST_EMPTY,
         request_generator: Either::Left(|_| all_values_request()),
     };
 
@@ -81,7 +81,7 @@ async fn should_enqueue_requests_for_enabled_functions() {
         allow_request_get_all_values: rng.gen(),
         allow_request_get_trie: ENABLED,
         allow_request_speculative_exec: rng.gen(),
-        call_restricted_allowed_ips: WHITELIST_EMPTY,
+        sandboxed_execution_allowed_ips: WHITELIST_EMPTY,
         request_generator: Either::Left(|_| trie_request()),
     };
 
@@ -89,7 +89,7 @@ async fn should_enqueue_requests_for_enabled_functions() {
         allow_request_get_all_values: rng.gen(),
         allow_request_get_trie: rng.gen(),
         allow_request_speculative_exec: ENABLED,
-        call_restricted_allowed_ips: WHITELIST_EMPTY,
+        sandboxed_execution_allowed_ips: WHITELIST_EMPTY,
         request_generator: Either::Left(try_speculative_exec_request),
     };
 
@@ -97,7 +97,7 @@ async fn should_enqueue_requests_for_enabled_functions() {
         allow_request_get_all_values: rng.gen(),
         allow_request_get_trie: rng.gen(),
         allow_request_speculative_exec: rng.gen(),
-        call_restricted_allowed_ips: vec!["127.0.0.1".to_string()],
+        sandboxed_execution_allowed_ips: vec!["127.0.0.1".to_string()],
         request_generator: Either::Left(try_sandboxed_execution),
     };
 
@@ -129,7 +129,7 @@ async fn should_return_error_for_disabled_functions() {
         allow_request_get_all_values: DISABLED,
         allow_request_get_trie: rng.gen(),
         allow_request_speculative_exec: rng.gen(),
-        call_restricted_allowed_ips: Vec::new(),
+        sandboxed_execution_allowed_ips: Vec::new(),
         request_generator: Either::Left(|_| all_values_request()),
     };
 
@@ -137,7 +137,7 @@ async fn should_return_error_for_disabled_functions() {
         allow_request_get_all_values: rng.gen(),
         allow_request_get_trie: DISABLED,
         allow_request_speculative_exec: rng.gen(),
-        call_restricted_allowed_ips: Vec::new(),
+        sandboxed_execution_allowed_ips: Vec::new(),
         request_generator: Either::Left(|_| trie_request()),
     };
 
@@ -145,7 +145,7 @@ async fn should_return_error_for_disabled_functions() {
         allow_request_get_all_values: rng.gen(),
         allow_request_get_trie: rng.gen(),
         allow_request_speculative_exec: DISABLED,
-        call_restricted_allowed_ips: Vec::new(),
+        sandboxed_execution_allowed_ips: Vec::new(),
         request_generator: Either::Left(try_speculative_exec_request),
     };
 
@@ -153,7 +153,7 @@ async fn should_return_error_for_disabled_functions() {
         allow_request_get_all_values: rng.gen(),
         allow_request_get_trie: rng.gen(),
         allow_request_speculative_exec: rng.gen(),
-        call_restricted_allowed_ips: Vec::new(),
+        sandboxed_execution_allowed_ips: Vec::new(),
         request_generator: Either::Left(try_sandboxed_execution),
     };
 
@@ -189,7 +189,7 @@ async fn should_return_empty_response_when_fetching_empty_key() {
             allow_request_get_all_values: DISABLED,
             allow_request_get_trie: DISABLED,
             allow_request_speculative_exec: DISABLED,
-            call_restricted_allowed_ips: Vec::new(),
+            sandboxed_execution_allowed_ips: Vec::new(),
             request_generator: Either::Right(request),
         })
         .collect();
@@ -217,7 +217,7 @@ async fn run_test_case(
         allow_request_get_all_values,
         allow_request_get_trie,
         allow_request_speculative_exec,
-        call_restricted_allowed_ips,
+        sandboxed_execution_allowed_ips,
         request_generator,
     }: TestCase,
     rng: &mut TestRng,
@@ -230,7 +230,7 @@ async fn run_test_case(
         allow_request_get_all_values,
         allow_request_get_trie,
         allow_request_speculative_exec,
-        call_restricted_allowed_ips,
+        sandboxed_execution_allowed_ips,
         max_message_size_bytes: 1024,
         max_connections: 2,
         ..Default::default()

--- a/node/src/reactor/main_reactor/tests/fixture.rs
+++ b/node/src/reactor/main_reactor/tests/fixture.rs
@@ -391,7 +391,7 @@ impl TestFixture {
                 allow_request_get_all_values: true,
                 allow_request_get_trie: true,
                 allow_request_speculative_exec: true,
-                call_restricted_allowed_ips: vec!["127.0.0.1".to_string()],
+                sandboxed_execution_allowed_ips: vec!["127.0.0.1".to_string()],
                 ..Default::default()
             },
             ..Default::default()

--- a/resources/local/config.toml
+++ b/resources/local/config.toml
@@ -335,9 +335,9 @@ allow_request_get_trie = false
 # Flag that enables the `TrySpeculativeExec` request. Disabled by default.
 allow_request_speculative_exec = false
 
-# IP addresses allowed to make `TryCallRestricted` requests. Empty list means no access allowed.
+# IP addresses allowed to make `TrySandboxedExecution` requests. Empty list means no access allowed.
 # Supports IP address strings like "127.0.0.1" or "::1". A string of "*" matches all IPs.
-call_restricted_allowed_ips = []
+sandboxed_execution_allowed_ips = []
 
 # Maximum size of a message in bytes.
 max_message_size_bytes = 4_194_304
@@ -375,6 +375,10 @@ accept_transaction_request_termination_delay = '24 seconds'
 #The amount of time which is given to a connection to extend it's lifetime when a valid
 #[`Command::TrySpeculativeExec`] is sent to the node
 speculative_exec_request_termination_delay = '0 seconds'
+
+#The amount of time which is given to a connection to extend it's lifetime when a valid
+#[`Command::TrySandboxedExecution`] is sent to the node
+try_sandboxed_execution_request_termination_delay = '30 seconds'
 
 # ==============================================
 # Configuration options for the REST HTTP server

--- a/resources/production/config-example.toml
+++ b/resources/production/config-example.toml
@@ -334,9 +334,9 @@ allow_request_get_trie = false
 # Flag that enables the `TrySpeculativeExec` request. Disabled by default.
 allow_request_speculative_exec = false
 
-# IP addresses allowed to make `TryCallRestricted` requests. Empty list means no access allowed.
+# IP addresses allowed to make `TrySandboxedExecution` requests. Empty list means no access allowed.
 # Supports IP address strings like "127.0.0.1" or "::1". A string of "*" matches all IPs.
-call_restricted_allowed_ips = []
+sandboxed_execution_allowed_ips = []
 
 # Maximum size of a message in bytes.
 max_message_size_bytes = 134_217_728
@@ -375,6 +375,9 @@ accept_transaction_request_termination_delay = '24 seconds'
 #[`Command::TrySpeculativeExec`] is sent to the node
 speculative_exec_request_termination_delay = '0 seconds'
 
+#The amount of time which is given to a connection to extend it's lifetime when a valid
+#[`Command::TrySandboxedExecution`] is sent to the node
+try_sandboxed_execution_request_termination_delay = '30 seconds'
 
 # ==============================================
 # Configuration options for the REST HTTP server


### PR DESCRIPTION
`Command::TryCallRestricted` had been renamed to `Command::TrySandboxedExecution`, but this change wasn't reflected everywhere. This PR addresses that.

Additionally, adds a missing field `try_sandboxed_execution_request_termination_delay` to default configuration.