### PR TITLE
[VM 2.0 SDK] Make `void` results in entrypoints present as `null` in the schema instead of ()

### DIFF
--- a/smart_contracts/macros/src/lib.rs
+++ b/smart_contracts/macros/src/lib.rs
@@ -706,7 +706,7 @@ fn generate_impl_for_contract(mut entry_points: ItemImpl) -> TokenStream {
                         definitions.populate_one::<()>();
                     });
 
-                    quote! { <() as casper_contract_sdk::abi::CasperABI>::declaration() }
+                    quote! { None }
                 }
                 syn::ReturnType::Type(_, ty) => match ty.as_ref() {
                     Type::Never(_) => {
@@ -714,14 +714,14 @@ fn generate_impl_for_contract(mut entry_points: ItemImpl) -> TokenStream {
                             definitions.populate_one::<()>();
                         });
 
-                        quote! { <() as casper_contract_sdk::abi::CasperABI>::declaration() }
+                        quote! { None }
                     }
                     _ => {
                         populate_definitions.push(quote! {
                             definitions.populate_one::<#ty>();
                         });
 
-                        quote! { <#ty as casper_contract_sdk::abi::CasperABI>::declaration() }
+                        quote! { Some(<#ty as casper_contract_sdk::abi::CasperABI>::declaration()) }
                     }
                 },
             };
@@ -1010,7 +1010,7 @@ fn casper_trait_definition(mut item_trait: ItemTrait, trait_meta: TraitMeta) -> 
                             definitions.populate_one::<()>();
                         });
 
-                        quote! { <() as #crate_path::abi::CasperABI>::declaration() }
+                        quote! { None }
                     }
                     syn::ReturnType::Type(_, ty) => {
                         if let Type::Never(_) = ty.as_ref() {
@@ -1018,13 +1018,13 @@ fn casper_trait_definition(mut item_trait: ItemTrait, trait_meta: TraitMeta) -> 
                                 definitions.populate_one::<()>();
                             });
 
-                            quote! { <() as #crate_path::abi::CasperABI>::declaration() }
+                            quote! { None }
                         } else {
                             populate_definitions.push(quote! {
                                 definitions.populate_one::<#ty>();
                             });
 
-                            quote! { <#ty as #crate_path::abi::CasperABI>::declaration() }
+                            quote! { Some(<#ty as #crate_path::abi::CasperABI>::declaration()) }
                         }
                     }
                 };

--- a/smart_contracts/sdk/src/schema.rs
+++ b/smart_contracts/sdk/src/schema.rs
@@ -41,7 +41,7 @@ pub struct SchemaArgument {
 pub struct SchemaEntryPoint {
     pub name: String,
     pub arguments: Vec<SchemaArgument>,
-    pub result: Declaration,
+    pub result: Option<Declaration>,
     #[serde(
         serialize_with = "serialize_bits",
         deserialize_with = "deserialize_bits"

--- a/smart_contracts/sdk_codegen/src/lib.rs
+++ b/smart_contracts/sdk_codegen/src/lib.rs
@@ -500,10 +500,13 @@ impl Codegen {
             let func = client_impl.new_fn(&entry_point.name);
             func.vis("pub");
 
-            let result_type = self
-                .type_mapping
-                .get(&entry_point.result)
-                .unwrap_or_else(|| panic!("Missing type mapping for {}", entry_point.result));
+            let result_type = if let Some(result_decl) = &entry_point.result {
+                self.type_mapping
+                    .get(result_decl)
+                    .unwrap_or_else(|| panic!("Missing type mapping for {}", result_decl))
+            } else {
+                "()"
+            };
 
             if entry_point.flags.contains(EntryPointFlags::CONSTRUCTOR) {
                 func.ret(Type::new(format!(
@@ -513,9 +516,15 @@ impl Codegen {
                 .generic("C")
                 .bound("C", "casper_contract_sdk::Contract");
             } else {
-                func.ret(Type::new(format!(
-                    "Result<casper_contract_sdk::host::CallResult<{result_type}>, casper_contract_sdk::types::CallError>"
-                )));
+                if entry_point.result.is_some() {
+                    func.ret(Type::new(format!(
+                        "Result<casper_contract_sdk::host::CallResult<{result_type}>, casper_contract_sdk::types::CallError>"
+                    )));
+                } else {
+                    func.ret(Type::new(
+                        "Result<(), casper_contract_sdk::types::CallError>",
+                    ));
+                }
                 func.arg_ref_self();
             }
 


### PR DESCRIPTION
Makes "void" results in entrypoints' schema present as `null` instead of "()".
