### PR TITLE
[VM2] integrate host crypto support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,8 @@ dependencies = [
  "base16",
  "blake2 0.10.6",
  "blake3",
+ "bnum",
+ "borsh",
  "bytes",
  "casper-executor-wasm-common",
  "casper-executor-wasm-interface",
@@ -931,6 +933,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.16",
  "tracing",
+ "zeropool-bn",
 ]
 
 [[package]]
@@ -3787,6 +3790,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128"
@@ -5585,6 +5591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7270,6 +7282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vm2-altbn128"
+version = "0.1.0"
+dependencies = [
+ "base16",
+ "casper-contract-sdk",
+ "zeropool-bn",
+]
+
+[[package]]
 name = "vm2-cargo-casper"
 version = "0.1.0"
 dependencies = [
@@ -8311,6 +8332,19 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zeropool-bn"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
+]
 
 [[package]]
 name = "zerotrie"

--- a/executor/wasm/src/testing.rs
+++ b/executor/wasm/src/testing.rs
@@ -368,6 +368,9 @@ pub fn call_dummy_host_fn_by_name(
                 env_info: HostFunctionV2::fixed(1),
                 generic_hash: HostFunctionV2::fixed(1),
                 recover_secp256k1: HostFunctionV2::fixed(1),
+                alt_bn128_add: HostFunctionV2::fixed(1),
+                alt_bn128_mul: HostFunctionV2::fixed(1),
+                alt_bn128_pairing: HostFunctionV2::fixed(1),
             },
         );
         let executor_config = ExecutorConfigBuilder::default()

--- a/executor/wasm/tests/altbn128.rs
+++ b/executor/wasm/tests/altbn128.rs
@@ -1,0 +1,174 @@
+use std::{env, path::PathBuf, sync::Arc};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use casper_executor_wasm::testing::{
+    base_execute_builder, base_install_request_builder, make_address_generator, make_executor,
+    make_global_state_with_genesis, read_wasm, run_create_contract, run_wasm_session,
+};
+
+use casper_executor_wasm::{chainspec_config, chainspec_config::ChainspecConfig};
+use casper_executor_wasm_interface::executor::{
+    ExecuteError, ExecuteWithProviderError, ExecutionKind,
+};
+use casper_storage::global_state::state::CommitProvider;
+use once_cell::sync::Lazy;
+
+/// Symlink to chainspec.
+pub static CHAINSPEC_SYMLINK: Lazy<PathBuf> = Lazy::new(|| {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../resources/local/")
+        .join(chainspec_config::CHAINSPEC_NAME)
+});
+
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+struct Pair {
+    /// G1 point
+    ax: [u8; 32],
+    /// G1 point
+    ay: [u8; 32],
+    /// G2 point
+    bax: [u8; 32],
+    /// G2 point
+    bay: [u8; 32],
+    /// G1 point
+    bbx: [u8; 32],
+    /// G1 point
+    bby: [u8; 32],
+}
+
+impl Pair {
+    fn zero() -> Self {
+        Self {
+            ax: [0; 32],
+            ay: [0; 32],
+            bax: [0; 32],
+            bay: [0; 32],
+            bbx: [0; 32],
+            bby: [0; 32],
+        }
+    }
+}
+
+#[test]
+fn should_run_test_suite() {
+    let chainspec_config = ChainspecConfig::from_chainspec_path(&*CHAINSPEC_SYMLINK)
+        .expect("must get chainspec config");
+
+    let mut executor = make_executor(&chainspec_config);
+
+    let (global_state, state_root_hash, _tempdir) = make_global_state_with_genesis();
+
+    let address_generator = make_address_generator();
+
+    let install_request = base_install_request_builder(&chainspec_config)
+        .with_wasm_bytes(read_wasm("vm2_altbn128.wasm"))
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_transferred_value(0)
+        .with_entry_point("new".to_string())
+        .build()
+        .expect("should build");
+
+    let create_result = run_create_contract(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        install_request,
+    );
+
+    // Compile above test contract with either feature flags: wasm_add_test, wasm_mul_test,
+    // wasm_pairing_test, and uncomment gas line. None of these flags will use host functions.
+    // bash -c 'cd smart_contracts/contracts &&
+    // RUSTFLAGS="--remap-path-prefix=$HOME/.cargo= --remap-path-prefix=$PWD=/dir" cargo --locked
+    // build --verbose --release --package altbn128 --features wasm_add_test'
+
+    eprintln!("gas {:?}", create_result.gas_usage());
+}
+
+#[test]
+fn should_fail_when_passed_wrong_data_to_pairing() {
+    let res = run_pairing_endpoint_test(Vec::<u8>::new());
+    let err = res.err().unwrap();
+    assert!(matches!(
+        err,
+        ExecuteWithProviderError::Execute(ExecuteError::Api(x)) if x == "Cannot deserialize arguments to AltBn128Pairing host function".to_owned()
+    ));
+
+    let res = run_pairing_endpoint_test(vec![1_u8, 5, 6, 7]); //Some random bytes, insufficient to build input data
+    let err = res.err().unwrap();
+    assert!(matches!(
+        err,
+        ExecuteWithProviderError::Execute(ExecuteError::Api(x)) if x == "Cannot deserialize arguments to AltBn128Pairing host function".to_owned()
+    ));
+}
+
+#[test]
+fn should_consider_zero_points_paired_and_on_curve() {
+    let input: Vec<Pair> = vec![];
+    let res = run_pairing_endpoint_test(borsh::to_vec(&input).unwrap());
+    let provider_result = res.ok().unwrap();
+    let result_bytes = provider_result.output().unwrap();
+    let deserialized: Result<bool, u32> = borsh::from_slice(&result_bytes).unwrap();
+    assert_eq!(deserialized, Ok(true));
+
+    let input = vec![Pair::zero()];
+    let res = run_pairing_endpoint_test(borsh::to_vec(&input).unwrap());
+    let provider_result = res.ok().unwrap();
+    let result_bytes = provider_result.output().unwrap();
+    let deserialized: Result<bool, u32> = borsh::from_slice(&result_bytes).unwrap();
+    assert_eq!(deserialized, Ok(true));
+
+    let input = vec![Pair::zero(), Pair::zero(), Pair::zero()];
+    let res = run_pairing_endpoint_test(borsh::to_vec(&input).unwrap());
+    let provider_result = res.ok().unwrap();
+    let result_bytes = provider_result.output().unwrap();
+    let deserialized: Result<bool, u32> = borsh::from_slice(&result_bytes).unwrap();
+    assert_eq!(deserialized, Ok(true));
+}
+
+fn run_pairing_endpoint_test<T: BorshSerialize>(
+    input: T,
+) -> Result<
+    casper_executor_wasm_interface::executor::ExecuteWithProviderResult,
+    ExecuteWithProviderError,
+> {
+    let chainspec_config = ChainspecConfig::from_chainspec_path(&*CHAINSPEC_SYMLINK)
+        .expect("must get chainspec config");
+
+    let mut executor = make_executor(&chainspec_config);
+
+    let (global_state, mut state_root_hash, _tempdir) = make_global_state_with_genesis();
+
+    let address_generator = make_address_generator();
+
+    let install_request = base_install_request_builder(&chainspec_config)
+        .with_wasm_bytes(read_wasm("vm2_altbn128.wasm"))
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_transferred_value(0)
+        .with_entry_point("new".to_string())
+        .build()
+        .expect("should build");
+
+    let create_result = run_create_contract(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        install_request,
+    );
+    let contract_address = *create_result.smart_contract_addr();
+    state_root_hash = global_state
+        .commit_effects(state_root_hash, create_result.effects().clone())
+        .expect("Should commit");
+
+    let run_method = base_execute_builder(&chainspec_config)
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_transferred_value(0)
+        .with_execution_kind(ExecutionKind::Stored {
+            address: contract_address,
+            entry_point: "pairing".to_owned(),
+        })
+        .with_serialized_input(input)
+        .expect("expected serialized input to be correct")
+        .build()
+        .expect("should build");
+    run_wasm_session(&mut executor, &global_state, state_root_hash, run_method)
+}

--- a/executor/wasm_host/Cargo.toml
+++ b/executor/wasm_host/Cargo.toml
@@ -13,6 +13,9 @@ base16 = "0.2"
 bytes = "1.10"
 blake2 = { version = "0.10.6", default-features = false }
 blake3 = { version = "1.5.0", default-features = false, features = ["pure"] }
+bn = { version = "0.5", package = "zeropool-bn", default-features = false }
+bnum = { version = "0.13.0", features = ["borsh", "num-integer", "num-traits"] }
+borsh = { version = "1.5", features = ["derive"] }
 sha2 = { version = "0.10.8", default-features = false }
 keccak-asm = { version = "0.1.4", default-features = false }
 casper-executor-wasm-common = { version = "0.1.3", path = "../wasm_common" }

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -1,3 +1,4 @@
+pub(crate) mod altbn128;
 use std::{borrow::Cow, num::NonZeroU32, sync::Arc};
 
 use bytes::Bytes;
@@ -18,7 +19,9 @@ use casper_executor_wasm_common::{
     keyspace::{Keyspace, KeyspaceTag},
 };
 use casper_executor_wasm_interface::{
-    executor::{ExecuteError, ExecuteRequestBuilder, ExecuteResult, ExecutionKind, Executor},
+    executor::{
+        CryptoMethods, ExecuteError, ExecuteRequestBuilder, ExecuteResult, ExecutionKind, Executor,
+    },
     u32_from_host_result, Caller, InternalHostError, VMError, VMResult,
 };
 use casper_storage::{global_state::GlobalStateReader, tracking_copy::TrackingCopyExt};
@@ -44,7 +47,7 @@ use tracing::{error, info, warn};
 use crate::{
     abi::{CreateResult, ReadInfo},
     context::Context,
-    system::{self},
+    system,
 };
 use blake2::{
     digest::{Update, VariableOutput},
@@ -1020,6 +1023,33 @@ pub fn casper_system<S: GlobalStateReader + 'static, E: Executor + 'static>(
             AuctionMethods::CancelReservation => caller.context().auction_costs.cancel_reservations,
             AuctionMethods::ChangePublicKey => caller.context().auction_costs.change_bid_public_key,
         },
+        SystemMenu::Crypto(crypto_methods) => {
+            let fn_cost = match crypto_methods {
+                CryptoMethods::AltBn128Add => {
+                    caller.context().config.host_function_costs().alt_bn128_add
+                }
+                CryptoMethods::AltBn128Multiply => {
+                    caller.context().config.host_function_costs().alt_bn128_mul
+                }
+                CryptoMethods::AltBn128Pairing => {
+                    caller
+                        .context()
+                        .config
+                        .host_function_costs()
+                        .alt_bn128_pairing
+                }
+            };
+            let Some(cost) =
+                fn_cost.calculate_gas_cost([u64::from(input_ptr), u64::from(input_len)])
+            else {
+                // Overflowing gas calculation means gas limit was exceeded
+                return Err(VMError::OutOfGas);
+            };
+            u64::try_from(cost.value()).map_err(|err| {
+                error!("Couldn't execute host function due to cost calculation overflow. Details: {err}");
+                VMError::Internal(InternalHostError::TypeConversion)
+            })?
+        }
     };
     // the following can produce a VMError::OutOfGas error
     charge_gas(&mut caller, cost)?;

