### PR TITLE
[VM2] Add a generic hash host function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,16 +912,20 @@ name = "casper-executor-wasm-host"
 version = "0.1.3"
 dependencies = [
  "base16",
+ "blake2 0.10.6",
+ "blake3",
  "bytes",
  "casper-executor-wasm-common",
  "casper-executor-wasm-interface",
  "casper-storage",
  "casper-types",
  "either",
+ "keccak-asm",
  "num-derive",
  "num-traits",
  "parking_lot",
  "safe-transmute",
+ "sha2",
  "thiserror 2.0.12",
  "tracing",
 ]

--- a/executor/wasm/src/testing.rs
+++ b/executor/wasm/src/testing.rs
@@ -147,7 +147,7 @@ pub fn base_execute_builder(chainspec_config: &ChainspecConfig) -> ExecuteReques
         .with_block_time(Timestamp::now().into())
         .with_state_hash(Digest::hash(b"state"))
         .with_block_height(1)
-        .with_runtime_native_config(make_runtime_config(&chainspec_config))
+        .with_runtime_native_config(make_runtime_config(chainspec_config))
         .with_parent_block_hash(BlockHash::new(Digest::hash(b"block1")))
         .with_runtime_native_config(runtime_native_config)
 }
@@ -206,7 +206,7 @@ pub fn base_install_request_builder(
         .with_block_time(Timestamp::now().into())
         .with_state_hash(Digest::hash(b"state"))
         .with_block_height(1)
-        .with_runtime_native_config(make_runtime_config(&chainspec_config))
+        .with_runtime_native_config(make_runtime_config(chainspec_config))
         .with_parent_block_hash(BlockHash::new(Digest::hash(b"block1")))
         .with_runtime_native_config(runtime_native_config)
 }
@@ -215,7 +215,7 @@ pub fn make_executor(chainspec_config: &ChainspecConfig) -> ExecutorV2 {
     let storage_costs = chainspec_config.storage_costs;
     let v1_config = EngineConfig::from(chainspec_config.clone());
     let execution_engine_v1 = ExecutionEngineV1::new(v1_config);
-    let wasm_v2_config = chainspec_config.wasm_config.v2().clone();
+    let wasm_v2_config = *chainspec_config.wasm_config.v2();
     let memory_limit = wasm_v2_config.max_memory();
     let message_limits = chainspec_config.wasm_config.messages_limits();
     let executor_config = ExecutorConfigBuilder::default()
@@ -331,6 +331,7 @@ pub fn call_dummy_host_fn_by_name(
                 print: HostFunctionV2::fixed(1),
                 emit: HostFunctionV2::fixed(1),
                 env_info: HostFunctionV2::fixed(1),
+                generic_hash: HostFunctionV2::fixed(1),
             },
         );
         let executor_config = ExecutorConfigBuilder::default()
