### PR TITLE
CRON job for automatically deploying dev-net protocols

### DIFF
--- a/.github/workflows/trigger-devnet-upgrade.yml
+++ b/.github/workflows/trigger-devnet-upgrade.yml
@@ -1,0 +1,33 @@
+---
+name: trigger-devnet-upgrade.yml
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  schedule:
+    - cron: '0 */4 * * *' # Runs every 4 hours
+jobs:
+  push_dev_net_protocol_upgrade_if_needed:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Assign AWS PROD role to get access to production cloudfronts and S3 buckets
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ACCESS_ROLE_GENESIS }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ secrets.AWS_ACCESS_REGION_GENESIS }}
+
+      - name: Build protocol update
+        run: ./ci/dev_net_protocol_generate.sh
+
+      - name: Upload artifacts to S3
+        run: aws s3 sync ./target/genesis/ s3://${{ secrets.AWS_BUCKET_GENESIS }}/dev-net/
+
+      # Required in case of overwrite
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_GENESIS }} --paths "/dev-net/*"
+
+

--- a/ci/build_update_package.sh
+++ b/ci/build_update_package.sh
@@ -8,6 +8,7 @@
 
 set -e
 
+echo "## Checking if jq is installed"
 if command -v jq >&2; then
   echo "jq installed"
 else
@@ -33,23 +34,26 @@ GIT_HASH=$(git rev-parse HEAD)
 BRANCH_NAME=$(git branch --show-current)
 PROTOCOL_VERSION=$(cat "$PRODUCTION_GENESIS_FILES_DIR/chainspec.toml" | python3 -c "import sys, toml; print(toml.load(sys.stdin)['protocol']['version'].replace('.','_'))")
 NODE_VERSION=$(cat "$NODE_BUILD_DIR/Cargo.toml" | python3 -c "import sys, toml; print(toml.load(sys.stdin)['package']['version'])")
+echo "## Running on branch: $BRANCH_NAME with git_hash: $GIT_HASH"
+echo "## Protocol Version from production chainspec.toml: $PROTOCOL_VERSION"
+echo "## Node package version: $NODE_VERSION"
 
-echo "Creating $BRANCH_NAME.latest file"
+echo "## Creating $BRANCH_NAME.latest file"
 mkdir -p "$LATEST_DIR"
 echo -n "$GIT_HASH" > "$LATEST_DIR/$BRANCH_NAME.latest"
 
-echo "Building casper-node"
+echo "## Building casper-node"
 cd "$NODE_BUILD_DIR" || exit
 cargo build --release
 
-echo "Building global-state-update-gen"
+echo "## Building global-state-update-gen"
 cd "$ROOT_DIR" || exit
 cargo build --release --package global-state-update-gen
 cargo deb --package global-state-update-gen
 mkdir -p "$UPGRADE_DIR"
 cp "$ROOT_DIR/target/debian/"* "$UPGRADE_DIR" || exit
 
-echo "Generating bin README.md"
+echo "## Generating bin README.md"
 mkdir -p "$BIN_DIR"
 readme="$BIN_DIR/README.md"
 {
@@ -62,7 +66,7 @@ readme="$BIN_DIR/README.md"
   echo "git commit hash: $GIT_HASH"
 } > "$readme"
 
-echo "Packaging bin.tar.gz"
+echo "## Packaging bin.tar.gz"
 mkdir -p "$BIN_DIR"
 cp "$NODE_BUILD_TARGET" "$BIN_DIR"
 # To get no path in tar, need to cd in.
@@ -71,7 +75,7 @@ tar -czvf "../bin.tar.gz" .
 cd ..
 rm -rf "$BIN_DIR"
 
-echo "Packaging config.tar.gz"
+echo "## Packaging config.tar.gz"
 mkdir -p "$CONFIG_DIR"
 cp "$PRODUCTION_GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
 cp "$PRODUCTION_GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
@@ -82,7 +86,7 @@ tar -czvf "../config.tar.gz" .
 cd ..
 rm -rf "$CONFIG_DIR"
 
-echo "Packaging config-main.tar.gz"
+echo "## Packaging config-main.tar.gz"
 mkdir -p "$CONFIG_DIR"
 cp "$MAIN_GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
 cp "$MAIN_GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
@@ -92,7 +96,7 @@ tar -czvf "../config-main.tar.gz" .
 cd ..
 rm -rf "$CONFIG_DIR"
 
-echo "Packaging config-test.tar.gz"
+echo "## Packaging config-test.tar.gz"
 mkdir -p "$CONFIG_DIR"
 cp "$TEST_GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
 cp "$TEST_GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
@@ -102,7 +106,7 @@ tar -czvf "../config-test.tar.gz" .
 cd ..
 rm -rf "$CONFIG_DIR"
 
-echo "Packaging config-int.tar.gz"
+echo "## Packaging config-int.tar.gz"
 mkdir -p "$CONFIG_DIR"
 cp "$INT_GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
 cp "$INT_GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
@@ -112,8 +116,8 @@ tar -czvf "../config-int.tar.gz" .
 cd ..
 rm -rf "$CONFIG_DIR"
 
-echo "Packaging config-dev.tar.gz"
-mkdir -p "$DEV_CONFIG_DIR"
+echo "## Packaging config-dev.tar.gz"
+mkdir -p "$CONFIG_DIR"
 cp "$DEV_GENESIS_FILES_DIR/chainspec.toml" "$CONFIG_DIR"
 cp "$DEV_GENESIS_FILES_DIR/config-example.toml" "$CONFIG_DIR"
 # To get no path in tar, need to cd in.


### PR DESCRIPTION
Enables a 4 hour publish of dev-net protocols if changes occurred.
Corrected path for config-dev.tar.gz build in script.