--- a/executor/wasm_host/src/host/altbn128.rs
+++ b/executor/wasm_host/src/host/altbn128.rs
@@ -1,0 +1,440 @@
+use bn::{AffineG1, Fq, Fr, Group, G1};
+use borsh::{BorshDeserialize, BorshSerialize};
+use casper_types::{bytesrepr::FromBytes, U256};
+use thiserror::Error as ThisError;
+use tracing::debug;
+
+#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
+pub struct Pair {
+    /// G1 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    ax: [u8; 32],
+    /// G1 point y-coordinate. 32 bytes little-endian encoded unsigned integer
+    ay: [u8; 32],
+    /// G2 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    bax: [u8; 32],
+    /// G2 point y-coordinate. 32 bytes little-endian encoded unsigned integer
+    bay: [u8; 32],
+    /// G1 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    bbx: [u8; 32],
+    /// G1 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    bby: [u8; 32],
+}
+
+impl FromBytes for Pair {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), casper_types::bytesrepr::Error> {
+        let (ax, remainder) = <[u8; 32]>::from_bytes(bytes)?;
+        let (ay, remainder) = <[u8; 32]>::from_bytes(remainder)?;
+        let (bax, remainder) = <[u8; 32]>::from_bytes(remainder)?;
+        let (bay, remainder) = <[u8; 32]>::from_bytes(remainder)?;
+        let (bbx, remainder) = <[u8; 32]>::from_bytes(remainder)?;
+        let (bby, remainder) = <[u8; 32]>::from_bytes(remainder)?;
+        Ok((
+            Pair {
+                ax,
+                ay,
+                bax,
+                bay,
+                bbx,
+                bby,
+            },
+            remainder,
+        ))
+    }
+}
+
+impl Pair {
+    pub fn to_u256_tuples(&self) -> (U256, U256, U256, U256, U256, U256) {
+        (
+            U256::from_little_endian(&self.ax),
+            U256::from_little_endian(&self.ay),
+            U256::from_little_endian(&self.bax),
+            U256::from_little_endian(&self.bay),
+            U256::from_little_endian(&self.bbx),
+            U256::from_little_endian(&self.bby),
+        )
+    }
+}
+
+/// Errors that can occur when working with alt_bn128 curve.
+#[derive(Debug, ThisError, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum AltBN128Error {
+    /// Invalid point x coordinate.
+    #[error("Invalid point x coordinate")]
+    InvalidXCoordinate = 1,
+    /// Invalid point y coordinate.
+    #[error("Invalid point y coordinate")]
+    InvalidYCoordinate = 2,
+    /// Invalid point.
+    #[error("Invalid point")]
+    InvalidPoint = 3,
+    /// Invalid A.
+    #[error("Invalid A")]
+    InvalidA = 4,
+    /// Invalid B.
+    #[error("Invalid B")]
+    InvalidB = 5,
+    /// Invalid Ax.
+    #[error("Invalid Ax")]
+    InvalidAx = 6,
+    /// Invalid Ay.
+    #[error("Invalid Ay")]
+    InvalidAy = 7,
+    /// Invalid Bay.
+    #[error("Invalid Bay")]
+    InvalidBay = 8,
+    /// Invalid Bax.
+    #[error("Invalid Bax")]
+    InvalidBax = 9,
+    /// Invalid Bby.
+    #[error("Invalid Bby")]
+    InvalidBby = 10,
+    /// Invalid Bbx.
+    #[error("Invalid Bbx")]
+    InvalidBbx = 11,
+}
+
+pub(crate) fn alt_bn128_add(
+    x1: U256,
+    y1: U256,
+    x2: U256,
+    y2: U256,
+) -> Result<(U256, U256), AltBN128Error> {
+    let p1 = point_from_coords(x1, y1)?;
+    let p2 = point_from_coords(x2, y2)?;
+    let mut x = U256::zero();
+    let mut y = U256::zero();
+
+    if let Some(sum) = AffineG1::from_jacobian(p1 + p2) {
+        x = fq_to_u256(sum.x());
+        y = fq_to_u256(sum.y());
+    }
+    Ok((x, y))
+}
+
+pub(crate) fn alt_bn128_mul(x: U256, y: U256, scalar: U256) -> Result<(U256, U256), AltBN128Error> {
+    let p = point_from_coords(x, y)?;
+
+    let mut x = U256::zero();
+    let mut y = U256::zero();
+    let mut buf = [0u8; 32];
+    scalar.to_big_endian(&mut buf);
+    let fr = Fr::from_slice(&buf).map_err(|_| AltBN128Error::InvalidPoint)?;
+
+    if let Some(product) = AffineG1::from_jacobian(p * fr) {
+        x = fq_to_u256(product.x());
+        y = fq_to_u256(product.y());
+    }
+
+    Ok((x, y))
+}
+
+/// Pairing check for a list of points.
+pub(crate) fn alt_bn128_pairing(
+    values: Vec<(U256, U256, U256, U256, U256, U256)>,
+) -> Result<bool, AltBN128Error> {
+    let mut pairs = Vec::with_capacity(values.len());
+    for (ax, ay, bax, bay, bbx, bby) in values {
+        let ax = fq_from_u256(ax).map_err(|_| AltBN128Error::InvalidAx)?;
+        let ay = fq_from_u256(ay).map_err(|_| AltBN128Error::InvalidAy)?;
+        let bax = fq_from_u256(bax).map_err(|_| AltBN128Error::InvalidBax)?;
+        let bay = fq_from_u256(bay).map_err(|_| AltBN128Error::InvalidBay)?;
+        let bbx = fq_from_u256(bbx).map_err(|_| AltBN128Error::InvalidBbx)?;
+        let bby = fq_from_u256(bby).map_err(|_| AltBN128Error::InvalidBby)?;
+
+        let g1_a = {
+            if ax.is_zero() && ay.is_zero() {
+                bn::G1::zero()
+            } else {
+                bn::AffineG1::new(ax, ay)
+                    .map_err(|_| AltBN128Error::InvalidA)?
+                    .into()
+            }
+        };
+        let g1_b = {
+            let ba = bn::Fq2::new(bax, bay);
+            let bb = bn::Fq2::new(bbx, bby);
+
+            if ba.is_zero() && bb.is_zero() {
+                bn::G2::zero()
+            } else {
+                bn::AffineG2::new(ba, bb)
+                    .map_err(|_| AltBN128Error::InvalidB)?
+                    .into()
+            }
+        };
+        pairs.push((g1_a, g1_b));
+    }
+
+    Ok(bn::pairing_batch(pairs.as_slice()) == bn::Gt::one())
+}
+
+pub(super) fn point_from_coords(x: U256, y: U256) -> Result<G1, AltBN128Error> {
+    let mut buf = [0u8; 32];
+    x.to_big_endian(&mut buf);
+    let px = Fq::from_slice(&buf).map_err(|_| AltBN128Error::InvalidXCoordinate)?;
+    let mut buf = [0u8; 32];
+    y.to_big_endian(&mut buf);
+    let py = Fq::from_slice(&buf).map_err(|_| AltBN128Error::InvalidYCoordinate)?;
+
+    Ok(if px == Fq::zero() && py == Fq::zero() {
+        G1::zero()
+    } else {
+        AffineG1::new(px, py)
+            .map_err(|_| AltBN128Error::InvalidPoint)?
+            .into()
+    })
+}
+
+fn fq_to_u256(fq: Fq) -> U256 {
+    let mut buf = [0u8; 32];
+    fq.to_big_endian(&mut buf).unwrap();
+    U256::from_big_endian(&buf)
+}
+
+enum FqDeserializationError {
+    FailedToDeserialize,
+}
+
+fn fq_from_u256(value: U256) -> Result<Fq, FqDeserializationError> {
+    let mut buf = [0u8; 32];
+    value.to_big_endian(&mut buf);
+    let arith_u256 = bn::arith::U256::from_slice(&buf).map_err(|_| {
+        debug!("Failed to build bn::arith::U256 from casper_types:U256");
+        FqDeserializationError::FailedToDeserialize
+    })?;
+    Fq::from_u256(arith_u256).map_err(|_| {
+        debug!("Failed to build Fq");
+        FqDeserializationError::FailedToDeserialize
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_alt_bn128_add() {
+        let x1 = U256::from_str_radix(
+            "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9",
+            16,
+        )
+        .unwrap();
+
+        let y1 = U256::from_str_radix(
+            "063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+            16,
+        )
+        .unwrap();
+
+        let x2 = U256::from_str_radix(
+            "07c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed",
+            16,
+        )
+        .unwrap();
+        let y2 = U256::from_str_radix(
+            "06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7",
+            16,
+        )
+        .unwrap();
+
+        let expected_x = U256::from_str_radix(
+            "2243525c5efd4b9c3d3c45ac0ca3fe4dd85e830a4ce6b65fa1eeaee202839703",
+            16,
+        )
+        .unwrap();
+        let expected_y = U256::from_str_radix(
+            "301d1d33be6da8e509df21cc35964723180eed7532537db9ae5e7d48f195c915",
+            16,
+        )
+        .unwrap();
+
+        let result = alt_bn128_add(x1, y1, x2, y2);
+        assert_eq!(result, Ok((expected_x, expected_y)));
+    }
+
+    #[test]
+    fn zero() {
+        assert_eq!(
+            alt_bn128_add(U256::zero(), U256::zero(), U256::zero(), U256::zero()),
+            Ok((U256::zero(), U256::zero()))
+        );
+    }
+
+    #[test]
+    fn add_error() {
+        let all_ones = U256::from_str_radix(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            16,
+        )
+        .unwrap();
+
+        assert_eq!(
+            alt_bn128_add(all_ones, all_ones, all_ones, all_ones),
+            Err(AltBN128Error::InvalidPoint),
+        );
+    }
+
+    #[test]
+    fn test_alt_bn128_mul() {
+        let x = U256::from_str_radix(
+            "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7",
+            16,
+        )
+        .unwrap();
+        let y = U256::from_str_radix(
+            "21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
+            16,
+        )
+        .unwrap();
+        let scalar = U256::from_str_radix(
+            "00000000000000000000000000000000000000000000000011138ce750fa15c2",
+            16,
+        )
+        .unwrap();
+
+        let expected_x = U256::from_str_radix(
+            "070a8d6a982153cae4be29d434e8faef8a47b274a053f5a4ee2a6c9c13c31e5c",
+            16,
+        )
+        .unwrap();
+        let expected_y = U256::from_str_radix(
+            "031b8ce914eba3a9ffb989f9cdd5b0f01943074bf4f0f315690ec3cec6981afc",
+            16,
+        )
+        .unwrap();
+
+        assert_eq!(alt_bn128_mul(x, y, scalar), Ok((expected_x, expected_y)));
+    }
+
+    #[test]
+    fn test_zero_multiplication() {
+        // zero multiplication test
+
+        let x = U256::from_str_radix(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            16,
+        )
+        .unwrap();
+        let y = U256::from_str_radix(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            16,
+        )
+        .unwrap();
+        let scalar = U256::from_str_radix(
+            "0200000000000000000000000000000000000000000000000000000000000000",
+            16,
+        )
+        .unwrap();
+
+        let expected_x = U256::from_str_radix(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            16,
+        )
+        .unwrap();
+
+        let expected_y = U256::from_str_radix(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            16,
+        )
+        .unwrap();
+
+        assert_eq!(alt_bn128_mul(x, y, scalar), Ok((expected_x, expected_y)));
+    }
+
+    #[test]
+    fn test_not_on_curve_multiplication() {
+        // point not on curve fail
+
+        let x = U256::from_str_radix(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            16,
+        )
+        .unwrap();
+        let y = U256::from_str_radix(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            16,
+        )
+        .unwrap();
+        let scalar = U256::from_str_radix(
+            "0f00000000000000000000000000000000000000000000000000000000000000",
+            16,
+        )
+        .unwrap();
+        assert_eq!(
+            alt_bn128_mul(x, y, scalar),
+            Err(AltBN128Error::InvalidPoint)
+        );
+    }
+
+    #[test]
+    fn test_pairing() {
+        let ax_1 = U256::from_str_radix(
+            "1c76476f4def4bb94541d57ebba1193381ffa7aa76ada664dd31c16024c43f59",
+            16,
+        )
+        .unwrap();
+        let ay_1 = U256::from_str_radix(
+            "3034dd2920f673e204fee2811c678745fc819b55d3e9d294e45c9b03a76aef41",
+            16,
+        )
+        .unwrap();
+        let bay_1 = U256::from_str_radix(
+            "209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7",
+            16,
+        )
+        .unwrap();
+        let bax_1 = U256::from_str_radix(
+            "04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678",
+            16,
+        )
+        .unwrap();
+        let bby_1 = U256::from_str_radix(
+            "2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d",
+            16,
+        )
+        .unwrap();
+        let bbx_1 = U256::from_str_radix(
+            "120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550",
+            16,
+        )
+        .unwrap();
+
+        let ax_2 = U256::from_str_radix(
+            "111e129f1cf1097710d41c4ac70fcdfa5ba2023c6ff1cbeac322de49d1b6df7c",
+            16,
+        )
+        .unwrap();
+        let ay_2 = U256::from_str_radix(
+            "2032c61a830e3c17286de9462bf242fca2883585b93870a73853face6a6bf411",
+            16,
+        )
+        .unwrap();
+        let bay_2 = U256::from_str_radix(
+            "198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2",
+            16,
+        )
+        .unwrap();
+        let bax_2 = U256::from_str_radix(
+            "1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed",
+            16,
+        )
+        .unwrap();
+        let bby_2 = U256::from_str_radix(
+            "090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b",
+            16,
+        )
+        .unwrap();
+        let bbx_2 = U256::from_str_radix(
+            "12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa",
+            16,
+        )
+        .unwrap();
+
+        let result = alt_bn128_pairing(vec![
+            (ax_1, ay_1, bax_1, bay_1, bbx_1, bby_1),
+            (ax_2, ay_2, bax_2, bay_2, bbx_2, bby_2),
+        ]);
+        assert!(result.expect("Pairing failed"));
+    }
+}

--- a/executor/wasm_host/src/system.rs
+++ b/executor/wasm_host/src/system.rs
@@ -18,7 +18,7 @@ mod withdraw_bid;
 
 use bytes::Bytes;
 use casper_executor_wasm_common::error::CallError;
-use casper_executor_wasm_interface::{GasUsage, InternalHostError};
+use casper_executor_wasm_interface::{executor::CryptoMethods, GasUsage, InternalHostError};
 use casper_storage::{
     global_state::GlobalStateReader,
     system::runtime_native::{Id, RuntimeNative},
@@ -27,7 +27,7 @@ use casper_storage::{
 };
 use casper_types::{
     bytesrepr, AccessRights, ApiError, CLValueError, EntityAddr, Key, Phase, PublicKey,
-    RuntimeFootprint, TransactionHash, URef, URefAddr, U512,
+    RuntimeFootprint, TransactionHash, URef, URefAddr, U256, U512,
 };
 use parking_lot::RwLock;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
@@ -39,7 +39,10 @@ use casper_executor_wasm_interface::executor::{
 };
 use casper_types::bytesrepr::ToBytes;
 
-use crate::system;
+use crate::{
+    host::altbn128::{alt_bn128_add, alt_bn128_mul, alt_bn128_pairing, Pair},
+    system,
+};
 use casper_types::system::auction::{
     DelegatorKind, Reservation, DELEGATION_RATE_DENOMINATOR, ERA_END_TIMESTAMP_MILLIS_KEY,
     ERA_ID_KEY,
@@ -763,6 +766,79 @@ pub fn native_exec<A, T: ToBytes, R: GlobalStateReader + 'static>(
                         Err(_) => Err(DispatchError::Api(ApiError::Formatting)),
                     },
                     Err(err) => Err(err),
+                }
+            }
+        },
+        SystemMenu::Crypto(crypto_method) => match crypto_method {
+            CryptoMethods::AltBn128Add => {
+                let (x1_bytes, y1_bytes, x2_bytes, y2_bytes) = bytesrepr::deserialize_from_slice::<
+                    &Bytes,
+                    ([u8; 32], [u8; 32], [u8; 32], [u8; 32]),
+                >(&input)
+                .map_err(|_e| {
+                    ExecuteError::Api(
+                        "Cannot deserialize arguments to AltBn128Add host function".to_string(),
+                    )
+                })?;
+                let x1 = U256::from_little_endian(&x1_bytes);
+                let y1 = U256::from_little_endian(&y1_bytes);
+                let x2 = U256::from_little_endian(&x2_bytes);
+                let y2 = U256::from_little_endian(&y2_bytes);
+                let res = alt_bn128_add(x1, y1, x2, y2)
+                    .map(|(x, y)| {
+                        let mut x_buf = [0u8; 32];
+                        let mut y_buf = [0u8; 32];
+                        x.to_little_endian(&mut x_buf);
+                        y.to_little_endian(&mut y_buf);
+                        (x_buf, y_buf)
+                    })
+                    .map_err(|err| err as u32);
+                match res.to_bytes() {
+                    Ok(bytes) => Ok(Some(bytes.into())),
+                    Err(_) => Err(DispatchError::Api(ApiError::Formatting)),
+                }
+            }
+            CryptoMethods::AltBn128Multiply => {
+                let (x_bytes, y_bytes, scalar_bytes) = bytesrepr::deserialize_from_slice::<
+                    &Bytes,
+                    ([u8; 32], [u8; 32], [u8; 32]),
+                >(&input)
+                .map_err(|_e| {
+                    ExecuteError::Api(
+                        "Cannot deserialize arguments to AltBn128Multiply host function"
+                            .to_string(),
+                    )
+                })?;
+                let x = U256::from_little_endian(&x_bytes);
+                let y = U256::from_little_endian(&y_bytes);
+                let scalar = U256::from_little_endian(&scalar_bytes);
+                let res = alt_bn128_mul(x, y, scalar)
+                    .map(|(x, y)| {
+                        let mut x_buf = [0u8; 32];
+                        let mut y_buf = [0u8; 32];
+                        x.to_little_endian(&mut x_buf);
+                        y.to_little_endian(&mut y_buf);
+                        (x_buf, y_buf)
+                    })
+                    .map_err(|err| err as u32);
+                match res.to_bytes() {
+                    Ok(bytes) => Ok(Some(bytes.into())),
+                    Err(_) => Err(DispatchError::Api(ApiError::Formatting)),
+                }
+            }
+            CryptoMethods::AltBn128Pairing => {
+                let pairs = bytesrepr::deserialize_from_slice::<&Bytes, Vec<Pair>>(&input)
+                    .map_err(|_e| {
+                        ExecuteError::Api(
+                            "Cannot deserialize arguments to AltBn128Pairing host function"
+                                .to_string(),
+                        )
+                    })?;
+                let values = pairs.iter().map(Pair::to_u256_tuples).collect();
+                let res = alt_bn128_pairing(values).map_err(|e| e as u32);
+                match res.to_bytes() {
+                    Ok(bytes) => Ok(Some(bytes.into())),
+                    Err(_) => Err(DispatchError::Api(ApiError::Formatting)),
                 }
             }
         },

