### PR TITLE
Changing EntityAddr::System to EntityAddr::Account

### DIFF
--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -2722,7 +2722,7 @@ where
             .metered_write_gs_unsafe(contract_package_key, contract_package)?;
         let system_account_hash = PublicKey::System.to_account_hash().value();
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_CONTRACT_PACKAGE_ADDR_TOPIC,
             MessagePayload::String(contract_package_key.to_formatted_string()),
             true,
@@ -2730,7 +2730,7 @@ where
             return Ok(Err(e));
         }
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_CONTRACT_ADDR_TOPIC,
             MessagePayload::String(contract_key.to_formatted_string()),
             true,
@@ -2738,7 +2738,7 @@ where
             return Ok(Err(e));
         }
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_CONTRACT_WASM_ADDR_TOPIC,
             MessagePayload::String(contract_wasm_key.to_formatted_string()),
             true,
@@ -2746,7 +2746,7 @@ where
             return Ok(Err(e));
         }
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_CONTRACT_VERSION_TOPIC,
             MessagePayload::String(insert_contract_result.to_string()),
             true,
@@ -2902,7 +2902,7 @@ where
 
         let system_account_hash = PublicKey::System.to_account_hash().value();
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_PACKAGE_ADDR_TOPIC,
             MessagePayload::String(Key::Hash(package_hash.value()).to_formatted_string()),
             true,
@@ -2910,7 +2910,7 @@ where
             return Ok(Err(e));
         }
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_ADDR_ENTITY_ADDR_TOPIC,
             MessagePayload::String(entity_key.to_formatted_string()),
             true,
@@ -2918,7 +2918,7 @@ where
             return Ok(Err(e));
         }
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_BYTE_CODE_WASM_ADDR_TOPIC,
             MessagePayload::String(
                 Key::ByteCode(ByteCodeAddr::new_wasm_addr(byte_code_hash)).to_formatted_string(),
@@ -2928,7 +2928,7 @@ where
             return Ok(Err(e));
         }
         if let Err(e) = self.emit_message_for_entity(
-            EntityAddr::System(system_account_hash),
+            EntityAddr::Account(system_account_hash),
             MESSAGING_CONTRACT_VERSION_TOPIC,
             MessagePayload::String(insert_entity_version_result.to_string()),
             true,

--- a/execution_engine_testing/tests/src/test/contract_messages.rs
+++ b/execution_engine_testing/tests/src/test/contract_messages.rs
@@ -1276,7 +1276,7 @@ fn emit_message_should_consume_variable_gas_based_on_topic_and_message_size() {
 #[ignore]
 #[test]
 fn on_install_should_emit_system_messages() {
-    let system_account_entity = EntityAddr::System(PublicKey::System.to_account_hash().value());
+    let system_account_entity = EntityAddr::Account(PublicKey::System.to_account_hash().value());
     let builder = RefCell::new(LmdbWasmTestBuilder::default());
     builder
         .borrow_mut()

--- a/storage/src/system/genesis/account_contract_installer.rs
+++ b/storage/src/system/genesis/account_contract_installer.rs
@@ -556,7 +556,7 @@ where
         block_time: BlockTime,
         topic_name: &str,
     ) -> Result<(), Box<GenesisError>> {
-        let entity_addr = EntityAddr::new_system(PublicKey::System.to_account_hash().value());
+        let entity_addr = EntityAddr::new_account(PublicKey::System.to_account_hash().value());
         let topic_name_hash = blake2b(topic_name.as_bytes()).into();
         let topic_key = Key::message_topic(entity_addr, topic_name_hash);
         let maybe_existing_topic = self

--- a/storage/src/system/genesis/entity_installer.rs
+++ b/storage/src/system/genesis/entity_installer.rs
@@ -900,7 +900,7 @@ where
         block_time: BlockTime,
         topic_name: &str,
     ) -> Result<(), Box<GenesisError>> {
-        let entity_addr = EntityAddr::new_system(PublicKey::System.to_account_hash().value());
+        let entity_addr = EntityAddr::new_account(PublicKey::System.to_account_hash().value());
         let topic_name_hash = blake2b(topic_name.as_bytes()).into();
         let topic_key = Key::message_topic(entity_addr, topic_name_hash);
         let maybe_existing_topic = self

--- a/storage/src/system/protocol_upgrade.rs
+++ b/storage/src/system/protocol_upgrade.rs
@@ -1456,7 +1456,7 @@ where
         block_time: BlockTime,
         topic_name: &str,
     ) -> Result<(), ProtocolUpgradeError> {
-        let entity_addr = EntityAddr::new_system(PublicKey::System.to_account_hash().value());
+        let entity_addr = EntityAddr::new_account(PublicKey::System.to_account_hash().value());
         let topic_name_hash = blake2b(topic_name.as_bytes()).into();
         let topic_key = Key::message_topic(entity_addr, topic_name_hash);
         let maybe_existing_topic = self


### PR DESCRIPTION
After discussion with @darthsiroftardis it became apparent that EntityAddr::Account(PublicKey::System.to_account_hash()) is the appropriate aproach instead of  EntityAddr::System(PublicKey::System.to_account_hash())
