### PR TITLE
[Experimental] known addr sync

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -264,7 +264,7 @@ impl BlockSynchronizer {
 
         let (block_header, maybe_sigs) = sync_leap.highest_block_header_and_signatures();
         if let Some(builder) = self.get_builder(block_header.block_hash(), true) {
-            debug!(%builder, "BlockSynchronizer: register_sync_leap update builder");
+            info!(%builder, "BlockSynchronizer: register_sync_leap update builder");
             apply_sigs(builder, maybe_sigs);
             builder.register_peers(peers);
         } else {
@@ -283,6 +283,7 @@ impl BlockSynchronizer {
                         .core_config
                         .start_protocol_version_with_strict_finality_signatures_required,
                 );
+                debug!(%builder, "BlockSynchronizer: register_sync_leap create new builder");
                 apply_sigs(&mut builder, maybe_sigs);
                 if should_fetch_execution_state {
                     self.historical = Some(builder);
@@ -649,16 +650,30 @@ impl BlockSynchronizer {
                     }
                 }
                 NeedNext::Peers(block_hash) => {
-                    if builder.should_fetch_execution_state() {
-                        builder.latch();
-                        // the accumulator may or may not have peers for an older block,
-                        // so we're going to also get a random sampling from networking
-                        results.extend(
-                            effect_builder
-                                .get_fully_connected_peers(max_simultaneous_peers as usize)
-                                .event(move |peers| Event::NetworkPeers(block_hash, peers)),
-                        )
-                    }
+                    const KNOWN_ADDR_COUNT: usize = 1;
+                    let total_count = if builder.should_fetch_execution_state() {
+                        max_simultaneous_peers as usize + KNOWN_ADDR_COUNT
+                    } else {
+                        KNOWN_ADDR_COUNT
+                    };
+
+                    // latch for each self event being added to effects...
+                    // the latch count will be decremented when the event comes back in from the
+                    // event loop (in get_builder with decrement latch == true)
+
+                    builder.latch();
+                    // the accumulator may or may not have peers for an older block,
+                    // so we're going to also get a random sampling from networking
+                    // plus 1 known address
+                    results.extend(
+                        effect_builder
+                            .get_fully_connected_peers_with_known_addresses(
+                                KNOWN_ADDR_COUNT,
+                                total_count,
+                            )
+                            .event(move |peers| Event::NetworkPeers(block_hash, peers)),
+                    );
+
                     builder.latch();
                     results.extend(
                         effect_builder

--- a/node/src/components/block_synchronizer/tests.rs
+++ b/node/src/components/block_synchronizer/tests.rs
@@ -30,7 +30,6 @@ use crate::{
     effect::Effect,
     reactor::{EventQueueHandle, QueueKind, Scheduler},
     tls::KeyFingerprint,
-    types::{BlockExecutionResultsOrChunkId, ValueOrChunk},
     utils,
 };
 
@@ -500,10 +499,11 @@ async fn synchronizer_doesnt_busy_loop_without_peers() {
         // Explicitly verify the two effects are indeed asking networking and accumulator for peers.
         assert_matches!(
             events[0],
-            MockReactorEvent::NetworkInfoRequest(NetworkInfoRequest::FullyConnectedPeers {
-                count,
+            MockReactorEvent::NetworkInfoRequest(NetworkInfoRequest::FullyConnectedPeersIncludingKnownAddresses {
+                total_count,
+                known_addr_count,
                 ..
-            }) if count == MAX_SIMULTANEOUS_PEERS as usize
+            }) if total_count == MAX_SIMULTANEOUS_PEERS as usize + known_addr_count && known_addr_count == 1
         );
         assert_matches!(
             events[1],
@@ -783,10 +783,11 @@ async fn historical_sync_gets_peers_form_both_connected_peers_and_accumulator() 
     // for the block that is being synchronized.
     assert_matches!(
         events[0],
-        MockReactorEvent::NetworkInfoRequest(NetworkInfoRequest::FullyConnectedPeers {
-            count,
+        MockReactorEvent::NetworkInfoRequest(NetworkInfoRequest::FullyConnectedPeersIncludingKnownAddresses {
+            total_count,
+            known_addr_count,
             ..
-        }) if count == MAX_SIMULTANEOUS_PEERS as usize
+        }) if total_count == MAX_SIMULTANEOUS_PEERS as usize + known_addr_count && known_addr_count == 1
     );
 
     assert_matches!(
@@ -817,14 +818,17 @@ async fn fwd_sync_gets_peers_only_from_accumulator() {
         &mut rng,
         Event::Request(BlockSynchronizerRequest::NeedNext),
     );
-    assert_eq!(effects.len(), 1);
+    // the count should be 2 bcs the block synchronizer will also ask for 1 known addr in addition
+    // to the normal ask
+    assert_eq!(effects.len(), 2);
     let events = mock_reactor.process_effects(effects).await;
 
     // The first thing the synchronizer should do is get peers.
     // For the forward flow, the synchronizer will ask the accumulator to provide peers
     // from which it has received information for the block that is being synchronized.
+
     assert_matches!(
-        events[0],
+        events[1],
         MockReactorEvent::BlockAccumulatorRequest(BlockAccumulatorRequest::GetPeersForBlock {
             block_hash,
             ..
@@ -3353,12 +3357,16 @@ async fn fwd_sync_latch_should_not_decrement_for_old_responses() {
             &mut rng,
             Event::Request(BlockSynchronizerRequest::NeedNext),
         );
-        assert_eq!(effects.len(), 1);
+
+        // with the tweaks made on this fork, the count should be 2
+        // bcs the block synchronizer will also ask for 1 known addr in addition
+        // to the normal ask
+        assert_eq!(effects.len(), 2);
 
         // First, the synchronizer should get peers.
         let events = mock_reactor.process_effects(effects).await;
         assert_matches!(
-            events[0],
+            events[1],
             MockReactorEvent::BlockAccumulatorRequest(BlockAccumulatorRequest::GetPeersForBlock {
                 block_hash,
                 ..
@@ -4087,7 +4095,6 @@ async fn historical_sync_latch_should_not_decrement_for_old_deploy_fetch_respons
 #[tokio::test]
 async fn historical_sync_latch_should_not_decrement_for_old_execution_results() {
     let rng = &mut TestRng::new();
-    let mock_reactor = MockReactor::new();
     let first_txn = Transaction::random(rng);
     let second_txn = Transaction::random(rng);
     let third_txn = Transaction::random(rng);
@@ -4131,6 +4138,7 @@ async fn historical_sync_latch_should_not_decrement_for_old_execution_results() 
         .register_block(block.clone(), None)
         .is_ok());
 
+    let mock_reactor = MockReactor::new();
     let _effects = block_synchronizer.handle_event(
         mock_reactor.effect_builder(),
         rng,
@@ -4159,11 +4167,12 @@ async fn historical_sync_latch_should_not_decrement_for_old_execution_results() 
         BlockExecutionResultsOrChunk::new_mock_value_with_multiple_random_results(
             rng,
             *block.hash(),
-            100000, // Lots of results to achieve chunking.
+            10_000, // Lots of results to achieve chunking.
         );
+
     let checksum = assert_matches!(
         execution_results.value(),
-        ValueOrChunk::ChunkWithProof(chunk) => chunk.proof().root_hash()
+        crate::types::ValueOrChunk::ChunkWithProof(chunk) => chunk.proof().root_hash()
     );
 
     let effects = block_synchronizer.handle_event(
@@ -4249,7 +4258,9 @@ async fn historical_sync_latch_should_not_decrement_for_old_execution_results() 
         Event::ExecutionResultsFetched {
             block_hash: *block.hash(),
             result: Err(FetcherError::Absent {
-                id: Box::new(BlockExecutionResultsOrChunkId::new(*block.hash())),
+                id: Box::new(crate::types::BlockExecutionResultsOrChunkId::new(
+                    *block.hash(),
+                )),
                 peer: peers[0],
             }),
         },

--- a/node/src/components/network.rs
+++ b/node/src/components/network.rs
@@ -141,7 +141,7 @@ const OUTGOING_MANAGER_SWEEP_INTERVAL: Duration = Duration::from_secs(1);
 /// How often to send a ping down a healthy connection.
 const PING_INTERVAL: Duration = Duration::from_secs(30);
 
-/// Maximum time for a ping until it connections are severed.
+/// Maximum time for a ping until its connections are severed.
 ///
 /// If you are running a network under very extreme conditions, it may make sense to alter these
 /// values, but usually these values should require no changing.
@@ -318,6 +318,9 @@ where
     state: ComponentState,
 
     peer_drop_handles: BTreeMap<NodeId, PeerDropData>,
+
+    /// Known address nodes.
+    known_address_nodes: Vec<NodeId>,
 }
 
 struct ChannelManagement {
@@ -419,6 +422,7 @@ where
             active_era: EraId::new(0),
             state: ComponentState::Uninitialized,
             peer_drop_handles: BTreeMap::new(),
+            known_address_nodes: Vec::new(),
         };
 
         Ok(component)
@@ -472,7 +476,7 @@ where
         let protocol_version = self.context.chain_info().protocol_version;
         // Run the server task.
         // We spawn it ourselves instead of through an effect to get a hold of the join handle,
-        // which we need to shutdown cleanly later on.
+        // which we need to shut down cleanly later on.
         info!(%local_addr, %public_addr, %protocol_version, "starting server background task");
 
         let (server_shutdown_sender, server_shutdown_receiver) = watch::channel(());
@@ -496,6 +500,15 @@ where
         };
 
         self.channel_management = Some(channel_management);
+
+        // keep track of known address node ids
+        let mut known_node_ids = vec![];
+        for known_addr in &known_addresses {
+            if let Some(node_id) = self.outgoing_manager.reverse_lookup(known_addr) {
+                known_node_ids.push(node_id);
+            }
+        }
+        self.known_address_nodes = known_node_ids;
 
         // Learn all known addresses and mark them as unforgettable.
         let now = Instant::now();
@@ -1061,7 +1074,7 @@ where
                         }),
                 ),
                 DialRequest::Disconnect { handle: _, span } => {
-                    // Dropping the `handle` is enough to signal the connection to shutdown.
+                    // Dropping the `handle` is enough to signal the connection to shut down.
                     span.in_scope(|| {
                         debug!("dropping connection, as requested");
                     });
@@ -1165,6 +1178,63 @@ where
         }
 
         ret
+    }
+
+    pub(crate) fn fully_connected_peers_random_include_known_addrs(
+        &self,
+        rng: &mut NodeRng,
+        total_count: usize,
+        known_addr_count: usize,
+    ) -> Vec<NodeId> {
+        let fully_connected: Vec<NodeId> = self
+            .connection_symmetries
+            .iter()
+            .filter(|(_, sym)| matches!(sym, ConnectionSymmetry::Symmetric { .. }))
+            .map(|(node_id, _)| *node_id)
+            .collect();
+
+        if known_addr_count == 0 || self.known_address_nodes.is_empty() {
+            // short circuit if no known addrs are asked for
+            // or if there are no captured known addresses
+            return fully_connected
+                .into_iter()
+                .choose_multiple(rng, total_count);
+        }
+
+        let peers: Vec<NodeId> = {
+            let mut ret: Vec<NodeId> = vec![];
+            let x = fully_connected.iter().copied().collect::<HashSet<NodeId>>();
+            let y = self.known_address_nodes.iter().copied().collect();
+
+            let known: Vec<NodeId> = x
+                .intersection(&y)
+                .to_owned()
+                .choose_multiple(rng, known_addr_count)
+                .iter()
+                .map(|n| **n)
+                .collect();
+
+            ret.extend(known);
+
+            let selection_count = ret.len();
+            let remaining = total_count.saturating_sub(selection_count);
+
+            if remaining > 0 {
+                // pick up additional nodes up to total count - known addr count (if able)
+                // filtering out already selected items for this backfill
+                let z = ret.iter().copied().collect();
+                let diff: Vec<NodeId> = x
+                    .difference(&z)
+                    .to_owned()
+                    .choose_multiple(rng, remaining)
+                    .iter()
+                    .map(|n| **n)
+                    .collect();
+                ret.extend(diff);
+            }
+            ret
+        };
+        peers
     }
 
     pub(crate) fn fully_connected_peers_random(
@@ -1554,6 +1624,17 @@ where
                     NetworkInfoRequest::FullyConnectedPeers { count, responder } => responder
                         .respond(self.fully_connected_peers_random(rng, count))
                         .ignore(),
+                    NetworkInfoRequest::FullyConnectedPeersIncludingKnownAddresses {
+                        total_count,
+                        known_addr_count,
+                        responder,
+                    } => responder
+                        .respond(self.fully_connected_peers_random_include_known_addrs(
+                            rng,
+                            total_count,
+                            known_addr_count,
+                        ))
+                        .ignore(),
                     NetworkInfoRequest::FullyConnectedValidators {
                         count,
                         era_id,
@@ -1643,6 +1724,7 @@ where
                             let min: Duration = flakiness_config.block_peer_after_drop_min.into();
                             let max: Duration = flakiness_config.block_peer_after_drop_max.into();
                             let block_for: Duration = rng.gen_range(min..=max);
+
                             debug!(
                                 %public_addr,
                                 %peer_addr,
@@ -1703,9 +1785,10 @@ pub(crate) type FullTransport<P> = tokio_serde::Framed<
 
 pub(crate) type FramedTransport = tokio_util::codec::Framed<Transport, LengthDelimitedCodec>;
 
-/// Constructs a new full transport on a stream.
+/// Constructs a new full transport instance on a stream.
 ///
-/// A full transport contains the framing as well as the encoding scheme used to send messages.
+/// A full transport instance contains the framing as well as the encoding scheme used to
+/// send messages.
 fn full_transport<P>(
     metrics: Weak<Metrics>,
     connection_id: ConnectionId,

--- a/node/src/components/network/outgoing.rs
+++ b/node/src/components/network/outgoing.rs
@@ -399,6 +399,16 @@ where
     fn metrics(&self) -> &OutgoingMetrics {
         &self.metrics
     }
+
+    /// Looks up a node id by socket addr.
+    pub(super) fn reverse_lookup(&self, addr_to_lookup: &SocketAddr) -> Option<NodeId> {
+        for (node_id, addr) in self.routes.iter() {
+            if addr_to_lookup == addr {
+                return Some(*node_id);
+            }
+        }
+        None
+    }
 }
 
 /// Creates a logging span for a specific connection.

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -725,6 +725,27 @@ impl<REv> EffectBuilder<REv> {
         .await
     }
 
+    /// Gets up to `total_count` fully-connected network peers in random order,
+    /// including up to `known_addr_count` known addresses.
+    pub async fn get_fully_connected_peers_with_known_addresses(
+        self,
+        known_addr_count: usize,
+        total_count: usize,
+    ) -> Vec<NodeId>
+    where
+        REv: From<NetworkInfoRequest>,
+    {
+        self.make_request(
+            |responder| NetworkInfoRequest::FullyConnectedPeersIncludingKnownAddresses {
+                known_addr_count,
+                total_count,
+                responder,
+            },
+            QueueKind::NetworkInfo,
+        )
+        .await
+    }
+
     /// Gets up to `count` fully-connected network validators in random order.
     pub async fn get_fully_connected_validators(self, count: usize, era_id: EraId) -> Vec<NodeId>
     where

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -212,6 +212,14 @@ pub(crate) enum NetworkInfoRequest {
         /// Responder to be called with the peers.
         responder: Responder<Vec<NodeId>>,
     },
+    /// Get up to `total_count` fully-connected peers in random order, including up to
+    /// `known_addr_count` known addresses.
+    FullyConnectedPeersIncludingKnownAddresses {
+        total_count: usize,
+        known_addr_count: usize,
+        /// Responder to be called with the peers.
+        responder: Responder<Vec<NodeId>>,
+    },
     /// Get detailed insights into the nodes networking.
     Insight {
         responder: Responder<NetworkInsights>,
@@ -239,8 +247,16 @@ impl Display for NetworkInfoRequest {
             } => {
                 write!(formatter, "get up to {} fully connected peers", count)
             }
-            NetworkInfoRequest::Insight { responder: _ } => {
-                formatter.write_str("get networking insights")
+            NetworkInfoRequest::FullyConnectedPeersIncludingKnownAddresses {
+                total_count,
+                known_addr_count,
+                responder: _,
+            } => {
+                write!(
+                    formatter,
+                    "get up to {} fully connected peers with up to {} known addrs",
+                    total_count, known_addr_count
+                )
             }
             NetworkInfoRequest::FullyConnectedValidators {
                 count,
@@ -252,6 +268,9 @@ impl Display for NetworkInfoRequest {
                     "get up to {} fully connected validators in era {}",
                     count, era_id
                 )
+            }
+            NetworkInfoRequest::Insight { responder: _ } => {
+                formatter.write_str("get networking insights")
             }
         }
     }

--- a/node/src/reactor/main_reactor/catch_up.rs
+++ b/node/src/reactor/main_reactor/catch_up.rs
@@ -322,9 +322,10 @@ impl MainReactor {
         block_hash: BlockHash,
     ) -> CatchUpInstruction {
         // we get a random sampling of peers to ask.
-        let peers_to_ask = self.net.fully_connected_peers_random(
+        let peers_to_ask = self.net.fully_connected_peers_random_include_known_addrs(
             rng,
             self.chainspec.core_config.simultaneous_peer_requests as usize,
+            1,
         );
         if peers_to_ask.is_empty() {
             return CatchUpInstruction::CheckLater(

--- a/node/src/reactor/main_reactor/keep_up.rs
+++ b/node/src/reactor/main_reactor/keep_up.rs
@@ -471,9 +471,10 @@ impl MainReactor {
         offset: Duration,
     ) -> KeepUpInstruction {
         // we get a random sampling of peers to ask.
-        let peers_to_ask = self.net.fully_connected_peers_random(
+        let peers_to_ask = self.net.fully_connected_peers_random_include_known_addrs(
             rng,
             self.chainspec.core_config.simultaneous_peer_requests as usize,
+            1,
         );
         if peers_to_ask.is_empty() {
             return KeepUpInstruction::CheckLater(

--- a/node/src/reactor/main_reactor/tests.rs
+++ b/node/src/reactor/main_reactor/tests.rs
@@ -49,6 +49,7 @@ const ERA_THREE: EraId = EraId::new(3);
 const TEN_SECS: Duration = Duration::from_secs(10);
 const THIRTY_SECS: Duration = Duration::from_secs(30);
 const ONE_MIN: Duration = Duration::from_secs(60);
+const TWO_MIN: Duration = Duration::from_secs(120);
 
 type Nodes = testing::network::Nodes<FilterReactor<MainReactor>>;
 

--- a/node/src/reactor/main_reactor/tests/network_general.rs
+++ b/node/src/reactor/main_reactor/tests/network_general.rs
@@ -32,7 +32,7 @@ use crate::{
                 fixture::TestFixture,
                 initial_stakes::InitialStakes,
                 node_has_lowest_available_block_at_or_below_height, Nodes, ERA_ONE, ERA_THREE,
-                ERA_TWO, ERA_ZERO, ONE_MIN, TEN_SECS, THIRTY_SECS,
+                ERA_TWO, ERA_ZERO, ONE_MIN, TEN_SECS, THIRTY_SECS, TWO_MIN,
             },
             MainEvent, MainReactor, ReactorState,
         },
@@ -61,7 +61,7 @@ async fn historical_sync_with_era_height_1() {
     let mut fixture = TestFixture::new(initial_stakes, Some(spec_override)).await;
 
     // Wait for all nodes to reach era 3.
-    fixture.run_until_consensus_in_era(ERA_THREE, ONE_MIN).await;
+    fixture.run_until_consensus_in_era(ERA_THREE, TWO_MIN).await;
 
     // Create a joiner node.
     let secret_key = SecretKey::random(&mut fixture.rng);


### PR DESCRIPTION
This PR modifies the network component to allow peer selection logic to mix in one known peer address selected from a given nodes config on each peer acquisition. Used for block synchronization. Improves sync behavior on a network in a fringe state with a low ratio of validators, assuming some of those nodes are included in known addresses.