--- a/executor/wasm_interface/src/executor.rs
+++ b/executor/wasm_interface/src/executor.rs
@@ -380,11 +380,20 @@ pub enum AuctionMethods {
     ChangePublicKey,
 }
 
+/// Available options for interacting with host-side cryptographic functions. For
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CryptoMethods {
+    AltBn128Add,
+    AltBn128Multiply,
+    AltBn128Pairing,
+}
+
 /// Available options for interacting with the system.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SystemMenu {
     Mint(MintMethods),
     Auction(AuctionMethods),
+    Crypto(CryptoMethods),
 }
 
 impl TryFrom<u32> for SystemMenu {
@@ -404,6 +413,9 @@ impl TryFrom<u32> for SystemMenu {
             106 => Ok(SystemMenu::Auction(AuctionMethods::AddReservation)),
             107 => Ok(SystemMenu::Auction(AuctionMethods::CancelReservation)),
             108 => Ok(SystemMenu::Auction(AuctionMethods::ChangePublicKey)),
+            200 => Ok(SystemMenu::Crypto(CryptoMethods::AltBn128Add)),
+            201 => Ok(SystemMenu::Crypto(CryptoMethods::AltBn128Multiply)),
+            202 => Ok(SystemMenu::Crypto(CryptoMethods::AltBn128Pairing)),
             _ => Err(()),
         }
     }
@@ -427,6 +439,11 @@ impl From<SystemMenu> for u32 {
                 AuctionMethods::AddReservation => 106,
                 AuctionMethods::CancelReservation => 107,
                 AuctionMethods::ChangePublicKey => 108,
+            },
+            SystemMenu::Crypto(crypto) => match crypto {
+                CryptoMethods::AltBn128Add => 200,
+                CryptoMethods::AltBn128Multiply => 201,
+                CryptoMethods::AltBn128Pairing => 202,
             },
         }
     }

