### PR TITLE
[VM2] Don't collect unreachable information into the schema

### DIFF
--- a/smart_contracts/contracts/vm2/vm2-harness/src/contracts/harness.rs
+++ b/smart_contracts/contracts/vm2/vm2-harness/src/contracts/harness.rs
@@ -72,6 +72,12 @@ pub enum CustomError {
     Deposit(CallError),
 }
 
+#[derive(Debug, PartialEq)]
+#[casper]
+pub struct PublicStructUsedOnlyByPrivateEntrypoint {
+    pub value: u64,
+}
+
 impl Default for Harness {
     fn default() -> Self {
         Self {
@@ -448,5 +454,10 @@ impl Harness {
         _arg23: u64,
     ) {
         log!("Nothing");
+    }
+
+    #[casper(private)]
+    pub fn private_only_uses_public_struct(&self, _arg: PublicStructUsedOnlyByPrivateEntrypoint) {
+        log!("This function should be private and its arg type should not appear in schema");
     }
 }

--- a/smart_contracts/macros/src/lib.rs
+++ b/smart_contracts/macros/src/lib.rs
@@ -343,6 +343,10 @@ fn generate_impl_for_contract(mut entry_points: ItemImpl) -> TokenStream {
 
                 func.attrs.clear();
 
+                if method_attribute.private {
+                    continue;
+                }
+
                 let func_name = func.sig.ident.clone();
                 if func_name.to_string().starts_with("__casper_") {
                     return TokenStream::from(


### PR DESCRIPTION
Makes it such that types only accessible from private call-paths will not be included in the VM2 contract's schema.