### PR TITLE
[VM-2] Write entry points and named keys consistent with VM1

### DIFF
--- a/executor/wasm/src/lib.rs
+++ b/executor/wasm/src/lib.rs
@@ -40,11 +40,12 @@ use casper_storage::{
 };
 use casper_types::{
     account::AccountHash,
-    addressable_entity::{ActionThresholds, AssociatedKeys},
-    bytesrepr, AddressableEntity, ByteCode, ByteCodeAddr, ByteCodeHash, ByteCodeKind,
-    ContractRuntimeTag, Digest, EntityAddr, EntityKind, Gas, Groups, InitiatorAddr, Key,
-    MessageLimits, Package, PackageHash, PackageStatus, Phase, ProtocolVersion, StorageCosts,
-    StoredValue, TransactionHash, TransactionInvocationTarget, URef, WasmV2Config,
+    addressable_entity::{ActionThresholds, AssociatedKeys, EntityEntryPoint},
+    bytesrepr, AddressableEntity, ByteCode, ByteCodeAddr, ByteCodeHash, ByteCodeKind, CLType,
+    ContractRuntimeTag, Digest, EntityAddr, EntityKind, EntryPointAccess, EntryPointAddr,
+    EntryPointPayment, EntryPointType, EntryPointValue, Gas, Groups, InitiatorAddr, Key,
+    MessageLimits, Package, PackageHash, PackageStatus, Parameters, Phase, ProtocolVersion,
+    StorageCosts, StoredValue, TransactionHash, TransactionInvocationTarget, URef, WasmV2Config,
 };
 use install::{InstallContractError, InstallContractRequest, InstallContractResult};
 use parking_lot::RwLock;