--- a/executor/wasm_interface/src/lib.rs
+++ b/executor/wasm_interface/src/lib.rs
@@ -267,11 +267,7 @@ pub trait Caller {
     /// Check if an export is present in the module.
     fn has_export(&self, name: &str) -> VMResult<bool>;
 
-    fn memory_read(&self, offset: u32, size: usize) -> VMResult<Vec<u8>> {
-        let mut vec = vec![0; size];
-        self.memory_read_into(offset, &mut vec)?;
-        Ok(vec)
-    }
+    fn memory_read(&self, offset: u32, size: usize) -> VMResult<Vec<u8>>;
     fn memory_read_into(&self, offset: u32, output: &mut [u8]) -> VMResult<()>;
     fn memory_write(&self, offset: u32, data: &[u8]) -> VMResult<()>;
     /// Allocates memory inside the Wasm VM by calling an export.

--- a/executor/wasmer_backend/src/lib.rs
+++ b/executor/wasmer_backend/src/lib.rs
@@ -176,6 +176,11 @@ impl<S: GlobalStateReader + 'static, E: Executor + 'static> Caller for WasmerCal
         self.env.data().bytecode.clone()
     }
 
+    fn memory_read(&self, offset: u32, size: usize) -> VMResult<Vec<u8>> {
+        self.with_memory(|mem| mem.copy_range_to_vec(offset as u64..size as u64 + offset as u64))?
+            .map_err(from_wasmer_memory_access_error)
+    }
+
     fn memory_read_into(&self, offset: u32, output: &mut [u8]) -> VMResult<()> {
         self.with_memory(|mem| mem.read(offset.into(), output))?
             .map_err(from_wasmer_memory_access_error)

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -323,6 +323,9 @@ mod tests {
             env_info: HostFunctionV2::new(114, [0, 1]),
             generic_hash: HostFunctionV2::new(115, [0, 1, 2, 3]),
             recover_secp256k1: HostFunctionV2::new(116, [0, 1, 2, 3, 4, 5]),
+            alt_bn128_add: HostFunctionV2::new(117, [0, 1]),
+            alt_bn128_mul: HostFunctionV2::new(118, [0, 1]),
+            alt_bn128_pairing: HostFunctionV2::new(119, [0, 1]),
         });
     static EXPECTED_GENESIS_WASM_COSTS: Lazy<WasmConfig> = Lazy::new(|| {
         let wasm_v1_config = WasmV1Config::new(

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -426,6 +426,9 @@ emit = { cost = 0, arguments = [0, 0, 0, 0] }
 env_info = { cost = 0, arguments = [0, 0] }
 generic_hash = { cost = 0, arguments = [0, 0, 0, 0] }
 recover_secp256k1 = { cost = 0, arguments = [0, 0, 0, 0, 0, 0] }
+alt_bn128_add = { cost = 1_000_000, arguments = [0, 0] }
+alt_bn128_mul = { cost = 1_000_000, arguments = [0, 0] }
+alt_bn128_pairing = { cost = 1_000_000, arguments = [0, 2_000] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -432,6 +432,9 @@ emit = { cost = 0, arguments = [0, 0, 0, 0] }
 env_info = { cost = 0, arguments = [0, 0] }
 generic_hash = { cost = 0, arguments = [0, 0, 0, 0] }
 recover_secp256k1 = { cost = 0, arguments = [0, 0, 0, 0, 0, 0] }
+alt_bn128_add = { cost = 1_000_000, arguments = [0, 0] }
+alt_bn128_mul = { cost = 1_000_000, arguments = [0, 0] }
+alt_bn128_pairing = { cost = 1_000_000, arguments = [0, 2_000] }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/smart_contracts/contracts/vm2/vm2-altbn128/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-altbn128/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "vm2-altbn128"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-contract-sdk = { path = "../../../sdk" }
+base16 = { version = "0.2.1", default-features = false, features = [] }
+bn = { version = "0.5", package = "zeropool-bn", default-features = false, optional = true }
+
+[features]
+default = []
+wasm_add_test = ["bn"]
+wasm_mul_test = ["bn"]
+wasm_pairing_test = ["bn"]

--- a/smart_contracts/contracts/vm2/vm2-altbn128/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-altbn128/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Check if target arch is wasm32 and set link flags accordingly
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        println!("cargo:rustc-link-arg=--import-memory");
+        println!("cargo:rustc-link-arg=--export-table");
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-altbn128/src/host.rs
+++ b/smart_contracts/contracts/vm2/vm2-altbn128/src/host.rs
@@ -1,0 +1,256 @@
+use alloc::{format, vec};
+use casper_contract_sdk::{
+    casper::{
+        self,
+        altbn128::{self, AltBn128Error as Error, Fq, Fr, Pair, G1},
+        casper_system,
+    },
+    casper_executor_wasm_common::flags::ReturnFlags,
+    serializers::borsh::from_slice,
+    types::CryptoFunctionOption,
+};
+
+const ADD_X1_LE: [u8; 32] = [
+    201, 61, 9, 78, 3, 116, 59, 93, 12, 97, 145, 70, 18, 221, 17, 179, 133, 113, 142, 54, 17, 84,
+    219, 118, 2, 195, 194, 180, 207, 138, 177, 24,
+];
+const ADD_Y1_LE: [u8; 32] = [
+    102, 114, 243, 152, 129, 40, 13, 252, 46, 211, 88, 150, 129, 150, 87, 117, 73, 167, 159, 245,
+    185, 76, 19, 181, 12, 132, 32, 71, 156, 144, 60, 6,
+];
+const ADD_X2_LE: [u8; 32] = [
+    237, 78, 1, 106, 124, 158, 1, 136, 58, 150, 146, 44, 255, 32, 127, 24, 26, 187, 192, 43, 156,
+    12, 240, 69, 97, 189, 132, 138, 245, 183, 194, 7,
+];
+const ADD_Y2_LE: [u8; 32] = [
+    215, 23, 250, 120, 132, 120, 214, 43, 116, 92, 72, 164, 6, 23, 54, 223, 23, 154, 76, 247, 163,
+    13, 215, 242, 64, 233, 71, 193, 32, 78, 97, 6,
+];
+const ADD_EXPECTED_X_LE: [u8; 32] = [
+    3, 151, 131, 2, 226, 174, 238, 161, 95, 182, 230, 76, 10, 131, 94, 216, 77, 254, 163, 12, 172,
+    69, 60, 61, 156, 75, 253, 94, 92, 82, 67, 34,
+];
+const ADD_EXPECTED_Y_LE: [u8; 32] = [
+    21, 201, 149, 241, 72, 125, 94, 174, 185, 125, 83, 50, 117, 237, 14, 24, 35, 71, 150, 53, 204,
+    33, 223, 9, 229, 168, 109, 190, 51, 29, 29, 48,
+];
+
+const MUL_X_LE: [u8; 32] = [
+    183, 159, 10, 26, 139, 38, 2, 29, 230, 72, 86, 174, 215, 3, 71, 76, 213, 185, 229, 156, 180,
+    167, 92, 79, 146, 66, 177, 243, 208, 230, 211, 43,
+];
+const MUL_Y_LE: [u8; 32] = [
+    4, 178, 253, 206, 102, 174, 12, 57, 200, 25, 70, 74, 173, 223, 73, 46, 206, 9, 9, 48, 112, 29,
+    47, 94, 145, 133, 175, 166, 224, 28, 97, 33,
+];
+const MUL_SCALAR_LE: [u8; 32] = [
+    194, 21, 250, 80, 231, 140, 19, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0,
+];
+const MUL_EXPECTED_X_LE: [u8; 32] = [
+    92, 30, 195, 19, 156, 108, 42, 238, 164, 245, 83, 160, 116, 178, 71, 138, 239, 250, 232, 52,
+    212, 41, 190, 228, 202, 83, 33, 152, 106, 141, 10, 7,
+];
+const MUL_EXPECTED_Y_LE: [u8; 32] = [
+    252, 26, 152, 198, 206, 195, 14, 105, 21, 243, 240, 244, 75, 7, 67, 25, 240, 176, 213, 205,
+    249, 137, 185, 255, 169, 163, 235, 20, 233, 140, 27, 3,
+];
+
+const PAIRING_AX_1_LE: [u8; 32] = [
+    89, 63, 196, 36, 96, 193, 49, 221, 100, 166, 173, 118, 170, 167, 255, 129, 51, 25, 161, 187,
+    126, 213, 65, 69, 185, 75, 239, 77, 111, 71, 118, 28,
+];
+const PAIRING_AY_1_LE: [u8; 32] = [
+    65, 239, 106, 167, 3, 155, 92, 228, 148, 210, 233, 211, 85, 155, 129, 252, 69, 135, 103, 28,
+    129, 226, 254, 4, 226, 115, 246, 32, 41, 221, 52, 48,
+];
+const PAIRING_BAY_1_LE: [u8; 32] = [
+    247, 91, 163, 3, 32, 69, 74, 107, 57, 20, 53, 198, 54, 150, 50, 167, 153, 207, 147, 26, 229,
+    136, 216, 75, 108, 212, 245, 191, 94, 209, 157, 32,
+];
+const PAIRING_BAX_1_LE: [u8; 32] = [
+    120, 22, 164, 21, 99, 75, 175, 73, 64, 192, 138, 76, 17, 96, 89, 144, 40, 141, 132, 97, 53,
+    180, 52, 139, 250, 59, 72, 1, 202, 17, 191, 4,
+];
+const PAIRING_BBY_1_LE: [u8; 32] = [
+    77, 52, 190, 81, 42, 60, 147, 191, 173, 31, 196, 122, 205, 26, 167, 162, 12, 253, 92, 68, 26,
+    173, 162, 55, 53, 201, 207, 246, 74, 50, 184, 43,
+];
+const PAIRING_BBX_1_LE: [u8; 32] = [
+    80, 117, 135, 222, 228, 229, 95, 22, 72, 176, 155, 12, 31, 230, 204, 162, 126, 224, 57, 254,
+    198, 32, 95, 132, 249, 27, 12, 243, 76, 42, 10, 18,
+];
+const PAIRING_AX_2_LE: [u8; 32] = [
+    124, 223, 182, 209, 73, 222, 34, 195, 234, 203, 241, 111, 60, 2, 162, 91, 250, 205, 15, 199,
+    74, 28, 212, 16, 119, 9, 241, 28, 159, 18, 30, 17,
+];
+const PAIRING_AY_2_LE: [u8; 32] = [
+    17, 244, 107, 106, 206, 250, 83, 56, 167, 112, 56, 185, 133, 53, 136, 162, 252, 66, 242, 43,
+    70, 233, 109, 40, 23, 60, 14, 131, 26, 198, 50, 32,
+];
+const PAIRING_BAY_2_LE: [u8; 32] = [
+    194, 18, 243, 174, 183, 133, 228, 151, 18, 231, 169, 53, 51, 73, 170, 241, 37, 93, 251, 49,
+    183, 191, 96, 114, 58, 72, 13, 146, 147, 147, 142, 25,
+];
+const PAIRING_BAX_2_LE: [u8; 32] = [
+    237, 246, 146, 217, 92, 189, 222, 70, 221, 218, 94, 247, 212, 34, 67, 103, 121, 68, 92, 94,
+    102, 0, 106, 66, 118, 30, 31, 18, 239, 222, 0, 24,
+];
+const PAIRING_BBY_2_LE: [u8; 32] = [
+    91, 151, 34, 209, 220, 218, 172, 85, 243, 142, 179, 112, 51, 49, 75, 188, 149, 51, 12, 105,
+    173, 153, 158, 236, 117, 240, 95, 88, 208, 137, 6, 9,
+];
+const PAIRING_BBX_2_LE: [u8; 32] = [
+    170, 125, 250, 102, 1, 204, 230, 76, 123, 211, 67, 12, 105, 231, 209, 227, 143, 64, 203, 141,
+    128, 113, 171, 74, 235, 109, 140, 219, 165, 94, 200, 18,
+];
+const ALL_ONES: [u8; 32] = [0x11; 32];
+
+pub(crate) fn alt_bn128_pairing_raw(input: &[u8]) -> altbn128::Result<bool> {
+    let option = CryptoFunctionOption::AltBn128Pairing;
+    let (output, result) = casper_system(option.into(), &input);
+    let _ = result.unwrap();
+    match output {
+        Some(raw) => {
+            let val: Result<bool, u32> = from_slice(&raw).unwrap();
+            val.map_err(|err_code| Error::from(err_code))
+        }
+        None => Err(Error::NoValueNorError),
+    }
+}
+
+fn test_alt_bn128_add() {
+    let actual = altbn128::alt_bn128_add(
+        &G1::from(ADD_X1_LE),
+        &G1::from(ADD_Y1_LE),
+        &G1::from(ADD_X2_LE),
+        &G1::from(ADD_Y2_LE),
+    );
+    let expected = Ok((Fq::from(ADD_EXPECTED_X_LE), Fq::from(ADD_EXPECTED_Y_LE)));
+    if actual != expected {
+        casper::print(&format!("left {:?} right {:?}", actual, expected));
+        let error_code = line!().to_le_bytes();
+        casper::ret(ReturnFlags::REVERT, Some(&error_code));
+    }
+}
+
+fn test_zero_add() {
+    if altbn128::alt_bn128_add(&G1::zero(), &G1::zero(), &G1::zero(), &G1::zero())
+        != Ok((Fq::zero(), Fq::zero()))
+    {
+        let error_code = line!().to_le_bytes();
+        casper::ret(ReturnFlags::REVERT, Some(&error_code));
+    }
+}
+
+fn test_add_error() {
+    let all_ones = G1::from(ALL_ONES);
+
+    if altbn128::alt_bn128_add(&all_ones, &all_ones, &all_ones, &all_ones)
+        != Err(Error::InvalidPoint)
+    {
+        let error_code = line!().to_le_bytes();
+        casper::ret(ReturnFlags::REVERT, Some(&error_code));
+    }
+}
+
+fn test_alt_bn128_mul() {
+    let x = G1::from(MUL_X_LE);
+    let y = G1::from(MUL_Y_LE);
+    let scalar = Fr::from(MUL_SCALAR_LE);
+
+    assert_eq!(
+        altbn128::alt_bn128_mul(&x, &y, &scalar),
+        Ok((Fq::from(MUL_EXPECTED_X_LE), Fq::from(MUL_EXPECTED_Y_LE)))
+    );
+}
+const BIG_SCALAR_0X02: [u8; 32] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0x02,
+];
+const BIG_SCALAR_0X0F: [u8; 32] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0x0f,
+];
+
+fn test_zero_multiplication() {
+    let x = G1::zero();
+    let y = G1::zero();
+    let scalar = Fr::from(BIG_SCALAR_0X02);
+    assert_eq!(
+        altbn128::alt_bn128_mul(&x, &y, &scalar),
+        Ok((Fq::zero(), Fq::zero()))
+    );
+}
+
+fn test_not_on_curve_multiplication() {
+    let x = G1::from(ALL_ONES);
+    let y = G1::from(ALL_ONES);
+    let scalar = Fr::from(BIG_SCALAR_0X0F);
+    assert_eq!(
+        altbn128::alt_bn128_mul(&x, &y, &scalar),
+        Err(Error::InvalidPoint)
+    );
+}
+
+fn test_alt_bn128_pairing() {
+    let all_pairs = [
+        Pair::from(
+            Fq::from(PAIRING_AX_1_LE),
+            Fq::from(PAIRING_AY_1_LE),
+            Fq::from(PAIRING_BAX_1_LE),
+            Fq::from(PAIRING_BAY_1_LE),
+            Fq::from(PAIRING_BBX_1_LE),
+            Fq::from(PAIRING_BBY_1_LE),
+        ),
+        Pair::from(
+            Fq::from(PAIRING_AX_2_LE),
+            Fq::from(PAIRING_AY_2_LE),
+            Fq::from(PAIRING_BAX_2_LE),
+            Fq::from(PAIRING_BAY_2_LE),
+            Fq::from(PAIRING_BBX_2_LE),
+            Fq::from(PAIRING_BBY_2_LE),
+        ),
+    ];
+
+    assert_eq!(altbn128::alt_bn128_pairing(&all_pairs.to_vec()), Ok(true));
+}
+
+fn test_pairing_invalid_a() {
+    let pair = Pair::from(
+        Fq::from([0x11u8; 32]),
+        Fq::from([0x11u8; 32]),
+        Fq::from([0x11u8; 32]),
+        Fq::from([0x11u8; 32]),
+        Fq::from([0x11u8; 32]),
+        Fq::from([0x11u8; 32]),
+    );
+
+    assert_eq!(
+        altbn128::alt_bn128_pairing(&vec!(pair)),
+        Err(Error::InvalidA)
+    );
+}
+fn test_pairing_on_curve() {
+    let pair = Pair::from(
+        Fq::from([0; 32]),
+        Fq::from([0; 32]),
+        Fq::from([0; 32]),
+        Fq::from([0; 32]),
+        Fq::from([0; 32]),
+        Fq::from([0; 32]),
+    );
+    assert_eq!(altbn128::alt_bn128_pairing(&vec!(pair)), Ok(true),);
+}
+
+pub(crate) fn perform_tests() {
+    test_alt_bn128_add();
+    test_alt_bn128_mul();
+    test_alt_bn128_pairing();
+    test_zero_add();
+    test_add_error();
+    test_zero_multiplication();
+    test_not_on_curve_multiplication();
+    test_pairing_invalid_a();
+    test_pairing_on_curve();
+}

--- a/smart_contracts/contracts/vm2/vm2-altbn128/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-altbn128/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use casper_contract_sdk::prelude::*;
+
+#[cfg(not(any(
+    feature = "wasm_add_test",
+    feature = "wasm_mul_test",
+    feature = "wasm_pairing_test"
+)))]
+mod host;
+#[cfg(not(any(
+    feature = "wasm_add_test",
+    feature = "wasm_mul_test",
+    feature = "wasm_pairing_test"
+)))]
+use host::perform_tests;
+#[cfg(any(
+    feature = "wasm_add_test",
+    feature = "wasm_mul_test",
+    feature = "wasm_pairing_test"
+))]
+mod wasm;
+#[cfg(any(
+    feature = "wasm_add_test",
+    feature = "wasm_mul_test",
+    feature = "wasm_pairing_test"
+))]
+use wasm::perform_tests;
+
+#[casper(contract_state)]
+pub struct AltBn128Contract {}
+
+impl Default for AltBn128Contract {
+    fn default() -> Self {
+        panic!("nope");
+    }
+}
+
+#[casper]
+impl AltBn128Contract {
+    #[casper(constructor)]
+    pub fn new() -> Self {
+        perform_tests();
+        Self {}
+    }
+
+    #[cfg(not(any(
+        feature = "wasm_add_test",
+        feature = "wasm_mul_test",
+        feature = "wasm_pairing_test"
+    )))]
+    pub fn pairing(&self, raw: Vec<u8>) -> Result<bool, u32> {
+        host::alt_bn128_pairing_raw(&raw).map_err(|e| u32::from(e))
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-altbn128/src/wasm.rs
+++ b/smart_contracts/contracts/vm2/vm2-altbn128/src/wasm.rs
@@ -1,0 +1,254 @@
+//! Consts for wasm-version of a bn curves.
+//!
+//! Counter-intuitively, these values are encoded in big-endian form as the bn crate expects u256
+//! integers to be encoded in big-endian form.
+//!
+//! The host version of the bn crate expects u256 integers to be encoded in little-endian form as
+//! it's more natural and expectedly more efficient for of transforming u256 values to and from
+//! host.
+#[allow(unused_imports)]
+use alloc::vec::Vec;
+#[allow(unused_imports)]
+use bn::{AffineG1, AffineG2, Fq, Fr, Group, G1};
+#[allow(unused_imports)]
+use casper_contract_sdk::casper::{self, altbn128::AltBn128Error as Error};
+
+#[allow(dead_code)]
+mod consts {
+    pub const ADD_X1_BE: [u8; 32] = [
+        24, 177, 138, 207, 180, 194, 195, 2, 118, 219, 84, 17, 54, 142, 113, 133, 179, 17, 221, 18,
+        70, 145, 97, 12, 93, 59, 116, 3, 78, 9, 61, 201,
+    ];
+    pub const ADD_Y1_BE: [u8; 32] = [
+        6, 60, 144, 156, 71, 32, 132, 12, 181, 19, 76, 185, 245, 159, 167, 73, 117, 87, 150, 129,
+        150, 88, 211, 46, 252, 13, 40, 129, 152, 243, 114, 102,
+    ];
+    pub const ADD_X2_BE: [u8; 32] = [
+        7, 194, 183, 245, 138, 132, 189, 97, 69, 240, 12, 156, 43, 192, 187, 26, 24, 127, 32, 255,
+        44, 146, 150, 58, 136, 1, 158, 124, 106, 1, 78, 237,
+    ];
+
+    pub const ADD_Y2_BE: [u8; 32] = [
+        6, 97, 78, 32, 193, 71, 233, 64, 242, 215, 13, 163, 247, 76, 154, 23, 223, 54, 23, 6, 164,
+        72, 92, 116, 43, 214, 120, 132, 120, 250, 23, 215,
+    ];
+
+    pub const ADD_EXPECTED_X_BE: [u8; 32] = [
+        34, 67, 82, 92, 94, 253, 75, 156, 61, 60, 69, 172, 12, 163, 254, 77, 216, 94, 131, 10, 76,
+        230, 182, 95, 161, 238, 174, 226, 2, 131, 151, 3,
+    ];
+    pub const ADD_EXPECTED_Y_BE: [u8; 32] = [
+        48, 29, 29, 51, 190, 109, 168, 229, 9, 223, 33, 204, 53, 150, 71, 35, 24, 14, 237, 117, 50,
+        83, 125, 185, 174, 94, 125, 72, 241, 149, 201, 21,
+    ];
+
+    pub const MUL_X_BE: [u8; 32] = [
+        43, 211, 230, 208, 243, 177, 66, 146, 79, 92, 167, 180, 156, 229, 185, 213, 76, 71, 3, 215,
+        174, 86, 72, 230, 29, 2, 38, 139, 26, 10, 159, 183,
+    ];
+    pub const MUL_Y_BE: [u8; 32] = [
+        33, 97, 28, 224, 166, 175, 133, 145, 94, 47, 29, 112, 48, 9, 9, 206, 46, 73, 223, 173, 74,
+        70, 25, 200, 57, 12, 174, 102, 206, 253, 178, 4,
+    ];
+    pub const MUL_SCALAR_BE: [u8; 32] = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 19, 140, 231,
+        80, 250, 21, 194,
+    ];
+    pub const MUL_EXPECTED_X_BE: [u8; 32] = [
+        7, 10, 141, 106, 152, 33, 83, 202, 228, 190, 41, 212, 52, 232, 250, 239, 138, 71, 178, 116,
+        160, 83, 245, 164, 238, 42, 108, 156, 19, 195, 30, 92,
+    ];
+    pub const MUL_EXPECTED_Y_BE: [u8; 32] = [
+        3, 27, 140, 233, 20, 235, 163, 169, 255, 185, 137, 249, 205, 213, 176, 240, 25, 67, 7, 75,
+        244, 240, 243, 21, 105, 14, 195, 206, 198, 152, 26, 252,
+    ];
+
+    pub const PAIRING_AX_1_BE: [u8; 32] = [
+        28, 118, 71, 111, 77, 239, 75, 185, 69, 65, 213, 126, 187, 161, 25, 51, 129, 255, 167, 170,
+        118, 173, 166, 100, 221, 49, 193, 96, 36, 196, 63, 89,
+    ];
+    pub const PAIRING_AY_1_BE: [u8; 32] = [
+        48, 52, 221, 41, 32, 246, 115, 226, 4, 254, 226, 129, 28, 103, 135, 69, 252, 129, 155, 85,
+        211, 233, 210, 148, 228, 92, 155, 3, 167, 106, 239, 65,
+    ];
+    pub const PAIRING_BAY_1_BE: [u8; 32] = [
+        32, 157, 209, 94, 191, 245, 212, 108, 75, 216, 136, 229, 26, 147, 207, 153, 167, 50, 150,
+        54, 198, 53, 20, 57, 107, 74, 69, 32, 3, 163, 91, 247,
+    ];
+    pub const PAIRING_BAX_1_BE: [u8; 32] = [
+        4, 191, 17, 202, 1, 72, 59, 250, 139, 52, 180, 53, 97, 132, 141, 40, 144, 89, 96, 17, 76,
+        138, 192, 64, 73, 175, 75, 99, 21, 164, 22, 120,
+    ];
+    pub const PAIRING_BBY_1_BE: [u8; 32] = [
+        43, 184, 50, 74, 246, 207, 201, 53, 55, 162, 173, 26, 68, 92, 253, 12, 162, 167, 26, 205,
+        122, 196, 31, 173, 191, 147, 60, 42, 81, 190, 52, 77,
+    ];
+    pub const PAIRING_BBX_1_BE: [u8; 32] = [
+        18, 10, 42, 76, 243, 12, 27, 249, 132, 95, 32, 198, 254, 57, 224, 126, 162, 204, 230, 31,
+        12, 155, 176, 72, 22, 95, 229, 228, 222, 135, 117, 80,
+    ];
+    pub const PAIRING_AX_2_BE: [u8; 32] = [
+        17, 30, 18, 159, 28, 241, 9, 119, 16, 212, 28, 74, 199, 15, 205, 250, 91, 162, 2, 60, 111,
+        241, 203, 234, 195, 34, 222, 73, 209, 182, 223, 124,
+    ];
+    pub const PAIRING_AY_2_BE: [u8; 32] = [
+        32, 50, 198, 26, 131, 14, 60, 23, 40, 109, 233, 70, 43, 242, 66, 252, 162, 136, 53, 133,
+        185, 56, 112, 167, 56, 83, 250, 206, 106, 107, 244, 17,
+    ];
+    pub const PAIRING_BAY_2_BE: [u8; 32] = [
+        25, 142, 147, 147, 146, 13, 72, 58, 114, 96, 191, 183, 49, 251, 93, 37, 241, 170, 73, 51,
+        53, 169, 231, 18, 151, 228, 133, 183, 174, 243, 18, 194,
+    ];
+    pub const PAIRING_BAX_2_BE: [u8; 32] = [
+        24, 0, 222, 239, 18, 31, 30, 118, 66, 106, 0, 102, 94, 92, 68, 121, 103, 67, 34, 212, 247,
+        94, 218, 221, 70, 222, 189, 92, 217, 146, 246, 237,
+    ];
+    pub const PAIRING_BBY_2_BE: [u8; 32] = [
+        9, 6, 137, 208, 88, 95, 240, 117, 236, 158, 153, 173, 105, 12, 51, 149, 188, 75, 49, 51,
+        112, 179, 142, 243, 85, 172, 218, 220, 209, 34, 151, 91,
+    ];
+    pub const PAIRING_BBX_2_BE: [u8; 32] = [
+        18, 200, 94, 165, 219, 140, 109, 235, 74, 171, 113, 128, 141, 203, 64, 143, 227, 209, 231,
+        105, 12, 67, 211, 123, 76, 230, 204, 1, 102, 250, 125, 170,
+    ];
+}
+use consts::*;
+
+#[cfg(feature = "wasm_add_test")]
+fn wasm_add_test() {
+    let p1 = bn_point_from_coords(&ADD_X1_BE, &ADD_Y1_BE);
+    let p2 = bn_point_from_coords(&ADD_X2_BE, &ADD_Y2_BE);
+
+    let mut x = None;
+    let mut y = None;
+
+    if let Some(sum) = AffineG1::from_jacobian(p1 + p2) {
+        x = Some(sum.x());
+        y = Some(sum.y());
+    }
+
+    assert_eq!(
+        (x, y),
+        (
+            Some(Fq::from_slice(&ADD_EXPECTED_X_BE).unwrap()),
+            Some(Fq::from_slice(&ADD_EXPECTED_Y_BE).unwrap())
+        )
+    );
+}
+#[allow(dead_code)]
+fn bn_point_from_coords(x: &[u8; 32], y: &[u8; 32]) -> G1 {
+    let px = Fq::from_slice(x).unwrap();
+    let py = Fq::from_slice(y).unwrap();
+
+    if px == Fq::zero() && py == Fq::zero() {
+        G1::zero()
+    } else {
+        AffineG1::new(px, py).unwrap().into()
+    }
+}
+#[cfg(feature = "wasm_mul_test")]
+fn wasm_mul_test() {
+    fn bn_fq_to_be_bytes(bn_fq: Fq) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bn_fq.to_big_endian(&mut bytes).unwrap();
+        bytes
+    }
+
+    let p = bn_point_from_coords(&MUL_X_BE, &MUL_Y_BE);
+
+    let mut x = None;
+    let mut y = None;
+    let fr = Fr::from_slice(&MUL_SCALAR_BE).unwrap();
+
+    if let Some(product) = AffineG1::from_jacobian(p * fr) {
+        x = Some(bn_fq_to_be_bytes(product.x()));
+        y = Some(bn_fq_to_be_bytes(product.y()));
+    }
+
+    assert_eq!((x, y), (Some(MUL_EXPECTED_X_BE), Some(MUL_EXPECTED_Y_BE)));
+}
+
+pub fn perform_tests() {
+    // Wasm-only tests (compile BN crate to Wassm)
+    #[cfg(feature = "wasm_add_test")]
+    {
+        wasm_add_test();
+    }
+
+    #[cfg(feature = "wasm_mul_test")]
+    {
+        wasm_mul_test();
+    }
+
+    #[cfg(feature = "wasm_pairing_test")]
+    {
+        wasm_pairing_test();
+    }
+}
+
+#[cfg(feature = "wasm_pairing_test")]
+pub fn wasm_alt_bn128_pairing(
+    values: &[(&[u8], &[u8], &[u8], &[u8], &[u8], &[u8])],
+) -> Result<bool, Error> {
+    let mut pairs = Vec::with_capacity(values.len());
+
+    for (ax, ay, bax, bay, bbx, bby) in values {
+        let ax = Fq::from_slice(&ax).map_err(|_| Error::InvalidAx)?;
+        let ay = Fq::from_slice(&ay).map_err(|_| Error::InvalidAy)?;
+        let bay = Fq::from_slice(&bay).map_err(|_| Error::InvalidBay)?;
+        let bax = Fq::from_slice(&bax).map_err(|_| Error::InvalidBax)?;
+        let bby = Fq::from_slice(&bby).map_err(|_| Error::InvalidBby)?;
+        let bbx = Fq::from_slice(&bbx).map_err(|_| Error::InvalidBbx)?;
+
+        let g1_a = {
+            if ax.is_zero() && ay.is_zero() {
+                bn::G1::zero()
+            } else {
+                bn::AffineG1::new(ax, ay)
+                    .map_err(|_| Error::InvalidA)?
+                    .into()
+            }
+        };
+        let g1_b = {
+            let ba = bn::Fq2::new(bax, bay);
+            let bb = bn::Fq2::new(bbx, bby);
+
+            if ba.is_zero() && bb.is_zero() {
+                bn::G2::zero()
+            } else {
+                bn::AffineG2::new(ba, bb)
+                    .map_err(|_| Error::InvalidB)?
+                    .into()
+            }
+        };
+
+        pairs.push((g1_a, g1_b));
+    }
+
+    Ok(bn::pairing_batch(pairs.as_slice()) == bn::Gt::one())
+}
+
+#[cfg(feature = "wasm_pairing_test")]
+fn wasm_pairing_test() {
+    assert_eq!(
+        wasm_alt_bn128_pairing(&[
+            (
+                &PAIRING_AX_1_BE,
+                &PAIRING_AY_1_BE,
+                &PAIRING_BAX_1_BE,
+                &PAIRING_BAY_1_BE,
+                &PAIRING_BBX_1_BE,
+                &PAIRING_BBY_1_BE
+            ),
+            (
+                &PAIRING_AX_2_BE,
+                &PAIRING_AY_2_BE,
+                &PAIRING_BAX_2_BE,
+                &PAIRING_BAY_2_BE,
+                &PAIRING_BBX_2_BE,
+                &PAIRING_BBY_2_BE
+            ),
+        ]),
+        Ok(true)
+    );
+}

