### PR TITLE
[VM2] Don't assume table export name

### DIFF
--- a/executor/wasmer_backend/src/lib.rs
+++ b/executor/wasmer_backend/src/lib.rs
@@ -433,15 +433,20 @@ where
             interface_versions.pop()
         };
 
-        // TODO: get first export of type table as some compilers generate different names (i.e.
-        // rust __indirect_function_table, assemblyscript `table` etc). There's only one table
-        // allowed in a valid module.
-        let table = match instance.exports.get_table("__indirect_function_table") {
-            Ok(table) => Some(table.clone()),
-            Err(error @ wasmer::ExportError::IncompatibleType) => {
-                return Err(WasmPreparationError::MissingExport(error.to_string()))
-            }
-            Err(wasmer::ExportError::Missing(_)) => None,
+        let table_export_name = module.exports().find_map(|export| match export.ty() {
+            wasmer::ExternType::Table(_) => Some(export.name().to_string()),
+            _ => None,
+        });
+
+        let table = match table_export_name {
+            Some(name) => match instance.exports.get_table(&name) {
+                Ok(table) => Some(table.clone()),
+                Err(error @ wasmer::ExportError::IncompatibleType) => {
+                    return Err(WasmPreparationError::MissingExport(error.to_string()))
+                }
+                Err(wasmer::ExportError::Missing(_)) => None,
+            },
+            None => None,
         };
 
         {


### PR DESCRIPTION
Previously, the ``from_wasm_bytes`` flow in executor assumed a table export name of ``__indirect_function_table``. This is PR makes it such that this is no longer the case.