### PR TITLE
Fix miswire of genesis config

### DIFF
--- a/execution_engine_testing/test_support/src/chainspec_config.rs
+++ b/execution_engine_testing/test_support/src/chainspec_config.rs
@@ -131,6 +131,7 @@ impl ChainspecConfig {
             locked_funds_period,
             unbonding_delay,
             round_seigniorage_rate,
+            enable_addressable_entity,
             ..
         } = core_config;
 
@@ -144,6 +145,7 @@ impl ChainspecConfig {
             .with_round_seigniorage_rate(*round_seigniorage_rate)
             .with_unbonding_delay(*unbonding_delay)
             .with_genesis_timestamp_millis(DEFAULT_GENESIS_TIMESTAMP_MILLIS)
+            .with_enable_addressable_entity(*enable_addressable_entity)
             .with_storage_costs(*storage_costs)
             .build();
 

--- a/execution_engine_testing/test_support/src/utils.rs
+++ b/execution_engine_testing/test_support/src/utils.rs
@@ -11,7 +11,9 @@ use casper_execution_engine::engine_state::{Error, WasmV1Result};
 use casper_storage::data_access_layer::GenesisRequest;
 use casper_types::{bytesrepr::Bytes, GenesisAccount, GenesisConfig};
 
-use super::{DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY};
+use super::{
+    ChainspecConfig, DEFAULT_ROUND_SEIGNIORAGE_RATE, DEFAULT_SYSTEM_CONFIG, DEFAULT_UNBONDING_DELAY,
+};
 use crate::{
     GenesisConfigBuilder, DEFAULT_AUCTION_DELAY, DEFAULT_CHAINSPEC_REGISTRY,
     DEFAULT_GENESIS_CONFIG_HASH, DEFAULT_GENESIS_TIMESTAMP_MILLIS,
@@ -134,9 +136,43 @@ pub fn create_genesis_config(accounts: Vec<GenesisAccount>) -> GenesisConfig {
         .build()
 }
 
+/// Returns an [`GenesisConfig`] using a given chainspec config.
+pub fn create_genesis_config_with_chainspec(
+    accounts: Vec<GenesisAccount>,
+    chainspec: ChainspecConfig,
+) -> GenesisConfig {
+    GenesisConfigBuilder::default()
+        .with_accounts(accounts)
+        .with_wasm_config(chainspec.wasm_config)
+        .with_system_config(chainspec.system_costs_config)
+        .with_validator_slots(chainspec.core_config.validator_slots)
+        .with_auction_delay(chainspec.core_config.auction_delay)
+        .with_locked_funds_period_millis(chainspec.core_config.locked_funds_period.millis())
+        .with_round_seigniorage_rate(chainspec.core_config.round_seigniorage_rate)
+        .with_unbonding_delay(chainspec.core_config.unbonding_delay)
+        .with_genesis_timestamp_millis(DEFAULT_GENESIS_TIMESTAMP_MILLIS)
+        .with_storage_costs(chainspec.storage_costs)
+        .with_enable_addressable_entity(chainspec.core_config.enable_addressable_entity)
+        .build()
+}
+
 /// Returns a [`GenesisRequest`].
 pub fn create_run_genesis_request(accounts: Vec<GenesisAccount>) -> GenesisRequest {
     let config = create_genesis_config(accounts);
+    GenesisRequest::new(
+        DEFAULT_GENESIS_CONFIG_HASH,
+        DEFAULT_PROTOCOL_VERSION,
+        config,
+        DEFAULT_CHAINSPEC_REGISTRY.clone(),
+    )
+}
+
+/// Returns a [`GenesisRequest`] using a given chainspec config.
+pub fn create_run_genesis_request_with_chainspec_config(
+    accounts: Vec<GenesisAccount>,
+    chainspec_config: ChainspecConfig,
+) -> GenesisRequest {
+    let config = create_genesis_config_with_chainspec(accounts, chainspec_config);
     GenesisRequest::new(
         DEFAULT_GENESIS_CONFIG_HASH,
         DEFAULT_PROTOCOL_VERSION,

--- a/execution_engine_testing/tests/src/test/regression/mod.rs
+++ b/execution_engine_testing/tests/src/test/regression/mod.rs
@@ -62,6 +62,7 @@ mod regression_20220224;
 mod regression_20220303;
 mod regression_20220727;
 mod regression_20240105;
+mod regression_20250812;
 mod slow_input;
 pub(crate) mod test_utils;
 mod transforms_must_be_ordered;

--- a/execution_engine_testing/tests/src/test/regression/regression_20250812.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20250812.rs
@@ -1,0 +1,35 @@
+use casper_engine_test_support::{
+    utils::create_run_genesis_request, ChainspecConfig, ExecuteRequestBuilder, LmdbWasmTestBuilder,
+    DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
+};
+use casper_types::RuntimeArgs;
+
+const DO_NOTHING_CONTRACT: &str = "do_nothing.wasm";
+
+#[ignore]
+#[test]
+fn should_correctly_install_and_add_contract_version_with_ae_turned_on() {
+    let chainspec = ChainspecConfig::default().with_enable_addressable_entity(true); // false makes test succeed
+
+    let mut builder = LmdbWasmTestBuilder::new_temporary_with_config(chainspec);
+    builder
+        .run_genesis(create_run_genesis_request(DEFAULT_ACCOUNTS.to_vec()))
+        .commit();
+
+    let install_request_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        DO_NOTHING_CONTRACT,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    let install_request_2 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        DO_NOTHING_CONTRACT,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(install_request_1).expect_success().commit();
+    builder.exec(install_request_2).expect_success().commit();
+}

--- a/execution_engine_testing/tests/src/test/regression/regression_20250812.rs
+++ b/execution_engine_testing/tests/src/test/regression/regression_20250812.rs
@@ -1,19 +1,22 @@
 use casper_engine_test_support::{
-    utils::create_run_genesis_request, ChainspecConfig, ExecuteRequestBuilder, LmdbWasmTestBuilder,
-    DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
+    utils::create_run_genesis_request_with_chainspec_config, ChainspecConfig,
+    ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR,
 };
 use casper_types::RuntimeArgs;
 
-const DO_NOTHING_CONTRACT: &str = "do_nothing.wasm";
+const DO_NOTHING_CONTRACT: &str = "do_nothing_stored.wasm";
 
 #[ignore]
 #[test]
 fn should_correctly_install_and_add_contract_version_with_ae_turned_on() {
-    let chainspec = ChainspecConfig::default().with_enable_addressable_entity(true); // false makes test succeed
+    let chainspec = ChainspecConfig::default().with_enable_addressable_entity(true);
 
-    let mut builder = LmdbWasmTestBuilder::new_temporary_with_config(chainspec);
+    let mut builder = LmdbWasmTestBuilder::new_temporary_with_config(chainspec.clone());
     builder
-        .run_genesis(create_run_genesis_request(DEFAULT_ACCOUNTS.to_vec()))
+        .run_genesis(create_run_genesis_request_with_chainspec_config(
+            DEFAULT_ACCOUNTS.to_vec(),
+            chainspec,
+        ))
         .commit();
 
     let install_request_1 = ExecuteRequestBuilder::standard(


### PR DESCRIPTION
Fixes an issue where the Genesis Config builder was not using the AE flag from the chainspec config