--- a/smart_contracts/sdk/src/casper.rs
+++ b/smart_contracts/sdk/src/casper.rs
@@ -1,3 +1,4 @@
+pub mod altbn128;
 #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
 pub mod native;
 

--- a/smart_contracts/sdk/src/casper/altbn128.rs
+++ b/smart_contracts/sdk/src/casper/altbn128.rs
@@ -1,0 +1,334 @@
+//! Host-optimized support for pairing cryptography with the Barreto-Naehrig curve
+use core::array::TryFromSliceError;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::{
+    casper::casper_system,
+    types::{CryptoFunctionOption, U256},
+};
+
+/// A point on the alt_bn128 curve.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, BorshSerialize, BorshDeserialize)]
+#[repr(C, packed)]
+pub struct G1([u8; 32]);
+
+impl G1 {
+    pub const SIZE_IN_BYTES: u32 = core::mem::size_of::<G1>() as u32;
+    /// Returns a point with all bytes set to zero.
+    pub const fn zero() -> Self {
+        G1([0; 32])
+    }
+
+    /// Returns the inner byte array.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for G1 {
+    fn from(value: [u8; 32]) -> Self {
+        G1(value)
+    }
+}
+
+impl From<U256> for G1 {
+    fn from(value: U256) -> Self {
+        let bytes = u256_to_le_bytes(value);
+        G1(bytes)
+    }
+}
+
+/// A scalar on the alt_bn128 curve.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, BorshSerialize, BorshDeserialize)]
+#[repr(C, packed)]
+pub struct Fr([u8; 32]);
+
+impl Fr {
+    pub const SIZE_IN_BYTES: u32 = core::mem::size_of::<Fr>() as u32;
+
+    /// Returns a point with all bytes set to zero.
+    pub const fn zero() -> Self {
+        Fr([0; 32])
+    }
+
+    /// Returns the inner byte array.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<U256> for Fr {
+    fn from(value: U256) -> Self {
+        let bytes = u256_to_le_bytes(value);
+        Self(bytes)
+    }
+}
+
+impl From<[u8; 32]> for Fr {
+    fn from(value: [u8; 32]) -> Self {
+        Fr(value)
+    }
+}
+
+/// A field element on the alt_bn128 curve.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, BorshSerialize, BorshDeserialize)]
+#[repr(C, packed)]
+pub struct Fq([u8; 32]);
+
+impl Fq {
+    /// Returns a point with all bytes set to zero.
+    pub const fn zero() -> Self {
+        Fq([0; 32])
+    }
+
+    /// Returns the inner byte array.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<U256> for Fq {
+    fn from(value: U256) -> Self {
+        let bytes = u256_to_le_bytes(value);
+        Self(bytes)
+    }
+}
+
+impl TryFrom<&[u8]> for Fq {
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &[u8]) -> core::result::Result<Self, Self::Error> {
+        Ok(Fq(value.try_into()?))
+    }
+}
+
+impl From<[u8; 32]> for Fq {
+    fn from(value: [u8; 32]) -> Self {
+        Fq(value)
+    }
+}
+
+/// Error type for the alt_bn128 module.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, BorshDeserialize, BorshSerialize)]
+#[borsh(crate = "crate::serializers::borsh", use_discriminant = true)]
+#[repr(u32)]
+pub enum AltBn128Error {
+    /// Invalid point x coordinate.
+    InvalidXCoordinate = 1,
+    /// Invalid point y coordinate.
+    InvalidYCoordinate = 2,
+    /// Invalid point.
+    InvalidPoint = 3,
+    /// Invalid A.
+    InvalidA = 4,
+    /// Invalid B.
+    InvalidB = 5,
+    /// Invalid Ax.
+    InvalidAx = 6,
+    /// Invalid Ay.
+    InvalidAy = 7,
+    /// Invalid Bay.
+    InvalidBay = 8,
+    /// Invalid Bax.
+    InvalidBax = 9,
+    /// Invalid Bby.
+    InvalidBby = 10,
+    /// Invalid Bbx.
+    InvalidBbx = 11,
+    /// No return value or error
+    NoValueNorError = 12,
+    /// Call error
+    CallError = 13,
+    /// Couldnt deserialize return value
+    ReturnNotDeserializable = 14,
+    /// Invalid length.
+    InvalidLength = 15,
+    /// Unknown error.
+    Unknown(u32),
+}
+
+impl From<AltBn128Error> for u32 {
+    fn from(value: AltBn128Error) -> Self {
+        match value {
+            AltBn128Error::InvalidXCoordinate => 1,
+            AltBn128Error::InvalidYCoordinate => 2,
+            AltBn128Error::InvalidPoint => 3,
+            AltBn128Error::InvalidA => 4,
+            AltBn128Error::InvalidB => 5,
+            AltBn128Error::InvalidAx => 6,
+            AltBn128Error::InvalidAy => 7,
+            AltBn128Error::InvalidBay => 8,
+            AltBn128Error::InvalidBax => 9,
+            AltBn128Error::InvalidBby => 10,
+            AltBn128Error::InvalidBbx => 11,
+            AltBn128Error::NoValueNorError => 12,
+            AltBn128Error::CallError => 13,
+            AltBn128Error::ReturnNotDeserializable => 14,
+            AltBn128Error::InvalidLength => 15,
+            AltBn128Error::Unknown(catch_all) => catch_all,
+        }
+    }
+}
+impl From<u32> for AltBn128Error {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => AltBn128Error::InvalidXCoordinate,
+            2 => AltBn128Error::InvalidYCoordinate,
+            3 => AltBn128Error::InvalidPoint,
+            4 => AltBn128Error::InvalidA,
+            5 => AltBn128Error::InvalidB,
+            6 => AltBn128Error::InvalidAx,
+            7 => AltBn128Error::InvalidAy,
+            8 => AltBn128Error::InvalidBay,
+            9 => AltBn128Error::InvalidBax,
+            10 => AltBn128Error::InvalidBby,
+            11 => AltBn128Error::InvalidBbx,
+            12 => AltBn128Error::NoValueNorError,
+            13 => AltBn128Error::CallError,
+            14 => AltBn128Error::ReturnNotDeserializable,
+            15 => AltBn128Error::InvalidLength,
+            value => AltBn128Error::Unknown(value),
+        }
+    }
+}
+
+/// Result type for the alt_bn128 module.
+pub type Result<T> = core::result::Result<T, AltBn128Error>;
+
+/// Adds two points on the alt_bn128 curve.
+pub fn alt_bn128_add(x1: &G1, y1: &G1, x2: &G1, y2: &G1) -> Result<(Fq, Fq)> {
+    let input = borsh::to_vec(&(x1, y1, x2, y2)).expect("Serialization to succeed");
+    let option = CryptoFunctionOption::AltBn128Add;
+    let (output, result) = casper_system(option.into(), &input);
+    result.map_err(|_err| AltBn128Error::CallError)?;
+    match output {
+        Some(raw) => {
+            let val: core::result::Result<([u8; 32], [u8; 32]), u32> =
+                borsh::from_slice(&raw).map_err(|_err| AltBn128Error::ReturnNotDeserializable)?;
+            val.map(|(x, y)| (Fq(x), Fq(y)))
+                .map_err(AltBn128Error::from)
+        }
+        None => Err(AltBn128Error::NoValueNorError),
+    }
+}
+
+/// Multiplies a point on the alt_bn128 curve by a scalar.
+pub fn alt_bn128_mul(x: &G1, y: &G1, scalar: &Fr) -> Result<(Fq, Fq)> {
+    let input = borsh::to_vec(&(x, y, scalar)).expect("Serialization to succeed");
+    let option = CryptoFunctionOption::AltBn128Multiply;
+    let (output, result) = casper_system(option.into(), &input);
+    result.map_err(|_err| AltBn128Error::CallError)?;
+    match output {
+        Some(raw) => {
+            let val: core::result::Result<([u8; 32], [u8; 32]), u32> =
+                borsh::from_slice(&raw).map_err(|_err| AltBn128Error::ReturnNotDeserializable)?;
+            val.map(|(x, y)| (Fq(x), Fq(y)))
+                .map_err(AltBn128Error::from)
+        }
+        None => Err(AltBn128Error::NoValueNorError),
+    }
+}
+
+/// A pairing of points on the alt_bn128 curve.
+#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
+pub struct Pair {
+    /// G1 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    ax: [u8; 32],
+    /// G1 point y-coordinate. 32 bytes little-endian encoded unsigned integer
+    ay: [u8; 32],
+    /// Fq2 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    bax: [u8; 32],
+    /// Fq2 point y-coordinate.32 bytes little-endian encoded unsigned integer
+    bay: [u8; 32],
+    /// Fq2 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    bbx: [u8; 32],
+    /// Fq2 point x-coordinate. 32 bytes little-endian encoded unsigned integer
+    bby: [u8; 32],
+}
+
+impl Pair {
+    pub fn from(ax: Fq, ay: Fq, bax: Fq, bay: Fq, bbx: Fq, bby: Fq) -> Self {
+        Pair {
+            ax: ax.0,
+            ay: ay.0,
+            bax: bax.0,
+            bay: bay.0,
+            bbx: bbx.0,
+            bby: bby.0,
+        }
+    }
+    pub fn zero() -> Self {
+        Pair {
+            ax: [0; 32],
+            ay: [0; 32],
+            bax: [0; 32],
+            bay: [0; 32],
+            bbx: [0; 32],
+            bby: [0; 32],
+        }
+    }
+}
+
+const _: () = assert!(
+    core::mem::size_of::<Pair>() == 192,
+    "Pair size is not correct",
+);
+
+/// Performs a pairing of points on the alt_bn128 curve.
+pub fn alt_bn128_pairing(pairs: &[Pair]) -> Result<bool> {
+    let input = borsh::to_vec(pairs).expect("Serialization to succeed");
+    let option = CryptoFunctionOption::AltBn128Pairing;
+
+    let (output, result) = casper_system(option.into(), &input);
+    result.map_err(|_err| AltBn128Error::CallError)?;
+    match output {
+        Some(raw) => {
+            let val: core::result::Result<bool, u32> =
+                borsh::from_slice(&raw).map_err(|_err| AltBn128Error::ReturnNotDeserializable)?;
+            val.map_err(AltBn128Error::from)
+        }
+        None => Err(AltBn128Error::NoValueNorError),
+    }
+}
+
+fn u256_to_le_bytes(value: U256) -> [u8; 32] {
+    // For some reason bnum::to_le_bytes is behind "nightly" flag,
+    // this is a helper method o achieve the same functionality.
+    // Should be replaced with bnum functionality once it evolves past nightly
+    let digits = value.digits();
+    let mut bytes = [0; 32];
+    let mut i = 0;
+    while i < 4 {
+        let digit_bytes = digits[i].to_le_bytes();
+        let mut j = 0;
+        while j < 8 {
+            bytes[(i << 3) + j] = digit_bytes[j];
+            j += 1;
+        }
+        i += 1;
+    }
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::casper::altbn128::u256_to_le_bytes;
+    use bnum::types::U256;
+    use casper_types::{testing::TestRng, U256 as CasperU256};
+    use rand::Rng;
+
+    #[test]
+    fn test_u256_to_le_bytes() {
+        let mut test_rng = TestRng::new();
+        for _ in 0..50 {
+            let u: CasperU256 = test_rng.gen();
+            let base_10_str = format!("{}", u);
+            let mut expected_le_bytes = [0; 32];
+            u.to_little_endian(&mut expected_le_bytes);
+            let u256 = U256::parse_str_radix(&base_10_str, 10);
+            let bytes = u256_to_le_bytes(u256);
+            assert_eq!(bytes, expected_le_bytes);
+        }
+    }
+}