@@ -352,7 +353,7 @@ pub fn call_dummy_host_fn_by_name(
         .map(Bytes::from)
         .unwrap();
 
-    let create_request = base_install_request_builder(&chainspec_config)
+    let create_request = base_install_request_builder(chainspec_config)
         .with_initiator(*DEFAULT_ACCOUNT_HASH)
         .with_gas_limit(gas_limit)
         .with_transaction_hash(TRANSACTION_HASH)

--- a/executor/wasm/tests/integration.rs
+++ b/executor/wasm/tests/integration.rs
@@ -471,7 +471,7 @@ fn upgradable() {
 
 #[test]
 fn backwards_compatibility() {
-    let (mut global_state, post_state_hash, _temp) = {
+    let (global_state, post_state_hash, _temp) = {
         let fixture_name = "counter_contract";
         // /Users/michal/Dev/casper-node/execution_engine_testing/tests/fixtures/counter_contract/
         // global_state/data.lmdb
@@ -600,7 +600,7 @@ fn backwards_compatibility() {
 
     let create_result = run_create_contract(
         &mut executor,
-        &mut global_state,
+        &global_state,
         state_root_hash,
         install_request,
     );
@@ -659,6 +659,7 @@ fn host_functions_consume_gas() {
     assert_consumes_gas(&chainspec_config, "transfer");
     assert_consumes_gas(&chainspec_config, "upgrade");
     assert_consumes_gas(&chainspec_config, "write");
+    assert_consumes_gas(&chainspec_config, "generic_hash");
 }
 
 #[test]
@@ -791,7 +792,7 @@ fn casper_return_fails_if_contract_uses_unsupported_flags() {
         .expect("must get chainspec config");
     let address_generator = make_address_generator();
     let mut executor = make_executor(&chainspec_config);
-    let (mut global_state, mut state_root_hash, _tempdir) = make_global_state_with_genesis();
+    let (global_state, mut state_root_hash, _tempdir) = make_global_state_with_genesis();
 
     // Create a contract that will be used to test the ret host function
     let input_data = borsh::to_vec(&("write".to_string(),))
@@ -809,7 +810,7 @@ fn casper_return_fails_if_contract_uses_unsupported_flags() {
 
     let create_result = run_create_contract(
         &mut executor,
-        &mut global_state,
+        &global_state,
         state_root_hash,
         install_request,
     );
@@ -832,7 +833,7 @@ fn casper_return_fails_if_contract_uses_unsupported_flags() {
 
     let result = executor.execute_with_provider(state_root_hash, &global_state, execute_request);
     assert!(result.is_err());
-    let err: ExecuteWithProviderError = result.err().expect("should have error details");
+    let err: ExecuteWithProviderError = result.expect_err("should have error details");
     assert!(matches!(
         err,
         ExecuteWithProviderError::Execute(ExecuteError::ReturnFlagsNotSupported(2))
@@ -846,7 +847,7 @@ fn escrow() {
         .expect("must get chainspec config");
     let mut executor = make_executor(&chainspec_config);
 
-    let (mut global_state, mut state_root_hash, _tempdir) = make_global_state_with_genesis();
+    let (global_state, mut state_root_hash, _tempdir) = make_global_state_with_genesis();
 
     let address_generator = make_address_generator();
 
@@ -870,7 +871,7 @@ fn escrow() {
 
     let create_result = run_create_contract(
         &mut executor,
-        &mut global_state,
+        &global_state,
         state_root_hash,
         create_request,
     );
@@ -905,7 +906,7 @@ fn escrow() {
 
     let result_2 = run_wasm_session(
         &mut executor,
-        &mut global_state,
+        &global_state,
         state_root_hash,
         execute_request,
     )
@@ -925,7 +926,7 @@ fn should_not_fail_without_account() {
         .expect("must get chainspec config");
     let executor = make_executor(&chainspec_config);
 
-    let (mut global_state, state_root_hash, _tempdir) = make_global_state_with_genesis();
+    let (global_state, state_root_hash, _tempdir) = make_global_state_with_genesis();
 
     let address_generator = make_address_generator();
 
@@ -949,7 +950,7 @@ fn should_not_fail_without_account() {
 
     let create_result = {
         executor
-            .install_contract(state_root_hash, &mut global_state, create_request)
+            .install_contract(state_root_hash, &global_state, create_request)
             .expect_err("Succeed")
     };
 

--- a/executor/wasm_host/Cargo.toml
+++ b/executor/wasm_host/Cargo.toml
@@ -11,6 +11,10 @@ license = "Apache-2.0"
 [dependencies]
 base16 = "0.2"
 bytes = "1.10"
+blake2 = { version = "0.10.6", default-features = false }
+blake3 = { version = "1.5.0", default-features = false, features = ["pure"] }
+sha2 = { version = "0.10.8", default-features = false }
+keccak-asm = { version = "0.1.4", default-features = false }
 casper-executor-wasm-common = { version = "0.1.3", path = "../wasm_common" }
 casper-executor-wasm-interface = { version = "0.1.3", path = "../wasm_interface" }
 casper-storage = { version = "2.1.1", path = "../../storage" }

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -34,19 +34,28 @@ use casper_types::{
     AddressableEntity, BlockGlobalAddr, BlockHash, BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash,
     ByteCodeKind, CLType, CLValue, ContractRuntimeTag, Digest, EntityAddr, EntityEntryPoint,
     EntityKind, EntryPointAccess, EntryPointAddr, EntryPointPayment, EntryPointType,
-    EntryPointValue, HashAddr, HostFunctionV2, Key, Package, PackageHash, ProtocolVersion,
-    StoredValue, URef, U512,
+    EntryPointValue, HashAddr, HashAlgorithm, HostFunctionV2, Key, Package, PackageHash,
+    ProtocolVersion, StoredValue, URef, U512,
 };
 use either::Either;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use tracing::{error, info, warn};
 
+use blake2::{
+    digest::{Update, VariableOutput},
+    Blake2bVar,
+};
+use keccak_asm::Digest as KeccakDigest;
+use sha2::Sha256;
+
 use crate::{
     abi::{CreateResult, ReadInfo},
     context::Context,
     system::{self, DispatchError, MintTransferArgs},
 };
+
+const DIGEST_LENGTH: usize = 32;
 
 #[derive(Debug, Copy, Clone, FromPrimitive, PartialEq)]
 enum EntityKindTag {
@@ -1799,6 +1808,74 @@ pub fn casper_emit<S: GlobalStateReader, E: Executor>(
         block_message_count_value,
         message,
     );
+
+    Ok(HOST_ERROR_SUCCESS)
+}
+
+/// Computes digest hash, using provided algorithm type.
+///
+/// # Arguments
+///
+/// * `in_ptr` - pointer to the location where argument bytes will be copied from the host side
+/// * `in_size` - size of output pointer
+/// * `out_ptr` - pointer to the location where argument bytes will be copied to the host side
+/// * `hash_algo_type` - integer representation of HashAlgorithm enum variant
+pub fn casper_generic_hash<S: GlobalStateReader, E: Executor>(
+    mut caller: impl Caller<Context = Context<S, E>>,
+    in_ptr: u32,
+    in_size: u32,
+    out_ptr: u32,
+    hash_algorithm: u32,
+) -> VMResult<u32> {
+    let in_bytes: Vec<u8> = caller.memory_read(in_ptr, in_size as usize)?;
+
+    // Charge for parameter weights.
+    let generic_hash_host_function = caller.context().config.host_function_costs().generic_hash;
+
+    charge_host_function_call(
+        &mut caller,
+        &generic_hash_host_function,
+        [
+            u64::from(in_ptr),
+            u64::from(in_size),
+            u64::from(out_ptr),
+            u64::from(hash_algorithm),
+        ],
+    )?;
+
+    let hash_algorithm =
+        HashAlgorithm::from_u32(hash_algorithm).ok_or(InternalHostError::TypeConversion)?;
+
+    let hashed_bytes = match hash_algorithm {
+        HashAlgorithm::Blake2b => {
+            let mut result = [0; DIGEST_LENGTH];
+            let mut hasher = Blake2bVar::new(DIGEST_LENGTH).expect("should create hasher");
+            hasher.update(in_bytes.as_ref());
+            hasher.finalize_variable(&mut result).ok();
+            result
+        }
+        HashAlgorithm::Blake3 => {
+            let mut result = [0; DIGEST_LENGTH];
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(in_bytes.as_ref());
+            let hash = hasher.finalize();
+            let hash_bytes: &[u8; DIGEST_LENGTH] = hash.as_bytes();
+            result.copy_from_slice(hash_bytes);
+            result
+        }
+        HashAlgorithm::Sha256 => Sha256::digest(in_bytes).into(),
+        HashAlgorithm::Keccak256 => {
+            use keccak_asm::Keccak256;
+            let mut result = [0u8; DIGEST_LENGTH];
+            let mut hasher = Keccak256::new();
+            KeccakDigest::update(&mut hasher, &in_bytes);
+            let hash = KeccakDigest::finalize(hasher);
+            result.copy_from_slice(&hash);
+            result
+        }
+    };
+
+    caller.memory_write(out_ptr, &hashed_bytes)?;
 
     Ok(HOST_ERROR_SUCCESS)
 }

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -55,8 +55,6 @@ use crate::{
     system::{self, DispatchError, MintTransferArgs},
 };
 
-const DIGEST_LENGTH: usize = 32;
-
 #[derive(Debug, Copy, Clone, FromPrimitive, PartialEq)]
 enum EntityKindTag {
     Account = 0,
@@ -1824,9 +1822,11 @@ pub fn casper_generic_hash<S: GlobalStateReader, E: Executor>(
     mut caller: impl Caller<Context = Context<S, E>>,
     in_ptr: u32,
     in_size: u32,
-    out_ptr: u32,
     hash_algorithm: u32,
+    out_ptr: u32,
 ) -> VMResult<u32> {
+    const DIGEST_LENGTH: usize = 32;
+
     let in_bytes: Vec<u8> = caller.memory_read(in_ptr, in_size as usize)?;
 
     // Charge for parameter weights.

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -321,6 +321,7 @@ mod tests {
             print: HostFunctionV2::new(112, [0, 1]),
             emit: HostFunctionV2::new(113, [0, 1, 2, 3]),
             env_info: HostFunctionV2::new(114, [0, 1]),
+            generic_hash: HostFunctionV2::new(115, [0, 1, 2, 3]),
         });
     static EXPECTED_GENESIS_WASM_COSTS: Lazy<WasmConfig> = Lazy::new(|| {
         let wasm_v1_config = WasmV1Config::new(

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -424,6 +424,7 @@ call = { cost = 0, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0] }
 print = { cost = 0, arguments = [0, 0] }
 emit = { cost = 0, arguments = [0, 0, 0, 0] }
 env_info = { cost = 0, arguments = [0, 0] }
+generic_hash = { cost = 0, arguments = [0, 0, 0, 0] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -430,6 +430,7 @@ call = { cost = 0, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0] }
 print = { cost = 0, arguments = [0, 0] }
 emit = { cost = 0, arguments = [0, 0, 0, 0] }
 env_info = { cost = 0, arguments = [0, 0] }
+generic_hash = { cost = 0, arguments = [0, 0, 0, 0] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/smart_contracts/contracts/vm2/vm2-host/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-host/src/lib.rs
@@ -8,23 +8,23 @@ use casper_contract_sdk::{
 
 const CURRENT_VERSION: &str = "v1";
 
-// This contract is used to assert that calling host functions consumes gas.
-// It is by design that it does nothing other than calling appropriate host functions.
+// This contract is used to assert that calling host functions consumes gas and doesn't panic.
 
-// There is no need for these functions to actually do anything meaningful, and it's alright
-// if they short-circuit.
+// There is no need for these functions to actually do anything meaningful, but the execution
+// should be succesful.
 
 #[casper(contract_state)]
-pub struct MinHostWrapper;
+pub struct MinimalHostWrapper;
 
-impl Default for MinHostWrapper {
+impl Default for MinimalHostWrapper {
     fn default() -> Self {
         panic!("Unable to instantiate contract without a constructor");
     }
 }
 
 #[casper]
-impl MinHostWrapper {
+#[allow(clippy::should_implement_trait)]
+impl MinimalHostWrapper {
     #[casper(constructor)]
     pub fn new(with_host_fn_call: String) -> Self {
         let ret = Self;
@@ -72,6 +72,7 @@ impl MinHostWrapper {
                 ret.write();
             }
             "ret_faulty_flags" => ret.ret_faulty_flags(),
+            "generic_hash" => ret.generic_hash(),
             _ => panic!("Unknown host function"),
         }
         ret
@@ -160,7 +161,43 @@ impl MinHostWrapper {
             casper::ret(ReturnFlags::empty(), Some(&[1, 2, 3]));
         }
         let data = [1, 2, 3];
-        let (data_ptr, data_len) = ((&data).as_ptr(), (&data).len());
+        let (data_ptr, data_len) = (data.as_ptr(), data.len());
         unsafe { casper_return(faulty_flags, data_ptr, data_len) };
+    }
+
+    pub fn generic_hash(&self) {
+        let data = [1, 1, 2, 5, 14, 42, 132];
+
+        assert_eq!(
+            casper::generic_hash(&data, 0), // Blake2b
+            Ok([
+                101, 134, 221, 117, 175, 165, 62, 143, 176, 114, 113, 246, 5, 183, 189, 207, 11,
+                104, 170, 199, 146, 141, 122, 205, 157, 158, 233, 5, 125, 81, 23, 241
+            ]),
+        );
+
+        assert_eq!(
+            casper::generic_hash(&data, 0), // Blake3
+            Ok([
+                126, 230, 212, 24, 35, 87, 8, 3, 4, 62, 160, 20, 182, 106, 115, 229, 187, 7, 147,
+                32, 244, 103, 58, 70, 70, 67, 7, 151, 246, 32, 38, 93
+            ]),
+        );
+
+        assert_eq!(
+            casper::generic_hash(&data, 0), // Sha256
+            Ok([
+                0, 230, 115, 1, 88, 98, 21, 212, 204, 82, 181, 141, 113, 17, 93, 117, 110, 170, 80,
+                53, 20, 125, 106, 121, 92, 98, 75, 159, 117, 104, 172, 57
+            ]),
+        );
+
+        assert_eq!(
+            casper::generic_hash(&data, 0), // Keccak256
+            Ok([
+                114, 172, 78, 22, 211, 115, 239, 44, 244, 233, 234, 252, 93, 139, 253, 67, 225, 90,
+                77, 165, 66, 13, 132, 134, 234, 199, 38, 235, 176, 138, 236, 105
+            ]),
+        );
     }
 }

--- a/smart_contracts/contracts/vm2/vm2-host/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-host/src/lib.rs
@@ -4,6 +4,7 @@ use casper_contract_sdk::{
     casper_executor_wasm_common::{flags::ReturnFlags, keyspace::Keyspace},
     prelude::*,
     sys::casper_return,
+    types::HashAlgorithm,
 };
 
 const CURRENT_VERSION: &str = "v1";
@@ -169,7 +170,7 @@ impl MinimalHostWrapper {
         let data = [1, 1, 2, 5, 14, 42, 132];
 
         assert_eq!(
-            casper::generic_hash(&data, 0), // Blake2b
+            casper::generic_hash(&data, HashAlgorithm::Blake2b),
             Ok([
                 101, 134, 221, 117, 175, 165, 62, 143, 176, 114, 113, 246, 5, 183, 189, 207, 11,
                 104, 170, 199, 146, 141, 122, 205, 157, 158, 233, 5, 125, 81, 23, 241
@@ -177,7 +178,7 @@ impl MinimalHostWrapper {
         );
 
         assert_eq!(
-            casper::generic_hash(&data, 0), // Blake3
+            casper::generic_hash(&data, HashAlgorithm::Blake3),
             Ok([
                 126, 230, 212, 24, 35, 87, 8, 3, 4, 62, 160, 20, 182, 106, 115, 229, 187, 7, 147,
                 32, 244, 103, 58, 70, 70, 67, 7, 151, 246, 32, 38, 93
@@ -185,7 +186,7 @@ impl MinimalHostWrapper {
         );
 
         assert_eq!(
-            casper::generic_hash(&data, 0), // Sha256
+            casper::generic_hash(&data, HashAlgorithm::Sha256),
             Ok([
                 0, 230, 115, 1, 88, 98, 21, 212, 204, 82, 181, 141, 113, 17, 93, 117, 110, 170, 80,
                 53, 20, 125, 106, 121, 92, 98, 75, 159, 117, 104, 172, 57
@@ -193,7 +194,7 @@ impl MinimalHostWrapper {
         );
 
         assert_eq!(
-            casper::generic_hash(&data, 0), // Keccak256
+            casper::generic_hash(&data, HashAlgorithm::Keccak256),
             Ok([
                 114, 172, 78, 22, 211, 115, 239, 44, 244, 233, 234, 252, 93, 139, 253, 67, 225, 90,
                 77, 165, 66, 13, 132, 134, 234, 199, 38, 235, 176, 138, 236, 105

--- a/smart_contracts/sdk/src/casper.rs
+++ b/smart_contracts/sdk/src/casper.rs
@@ -553,6 +553,20 @@ pub fn get_block_time() -> u64 {
     info.block_time
 }
 
+#[inline]
+pub fn generic_hash(data: &[u8], algorithm: usize) -> Result<[u8; 32], CommonResult> {
+    let output = [0; 32];
+    let ret = unsafe {
+        casper_contract_sdk_sys::casper_generic_hash(
+            data.as_ptr(),
+            data.len(),
+            output.as_ptr(),
+            algorithm,
+        )
+    };
+    result_from_code(ret).map(|_| output)
+}
+
 #[doc(hidden)]
 pub fn emit_raw(topic: &str, payload: &[u8]) -> Result<(), CommonResult> {
     let ret = unsafe {

--- a/smart_contracts/sdk/src/casper.rs
+++ b/smart_contracts/sdk/src/casper.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     reserve_vec_space,
     serializers::borsh::{BorshDeserialize, BorshSerialize},
-    types::{Address, CallError},
+    types::{Address, CallError, HashAlgorithm},
     Message, ToCallData,
 };
 
@@ -554,14 +554,14 @@ pub fn get_block_time() -> u64 {
 }
 
 #[inline]
-pub fn generic_hash(data: &[u8], algorithm: usize) -> Result<[u8; 32], CommonResult> {
+pub fn generic_hash(data: &[u8], algorithm: HashAlgorithm) -> Result<[u8; 32], CommonResult> {
     let output = [0; 32];
     let ret = unsafe {
         casper_contract_sdk_sys::casper_generic_hash(
             data.as_ptr(),
             data.len(),
             output.as_ptr(),
-            algorithm,
+            algorithm as usize,
         )
     };
     result_from_code(ret).map(|_| output)

--- a/smart_contracts/sdk/src/casper/native.rs
+++ b/smart_contracts/sdk/src/casper/native.rs
@@ -905,6 +905,16 @@ mod symbols {
         let ret = with_current_environment(|env| env.casper_env_info(info_ptr, info_size));
         crate::casper::native::handle_ret(ret)
     }
+
+    #[no_mangle]
+    pub extern "C" fn casper_generic_hash(
+        _in_ptr: *const u8,
+        _in_size: u32,
+        _out_ptr: *const u8,
+        _algorithm: u32,
+    ) -> u32 {
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/smart_contracts/sdk/src/types.rs
+++ b/smart_contracts/sdk/src/types.rs
@@ -11,6 +11,20 @@ use crate::{
 pub type Address = [u8; 32];
 pub use bnum::types::U256;
 
+/// A type of hashing algorithm.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "crate::serializers::borsh", use_discriminant = true)]
+pub enum HashAlgorithm {
+    /// Blake2b
+    Blake2b = 0,
+    /// Blake3
+    Blake3 = 1,
+    /// Sha256,
+    Sha256 = 2,
+    /// Keccak256
+    Keccak256 = 3,
+}
+
 // Keep in sync with [`casper_executor_wasm_common::error::CallError`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "crate::serializers::borsh")]

--- a/smart_contracts/sdk_sys/src/for_each_host_function.rs
+++ b/smart_contracts/sdk_sys/src/for_each_host_function.rs
@@ -67,6 +67,7 @@ macro_rules! for_each_host_function {
             pub fn casper_env_info(info_ptr: *const u8, info_size: u32,) -> u32;
             pub fn casper_transfer(entity_addr_ptr: *const u8, entity_addr_len: usize, amount: *const core::ffi::c_void,) -> u32;
             pub fn casper_emit(topic_ptr: *const u8, topic_size: usize, payload_ptr: *const u8, payload_size: usize,) -> u32;
+            pub fn casper_generic_hash(in_ptr: *const u8, in_size: usize, out_ptr: *const u8, hash_algorithm: usize,) -> u32;
         }
     };
 }

--- a/types/src/chainspec/vm_config/host_function_costs_v2.rs
+++ b/types/src/chainspec/vm_config/host_function_costs_v2.rs
@@ -354,6 +354,7 @@ impl ToBytes for HostFunctionCostsV2 {
         ret.append(&mut self.print.to_bytes()?);
         ret.append(&mut self.emit.to_bytes()?);
         ret.append(&mut self.env_info.to_bytes()?);
+        ret.append(&mut self.generic_hash.to_bytes()?);
         Ok(ret)
     }
 
@@ -371,6 +372,7 @@ impl ToBytes for HostFunctionCostsV2 {
             + self.print.serialized_length()
             + self.emit.serialized_length()
             + self.env_info.serialized_length()
+            + self.generic_hash.serialized_length()
     }
 }
 

--- a/types/src/chainspec/vm_config/host_function_costs_v2.rs
+++ b/types/src/chainspec/vm_config/host_function_costs_v2.rs
@@ -197,6 +197,9 @@ const DEFAULT_EMIT_PAYLOAD_SIZE_HEIGHT: Cost = 100;
 
 const DEFAULT_ENV_INFO_COST: Cost = 10_000;
 
+const DEFAULT_GENERIC_HASH_COST: Cost = 0;
+const DEFAULT_GENERIC_HASH_SIZE_WEIGHT: Cost = 0;
+
 /// Definition of a host function cost table.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "datasize", derive(DataSize))]
@@ -228,6 +231,8 @@ pub struct HostFunctionCostsV2 {
     pub emit: HostFunctionV2<[Cost; 4]>,
     /// Cost of calling the `env_info` host function.
     pub env_info: HostFunctionV2<[Cost; 2]>,
+    /// Cost of calling the `generic_hash` host function.
+    pub generic_hash: HostFunctionV2<[Cost; 4]>,
 }
 
 impl HostFunctionCostsV2 {
@@ -246,6 +251,7 @@ impl HostFunctionCostsV2 {
             print: HostFunctionV2::zero(),
             emit: HostFunctionV2::zero(),
             env_info: HostFunctionV2::zero(),
+            generic_hash: HostFunctionV2::zero(),
         }
     }
 }
@@ -319,6 +325,15 @@ impl Default for HostFunctionCostsV2 {
                 ],
             ),
             env_info: HostFunctionV2::new(DEFAULT_ENV_INFO_COST, [NOT_USED, NOT_USED]),
+            generic_hash: HostFunctionV2::new(
+                DEFAULT_GENERIC_HASH_COST,
+                [
+                    NOT_USED,
+                    DEFAULT_GENERIC_HASH_SIZE_WEIGHT,
+                    NOT_USED,
+                    NOT_USED,
+                ],
+            ),
         }
     }
 }
@@ -374,6 +389,7 @@ impl FromBytes for HostFunctionCostsV2 {
         let (print, rem) = FromBytes::from_bytes(rem)?;
         let (emit, rem) = FromBytes::from_bytes(rem)?;
         let (env_info, rem) = FromBytes::from_bytes(rem)?;
+        let (generic_hash, rem) = FromBytes::from_bytes(rem)?;
         Ok((
             HostFunctionCostsV2 {
                 read,
@@ -389,6 +405,7 @@ impl FromBytes for HostFunctionCostsV2 {
                 print,
                 emit,
                 env_info,
+                generic_hash,
             },
             rem,
         ))
@@ -412,6 +429,7 @@ impl Distribution<HostFunctionCostsV2> for Standard {
             print: rng.gen(),
             emit: rng.gen(),
             env_info: rng.gen(),
+            generic_hash: rng.gen(),
         }
     }
 }
@@ -445,6 +463,7 @@ pub mod gens {
             print in host_function_cost_v2_arb(),
             emit in host_function_cost_v2_arb(),
             env_info in host_function_cost_v2_arb(),
+            generic_hash in host_function_cost_v2_arb(),
         ) -> HostFunctionCostsV2 {
             HostFunctionCostsV2 {
                 read,
@@ -459,7 +478,8 @@ pub mod gens {
                 call,
                 print,
                 emit,
-                env_info
+                env_info,
+                generic_hash,
             }
         }
     }


### PR DESCRIPTION
Adds a `casper_generic_hash` host function to VM2. This is the same as the VM1 generic hashing capability, and has been added to match feature parity.

Supports Blake2b, Blake3, Sha256, Keccak256, just like the VM1 equivalent.