@@ -245,6 +246,47 @@ impl ExecutorV2 {
         // 3. Store addressable entity
         let addressable_entity_key =
             Key::AddressableEntity(EntityAddr::SmartContract(smart_contract_addr));
+
+        // 3.1 Store entry points first
+        {
+            let config = ConfigBuilder::new()
+                .with_gas_limit(gas_limit)
+                .with_memory_limit(self.config.memory_limit)
+                .build();
+
+            let entry_point_names = casper_executor_wasmer_backend::entry_point_names(
+                wasm_bytes, config,
+            )
+            .map_err(|wasm_prep_error| {
+                InstallContractError::Execute(ExecuteError::WasmPreparation(wasm_prep_error))
+            })?;
+
+            for name in entry_point_names {
+                let entry_point = EntityEntryPoint::new(
+                    name.clone(),
+                    Parameters::new(),
+                    CLType::Unit,
+                    EntryPointAccess::Public,
+                    EntryPointType::Called,
+                    EntryPointPayment::Caller,
+                );
+
+                let entry_point_addr = EntryPointAddr::new_v1_entry_point_addr(
+                    EntityAddr::SmartContract(smart_contract_addr),
+                    &name,
+                )
+                .map_err(|err| {
+                    InstallContractError::GlobalState(GlobalStateError::BytesRepr(err))
+                })?;
+
+                let entry_point_key = Key::EntryPoint(entry_point_addr);
+
+                tracking_copy.write(
+                    entry_point_key,
+                    StoredValue::EntryPoint(EntryPointValue::V1CasperVm(entry_point)),
+                )
+            }
+        }
 
         // TODO: abort(str) as an alternative to trap
         let main_purse: URef = match system::create_purse(

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -41,6 +41,8 @@ use either::Either;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use tracing::{error, info, warn};
+use casper_types::addressable_entity::NamedKeyValue;
+use casper_types::bytesrepr::FromBytes;
 
 use crate::{
     abi::{CreateResult, ReadInfo},
@@ -192,10 +194,20 @@ pub fn casper_write<S: GlobalStateReader, E: Executor>(
     let value = caller.memory_read(value_ptr, value_size.try_into_wrapped()?)?;
 
     let stored_value = match keyspace {
-        Keyspace::State | Keyspace::Context(_) | Keyspace::NamedKey(_) => {
+        Keyspace::State | Keyspace::Context(_)  => {
             let cl_value_any = CLValue::from_components(CLType::Any, value);
             StoredValue::CLValue(cl_value_any)
         }
+        Keyspace::NamedKey(name) => {
+            let (key, remainder) = Key::from_bytes(&value)?;
+            if !remainder.is_empty() {
+
+            }
+
+
+
+            let stored_value = StoredValue::NamedKey(NamedKeyValue::from_concrete_values(, name.clone()))
+        },
         Keyspace::PaymentInfo(_) => {
             let entry_point_payment = match value.as_slice() {
                 [ENTRY_POINT_PAYMENT_CALLER] => EntryPointPayment::Caller,

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -27,8 +27,10 @@ use casper_storage::{
 };
 use casper_types::{
     account::AccountHash,
-    addressable_entity::{ActionThresholds, AssociatedKeys, MessageTopicError, NamedKeyAddr},
-    bytesrepr::ToBytes,
+    addressable_entity::{
+        ActionThresholds, AssociatedKeys, MessageTopicError, NamedKeyAddr, NamedKeyValue,
+    },
+    bytesrepr::{FromBytes, ToBytes},
     contract_messages::{Message, MessageAddr, MessagePayload, MessageTopicSummary},
     execution::RetValue,
     AddressableEntity, BlockGlobalAddr, BlockHash, BlockTime, ByteCode, ByteCodeAddr, ByteCodeHash,
@@ -41,8 +43,6 @@ use either::Either;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use tracing::{error, info, warn};
-use casper_types::addressable_entity::NamedKeyValue;
-use casper_types::bytesrepr::FromBytes;
 
 use crate::{
     abi::{CreateResult, ReadInfo},
@@ -194,20 +194,27 @@ pub fn casper_write<S: GlobalStateReader, E: Executor>(
     let value = caller.memory_read(value_ptr, value_size.try_into_wrapped()?)?;
 
     let stored_value = match keyspace {
-        Keyspace::State | Keyspace::Context(_)  => {
+        Keyspace::State | Keyspace::Context(_) => {
             let cl_value_any = CLValue::from_components(CLType::Any, value);
             StoredValue::CLValue(cl_value_any)
         }
         Keyspace::NamedKey(name) => {
-            let (key, remainder) = Key::from_bytes(&value)?;
-            if !remainder.is_empty() {
+            let key = match Key::from_bytes(&value) {
+                Ok((key, remainder)) => {
+                    if !remainder.is_empty() {
+                        return Ok(HOST_ERROR_INVALID_INPUT);
+                    }
+                    key
+                }
+                Err(_) => return Ok(HOST_ERROR_INVALID_DATA),
+            };
 
-            }
-
-
-
-            let stored_value = StoredValue::NamedKey(NamedKeyValue::from_concrete_values(, name.clone()))
-        },
+            let named_key_value = match NamedKeyValue::from_concrete_values(key, name.to_string()) {
+                Ok(named_key_value) => named_key_value,
+                Err(_) => return Ok(HOST_ERROR_INVALID_DATA),
+            };
+            StoredValue::NamedKey(named_key_value)
+        }
         Keyspace::PaymentInfo(_) => {
             let entry_point_payment = match value.as_slice() {
                 [ENTRY_POINT_PAYMENT_CALLER] => EntryPointPayment::Caller,

--- a/executor/wasmer_backend/src/lib.rs
+++ b/executor/wasmer_backend/src/lib.rs
@@ -470,3 +470,36 @@ where
         }
     }
 }
+
+pub fn entry_point_names(
+    wasm_bytes: Bytes,
+    config: Config,
+) -> Result<Vec<String>, WasmPreparationError> {
+    let engine = {
+        let mut singlepass_compiler = Singlepass::new();
+        let gatekeeper_config = GatekeeperConfig::default();
+        singlepass_compiler.push_middleware(Arc::new(Gatekeeper::new(gatekeeper_config)));
+
+        singlepass_compiler
+            .push_middleware(gas_metering::gas_metering_middleware(config.gas_limit()));
+
+        singlepass_compiler
+    };
+
+    let max_mem_pages = Pages(config.memory_limit());
+
+    let base = BaseTunables::for_target(&Target::default());
+    let tunables = MemLimitTunables::new(base, max_mem_pages);
+    let mut engine = Engine::from(engine);
+    engine.set_tunables(tunables);
+
+    let module = Module::new(&engine, &wasm_bytes)
+        .map_err(|error| WasmPreparationError::Compile(error.to_string()))?;
+
+    let entry_point_names = module
+        .exports()
+        .map(|export| export.name().to_string())
+        .collect();
+
+    Ok(entry_point_names)
+}


### PR DESCRIPTION
CHANGELOG:

- Write Entrypoints for a given contract entity in the style of the 1.x engine
- Write NamedKeys for a given addressable entity in the style of the 1.x engine