--- a/smart_contracts/sdk/src/types.rs
+++ b/smart_contracts/sdk/src/types.rs
@@ -263,3 +263,32 @@ impl CasperABI for CallError {
         }
     }
 }
+
+#[repr(u32)]
+pub enum CryptoFunctionOption {
+    AltBn128Add = 200,
+    AltBn128Multiply = 201,
+    AltBn128Pairing = 202,
+}
+
+impl From<CryptoFunctionOption> for u32 {
+    fn from(value: CryptoFunctionOption) -> Self {
+        value as u32
+    }
+}
+
+impl TryFrom<u32> for CryptoFunctionOption {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        if value == 200 {
+            Ok(CryptoFunctionOption::AltBn128Add)
+        } else if value == 201 {
+            Ok(CryptoFunctionOption::AltBn128Multiply)
+        } else if value == 202 {
+            Ok(CryptoFunctionOption::AltBn128Pairing)
+        } else {
+            Err(())
+        }
+    }
+}

--- a/types/src/chainspec/vm_config/host_function_costs_v2.rs
+++ b/types/src/chainspec/vm_config/host_function_costs_v2.rs
@@ -201,6 +201,9 @@ const DEFAULT_GENERIC_HASH_SIZE_WEIGHT: Cost = 0;
 
 const DEFAULT_RECOVER_SECP256K1_COST: Cost = 0;
 const DEFAULT_RECOVER_SECP256K1_SIZE_WEIGHT: Cost = 0;
+const DEFAULT_ALT_BN128_ADD_COST: Cost = 1_000_000;
+const DEFAULT_ALT_BN128_MUL_COST: Cost = 1_000_000;
+const DEFAULT_ALT_BN128_PAIRING_COST: Cost = 1_000_000;
 
 /// Definition of a host function cost table.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
@@ -237,6 +240,12 @@ pub struct HostFunctionCostsV2 {
     pub generic_hash: HostFunctionV2<[Cost; 4]>,
     /// Cost of calling the `` host function.
     pub recover_secp256k1: HostFunctionV2<[Cost; 6]>,
+    /// Cost of calling the `alt_bn128_add` host function.
+    pub alt_bn128_add: HostFunctionV2<[Cost; 2]>,
+    /// Cost of calling the `alt_bn128_mul` host function.
+    pub alt_bn128_mul: HostFunctionV2<[Cost; 2]>,
+    /// Cost of calling the `alt_bn128_pairing` host function.
+    pub alt_bn128_pairing: HostFunctionV2<[Cost; 2]>,
 }
 
 impl HostFunctionCostsV2 {
@@ -257,6 +266,9 @@ impl HostFunctionCostsV2 {
             env_info: HostFunctionV2::zero(),
             generic_hash: HostFunctionV2::zero(),
             recover_secp256k1: HostFunctionV2::zero(),
+            alt_bn128_add: HostFunctionV2::zero(),
+            alt_bn128_mul: HostFunctionV2::zero(),
+            alt_bn128_pairing: HostFunctionV2::zero(),
         }
     }
 }
@@ -350,6 +362,12 @@ impl Default for HostFunctionCostsV2 {
                     NOT_USED,
                 ],
             ),
+            alt_bn128_add: HostFunctionV2::new(DEFAULT_ALT_BN128_ADD_COST, [NOT_USED, NOT_USED]),
+            alt_bn128_mul: HostFunctionV2::new(DEFAULT_ALT_BN128_MUL_COST, [NOT_USED, NOT_USED]),
+            alt_bn128_pairing: HostFunctionV2::new(
+                DEFAULT_ALT_BN128_PAIRING_COST,
+                [NOT_USED, NOT_USED],
+            ),
         }
     }
 }
@@ -372,6 +390,9 @@ impl ToBytes for HostFunctionCostsV2 {
         ret.append(&mut self.env_info.to_bytes()?);
         ret.append(&mut self.generic_hash.to_bytes()?);
         ret.append(&mut self.recover_secp256k1.to_bytes()?);
+        ret.append(&mut self.alt_bn128_add.to_bytes()?);
+        ret.append(&mut self.alt_bn128_mul.to_bytes()?);
+        ret.append(&mut self.alt_bn128_pairing.to_bytes()?);
         Ok(ret)
     }
 
@@ -391,6 +412,9 @@ impl ToBytes for HostFunctionCostsV2 {
             + self.env_info.serialized_length()
             + self.generic_hash.serialized_length()
             + self.recover_secp256k1.serialized_length()
+            + self.alt_bn128_add.serialized_length()
+            + self.alt_bn128_mul.serialized_length()
+            + self.alt_bn128_pairing.serialized_length()
     }
 }
 
@@ -411,6 +435,9 @@ impl FromBytes for HostFunctionCostsV2 {
         let (env_info, rem) = FromBytes::from_bytes(rem)?;
         let (generic_hash, rem) = FromBytes::from_bytes(rem)?;
         let (recover_secp256k1, rem) = FromBytes::from_bytes(rem)?;
+        let (alt_bn128_add, rem) = FromBytes::from_bytes(rem)?;
+        let (alt_bn128_mul, rem) = FromBytes::from_bytes(rem)?;
+        let (alt_bn128_pairing, rem) = FromBytes::from_bytes(rem)?;
         Ok((
             HostFunctionCostsV2 {
                 read,
@@ -428,6 +455,9 @@ impl FromBytes for HostFunctionCostsV2 {
                 env_info,
                 generic_hash,
                 recover_secp256k1,
+                alt_bn128_add,
+                alt_bn128_mul,
+                alt_bn128_pairing,
             },
             rem,
         ))
@@ -453,6 +483,9 @@ impl Distribution<HostFunctionCostsV2> for Standard {
             env_info: rng.gen(),
             generic_hash: rng.gen(),
             recover_secp256k1: rng.gen(),
+            alt_bn128_add: rng.gen(),
+            alt_bn128_mul: rng.gen(),
+            alt_bn128_pairing: rng.gen(),
         }
     }
 }
@@ -488,6 +521,9 @@ pub mod gens {
             env_info in host_function_cost_v2_arb(),
             generic_hash in host_function_cost_v2_arb(),
             recover_secp256k1 in host_function_cost_v2_arb(),
+                        alt_bn128_add in host_function_cost_v2_arb(),
+            alt_bn128_mul in host_function_cost_v2_arb(),
+            alt_bn128_pairing in host_function_cost_v2_arb(),
         ) -> HostFunctionCostsV2 {
             HostFunctionCostsV2 {
                 read,
@@ -505,6 +541,9 @@ pub mod gens {
                 env_info,
                 generic_hash,
                 recover_secp256k1,
+                                alt_bn128_add,
+                alt_bn128_mul,
+                alt_bn128_pairing
             }
         }
     }


### PR DESCRIPTION
This PR implements host-optimized pairing cryptography with the Barre to-Naehrig curve.

The new host functionalities are accessible via the SystemMenu mechanism and `casper_system` ffi function. A new variant with three possible values have been implemented:

* SystemMenu::Crypto(CryptoMethods::AltBn128Add)
* SystemMenu::Crypto(CryptoMethods::AltBn128Multiply)
* SystemMenu::Crypto(CryptoMethods::AltBn128Pairing)

From the perspective of a smart contract three sdk functions were created to facilitate use:
* `alt_bn128_add`
* `alt_bn128_mul`
* `alt_bn128_pairing`

# Functionality

```rust
use casper_contract_sdk::{
    casper::{
        self,
        altbn128::{self, alt_bn128_add, alt_bn128_mul, casper_alt_bn128_pairing, Fq, Fr, Pair, G1},
    },
    casper_executor_wasm_common::flags::ReturnFlags,
};

fn main() {
    // Addition
    let actual = alt_bn128_add(
        &G1::from(ADD_X1_LE),
        &G1::from(ADD_Y1_LE),
        &G1::from(ADD_X2_LE),
        &G1::from(ADD_Y2_LE),
    );
    let expected = Ok((Fq::from(ADD_EXPECTED_X_LE), Fq::from(ADD_EXPECTED_Y_LE)));
    assert_eq!(actual, expected);
    // Multiply
    let x = G1::from(MUL_X_LE);
    let y = G1::from(MUL_Y_LE);
    let scalar = Fr::from(MUL_SCALAR_LE);

    assert_eq!(
        alt_bn128_mul(&x, &y, &scalar),
        Ok((Fq::from(MUL_EXPECTED_X_LE), Fq::from(MUL_EXPECTED_Y_LE)))
    );
    // Pairing
    let all_pairs = [
        Pair::from(
            Fq::from(PAIRING_AX_1_LE),
            Fq::from(PAIRING_AY_1_LE),
            Fq::from(PAIRING_BAX_1_LE),
            Fq::from(PAIRING_BAY_1_LE),
            Fq::from(PAIRING_BBX_1_LE),
            Fq::from(PAIRING_BBY_1_LE),
        ),
        Pair::from(
            Fq::from(PAIRING_AX_2_LE),
            Fq::from(PAIRING_AY_2_LE),
            Fq::from(PAIRING_BAX_2_LE),
            Fq::from(PAIRING_BAY_2_LE),
            Fq::from(PAIRING_BBX_2_LE),
            Fq::from(PAIRING_BBY_2_LE),
        ),
    ];

    assert_eq!(alt_bn128_pairing(&all_pairs), Ok(true));
}
```

# Prior art

This work results from extensive internal research and is a foundation for implementing various zero-knowledge proof verifiers on Casper Network i.e. risc0, sp1, and others. This is compatible with alt_bn128 EVM precompiles (ecAdd, ecMul, ecPairing). The code is also inspired by other Rust implementations of EVM precompiles including `aurora-engine` and `rust-ethereum`.

# Costs

Comparison of using a `bn` crate compiled to Wasm vs using the same functionality through host functions.
Based on running executor/wasm/tests/altbn128.rs#should_run_test_suite test with smart_contracts/contracts/vm2/vm2-altbn128 compiled using different feature flags

| Function     | Wasm cost | Host-side cost | 
| ----------- | ----------- | ----------- |
| `alt_bn128_add`      |  0.009076522 CSPR  | 0.00775857 CSPR |
| `alt_bn128_mul`      |  0.038031226 CSPR | 0.007758346 CSPR | 
| `alt_bn128_pairing` | 2.523714186 CSPR | 0.01511345 CSPR |

Based on these results functions each `alt_bn128_*`  will have a base cost of 1_000_000 motes, with the addition that `alt_bn128_pairing` function will have a dynamic cost depending on the amount of curves being paired.


Based on @mpapierski work: https://github.com/casper-network/casper-node/pull/4852