### PR TITLE
[VM2] Extract 'executor' from Context to the outer WasmerEnv

### DIFF
--- a/executor/wasm/src/lib.rs
+++ b/executor/wasm/src/lib.rs
@@ -918,7 +918,6 @@ impl ExecutorV2 {
             callee: callee_key,
             transferred_value,
             tracking_copy,
-            executor: self.clone(),
             address_generator: Arc::clone(&address_generator),
             transaction_hash,
             chain_name,
@@ -951,7 +950,7 @@ impl ExecutorV2 {
             })?;
 
         let mut instance = vm
-            .instantiate(wasm_bytes, context, wasm_instance_config)
+            .instantiate(wasm_bytes, self.clone(), context, wasm_instance_config)
             .map_err(ExecuteError::WasmPreparation)?;
 
         self.push_execution_stack(execution_kind.clone());

--- a/executor/wasm_host/src/context.rs
+++ b/executor/wasm_host/src/context.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use casper_executor_wasm_interface::executor::Executor;
 use casper_storage::{
     global_state::GlobalStateReader, AddressGenerator, RuntimeNativeConfig, TrackingCopy,
 };
@@ -12,7 +11,7 @@ use casper_types::{
 use parking_lot::RwLock;
 
 /// Container that holds all relevant modules necessary to process an execution request.
-pub struct Context<S: GlobalStateReader, E: Executor> {
+pub struct Context<S: GlobalStateReader> {
     /// The address of the account that initiated the contract or session code.
     pub initiator: AccountHash,
     /// The address of the addressable entity that is currently executing the contract or session
@@ -32,7 +31,6 @@ pub struct Context<S: GlobalStateReader, E: Executor> {
     pub baseline_motes_amount: u64,
     pub message_limits: MessageLimits,
     pub tracking_copy: TrackingCopy<S>,
-    pub executor: E,
     pub transaction_hash: TransactionHash,
     pub address_generator: Arc<RwLock<AddressGenerator>>,
     pub chain_name: Arc<str>,

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -85,8 +85,8 @@ where
 }
 
 /// Consumes imputed amount of gas.
-fn charge_gas<S: GlobalStateReader, E: Executor>(
-    caller: &mut impl Caller<Context = Context<S, E>>,
+fn charge_gas<S: GlobalStateReader>(
+    caller: &mut impl Caller<Context = Context<S>>,
     imputed: u64,
 ) -> VMResult<()> {
     caller.consume_gas(imputed)?;
@@ -94,8 +94,8 @@ fn charge_gas<S: GlobalStateReader, E: Executor>(
 }
 
 /// Consumes a set amount of gas for the specified storage value.
-fn charge_gas_storage<S: GlobalStateReader, E: Executor>(
-    caller: &mut impl Caller<Context = Context<S, E>>,
+fn charge_gas_storage<S: GlobalStateReader>(
+    caller: &mut impl Caller<Context = Context<S>>,
     size_bytes: usize,
 ) -> VMResult<()> {
     let storage_costs = &caller.context().storage_costs;
@@ -106,14 +106,13 @@ fn charge_gas_storage<S: GlobalStateReader, E: Executor>(
 }
 
 /// Consumes a set amount of gas for the specified host function and weights
-fn charge_host_function_call<S, E, const N: usize>(
-    caller: &mut impl Caller<Context = Context<S, E>>,
+fn charge_host_function_call<S, const N: usize>(
+    caller: &mut impl Caller<Context = Context<S>>,
     host_function: &HostFunctionV2<[u64; N]>,
     weights: [u64; N],
 ) -> VMResult<()>
 where
     S: GlobalStateReader,
-    E: Executor,
 {
     let Some(cost) = host_function.calculate_gas_cost(weights) else {
         // Overflowing gas calculation means gas limit was exceeded
@@ -125,8 +124,8 @@ where
 }
 
 /// Writes a message to the global state and charges for storage used.
-fn metered_write<S: GlobalStateReader, E: Executor>(
-    caller: &mut impl Caller<Context = Context<S, E>>,
+fn metered_write<S: GlobalStateReader>(
+    caller: &mut impl Caller<Context = Context<S>>,
     key: Key,
     value: StoredValue,
 ) -> VMResult<()> {
@@ -140,8 +139,8 @@ fn metered_write<S: GlobalStateReader, E: Executor>(
 }
 
 /// Write value under a key.
-pub fn casper_write<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_write<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     key_space: u64,
     key_ptr: u32,
     key_size: u32,
@@ -312,8 +311,8 @@ pub fn casper_write<S: GlobalStateReader, E: Executor>(
 ///
 /// The name for this host function is `remove` to keep it simple and consistent with read/write
 /// verbs, and also consistent with the rust stdlib vocabulary i.e. `V`
-pub fn casper_remove<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_remove<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     key_space: u64,
     key_ptr: u32,
     key_size: u32,
@@ -400,8 +399,8 @@ pub fn casper_remove<S: GlobalStateReader, E: Executor>(
     Ok(HOST_ERROR_SUCCESS)
 }
 
-pub fn casper_print<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_print<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     message_ptr: u32,
     message_size: u32,
 ) -> VMResult<()> {
@@ -422,8 +421,8 @@ pub fn casper_print<S: GlobalStateReader, E: Executor>(
 }
 
 /// Write value under a key.
-pub fn casper_read<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_read<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     key_tag: u64,
     key_ptr: u32,
     key_size: u32,
@@ -616,8 +615,8 @@ pub fn casper_read<S: GlobalStateReader, E: Executor>(
     Ok(HOST_ERROR_SUCCESS)
 }
 
-fn keyspace_to_global_state_key<S: GlobalStateReader, E: Executor>(
-    context: &Context<S, E>,
+fn keyspace_to_global_state_key<S: GlobalStateReader>(
+    context: &Context<S>,
     keyspace: Keyspace<'_>,
 ) -> Option<Key> {
     let entity_addr = context_to_entity_addr(context);
@@ -655,9 +654,7 @@ fn keyspace_to_global_state_key<S: GlobalStateReader, E: Executor>(
     }
 }
 
-fn context_to_entity_addr<S: GlobalStateReader, E: Executor>(
-    context: &Context<S, E>,
-) -> EntityAddr {
+fn context_to_entity_addr<S: GlobalStateReader>(context: &Context<S>) -> EntityAddr {
     match context.callee {
         Key::Account(account_hash) => EntityAddr::new_account(account_hash.value()),
         Key::Hash(hash_addr) => EntityAddr::SmartContract(hash_addr),
@@ -669,8 +666,8 @@ fn context_to_entity_addr<S: GlobalStateReader, E: Executor>(
     }
 }
 
-pub fn casper_copy_input<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_copy_input<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     cb_alloc: u32,
     alloc_ctx: u32,
 ) -> VMResult<u32> {
@@ -705,8 +702,8 @@ pub fn casper_copy_input<S: GlobalStateReader, E: Executor>(
 }
 
 /// Returns from the execution of a smart contract with an optional flags.
-pub fn casper_return<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_return<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     flags: u32,
     data_ptr: u32,
     data_len: u32,
@@ -747,8 +744,8 @@ pub fn casper_return<S: GlobalStateReader, E: Executor>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn casper_create<S: GlobalStateReader + 'static, E: Executor + 'static>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_create<S: GlobalStateReader + 'static>(
+    mut caller: impl Caller<Context = Context<S>>,
     code_ptr: u32,
     code_len: u32,
     transferred_value: u64,
@@ -1036,8 +1033,7 @@ pub fn casper_create<S: GlobalStateReader + 'static, E: Executor + 'static>(
             let tracking_copy_for_ctor = caller.context().tracking_copy.fork2();
 
             match caller
-                .context()
-                .executor
+                .executor()
                 .execute(tracking_copy_for_ctor, execute_request)
             {
                 Ok(ExecuteResult {
@@ -1086,8 +1082,8 @@ pub fn casper_create<S: GlobalStateReader + 'static, E: Executor + 'static>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn casper_system<S: GlobalStateReader + 'static, E: Executor + 'static>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_system<S: GlobalStateReader + 'static>(
+    mut caller: impl Caller<Context = Context<S>>,
     system_contract_opt: u32,
     input_ptr: u32,
     input_len: u32,
@@ -1187,8 +1183,8 @@ pub fn casper_system<S: GlobalStateReader + 'static, E: Executor + 'static>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn casper_call<S: GlobalStateReader + 'static, E: Executor + 'static>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_call<S: GlobalStateReader + 'static>(
+    mut caller: impl Caller<Context = Context<S>>,
     address_ptr: u32,
     address_len: u32,
     transferred_value: u64,
@@ -1291,19 +1287,15 @@ pub fn casper_call<S: GlobalStateReader + 'static, E: Executor + 'static>(
     ret
 }
 
-fn exec<S: GlobalStateReader + 'static, E: Executor + 'static>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+fn exec<S: GlobalStateReader + 'static>(
+    mut caller: impl Caller<Context = Context<S>>,
     execute_request: ExecuteRequest,
     cb_alloc: u32,
     cb_ctx: u32,
 ) -> VMResult<u32> {
     let tracking_copy = caller.context().tracking_copy.fork2();
 
-    let (gas_usage, host_result) = match caller
-        .context()
-        .executor
-        .execute(tracking_copy, execute_request)
-    {
+    let (gas_usage, host_result) = match caller.executor().execute(tracking_copy, execute_request) {
         Ok(ExecuteResult {
             host_error,
             output,
@@ -1357,8 +1349,8 @@ fn exec<S: GlobalStateReader + 'static, E: Executor + 'static>(
     Ok(u32_from_host_result(host_result))
 }
 
-pub fn casper_env_balance<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_env_balance<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     entity_kind: u32,
     entity_addr_ptr: u32,
     entity_addr_len: u32,
@@ -1522,8 +1514,8 @@ pub fn casper_env_balance<S: GlobalStateReader, E: Executor>(
     Ok(HOST_ERROR_NOT_FOUND)
 }
 
-pub fn casper_upgrade<S: GlobalStateReader + 'static, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_upgrade<S: GlobalStateReader + 'static>(
+    mut caller: impl Caller<Context = Context<S>>,
     code_ptr: u32,
     code_size: u32,
     entry_point_ptr: u32,
@@ -1870,8 +1862,7 @@ pub fn casper_upgrade<S: GlobalStateReader + 'static, E: Executor>(
         let tracking_copy_for_ctor = caller.context().tracking_copy.fork2();
 
         match caller
-            .context()
-            .executor
+            .executor()
             .execute(tracking_copy_for_ctor, execute_request)
         {
             Ok(ExecuteResult {
@@ -1920,8 +1911,8 @@ pub fn casper_upgrade<S: GlobalStateReader + 'static, E: Executor>(
     Ok(CALLEE_SUCCEEDED)
 }
 
-pub fn casper_env_info<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_env_info<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     info_ptr: u32,
     info_size: u32,
 ) -> VMResult<u32> {
@@ -1978,8 +1969,8 @@ pub fn casper_env_info<S: GlobalStateReader, E: Executor>(
     Ok(HOST_ERROR_SUCCESS)
 }
 
-pub fn casper_emit<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_emit<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     topic_name_ptr: u32,
     topic_name_size: u32,
     payload_ptr: u32,
@@ -2195,8 +2186,8 @@ pub fn casper_emit<S: GlobalStateReader, E: Executor>(
 /// * `in_size` - size of output pointer
 /// * `hash_algo_type` - integer representation of HashAlgorithm enum variant
 /// * `out_ptr` - pointer to the location where argument bytes will be copied to the host side
-pub fn casper_generic_hash<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_generic_hash<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     in_ptr: u32,
     in_size: u32,
     hash_algorithm: u32,
@@ -2278,8 +2269,8 @@ pub fn casper_generic_hash<S: GlobalStateReader, E: Executor>(
 ///     multiplication 𝑘×𝑮 odd?
 ///   - Hi bit (3/4): did the affine x-coordinate of 𝑘×𝑮 overflow the order of the scalar field,
 ///     requiring a reduction when computing r?
-pub fn casper_recover_secp256k1<S: GlobalStateReader, E: Executor>(
-    mut caller: impl Caller<Context = Context<S, E>>,
+pub fn casper_recover_secp256k1<S: GlobalStateReader>(
+    mut caller: impl Caller<Context = Context<S>>,
     message_ptr: u32,
     message_size: u32,
     signature_ptr: u32,

--- a/executor/wasm_interface/src/lib.rs
+++ b/executor/wasm_interface/src/lib.rs
@@ -264,6 +264,7 @@ impl MeteringPoints {
 /// instance, wasm linear memory access, etc.
 pub trait Caller {
     type Context;
+    type Executor: crate::executor::Executor;
 
     fn context(&self) -> &Self::Context;
     fn context_mut(&mut self) -> &mut Self::Context;
@@ -284,6 +285,8 @@ pub trait Caller {
     fn get_remaining_points(&mut self) -> VMResult<MeteringPoints>;
     /// Check for gas exhaustion, then reduce remaining by amount if able.
     fn consume_gas(&mut self, value: u64) -> VMResult<()>;
+    /// Returns a reference to the executor used by the current instance.
+    fn executor(&self) -> &Self::Executor;
 }
 
 #[derive(Debug, Error)]

--- a/executor/wasmer_backend/src/lib.rs
+++ b/executor/wasmer_backend/src/lib.rs
@@ -88,15 +88,17 @@ impl WasmerEngine {
     pub fn instantiate<T: Into<Bytes>, S: GlobalStateReader + 'static, E: Executor + 'static>(
         &self,
         wasm_bytes: T,
-        context: Context<S, E>,
+        executor: E,
+        context: Context<S>,
         config: Config,
-    ) -> Result<impl WasmInstance<Context = Context<S, E>>, WasmPreparationError> {
-        WasmerInstance::from_wasm_bytes(wasm_bytes, context, config)
+    ) -> Result<impl WasmInstance<Context = Context<S>>, WasmPreparationError> {
+        WasmerInstance::from_wasm_bytes(wasm_bytes, executor, context, config)
     }
 }
 
 struct WasmerEnv<S: GlobalStateReader, E: Executor> {
-    context: Context<S, E>,
+    context: Context<S>,
+    executor: E,
     instance: Weak<Instance>,
     bytecode: Bytes,
     exported_runtime: Option<ExportedRuntime>,
@@ -154,19 +156,24 @@ impl<S: GlobalStateReader + 'static, E: Executor + 'static> WasmerCaller<'_, S, 
 }
 
 impl<S: GlobalStateReader + 'static, E: Executor + 'static> Caller for WasmerCaller<'_, S, E> {
-    type Context = Context<S, E>;
+    type Context = Context<S>;
+    type Executor = E;
 
     fn memory_write(&self, offset: u32, data: &[u8]) -> VMResult<()> {
         self.with_memory(|mem| mem.write(offset.into(), data))?
             .map_err(from_wasmer_memory_access_error)
     }
 
-    fn context(&self) -> &Context<S, E> {
+    fn context(&self) -> &Context<S> {
         &self.env.data().context
     }
 
-    fn context_mut(&mut self) -> &mut Context<S, E> {
+    fn context_mut(&mut self) -> &mut Context<S> {
         &mut self.env.data_mut().context
+    }
+
+    fn executor(&self) -> &Self::Executor {
+        &self.env.data().executor
     }
 
     fn bytecode(&self) -> Bytes {
@@ -255,9 +262,15 @@ impl<S: GlobalStateReader + 'static, E: Executor + 'static> Caller for WasmerCal
 }
 
 impl<S: GlobalStateReader, E: Executor> WasmerEnv<S, E> {
-    fn new(context: Context<S, E>, code: Bytes, interface_version: InterfaceVersion) -> Self {
+    fn new(
+        context: Context<S>,
+        executor: E,
+        code: Bytes,
+        interface_version: InterfaceVersion,
+    ) -> Self {
         Self {
             context,
+            executor,
             instance: Weak::new(),
             exported_runtime: None,
             bytecode: code,
@@ -324,7 +337,8 @@ where
 
     pub(crate) fn from_wasm_bytes<C: Into<Bytes>>(
         wasm_bytes: C,
-        context: Context<S, E>,
+        executor: E,
+        context: Context<S>,
         config: Config,
     ) -> Result<Self, WasmPreparationError> {
         let wasm_bytes: Bytes = wasm_bytes.into();
@@ -360,7 +374,8 @@ where
 
         let mut store = Store::new(engine);
 
-        let wasmer_env = WasmerEnv::new(context, wasm_bytes, InterfaceVersion::from(1u32));
+        let wasmer_env =
+            WasmerEnv::new(context, executor, wasm_bytes, InterfaceVersion::from(1u32));
         let function_env = FunctionEnv::new(&mut store, wasmer_env);
 
         let memory = Memory::new(
@@ -465,7 +480,7 @@ where
     S: GlobalStateReader + 'static,
     E: Executor + 'static,
 {
-    type Context = Context<S, E>;
+    type Context = Context<S>;
     fn call_export(&mut self, name: &str) -> (VMResult<()>, GasUsage) {
         let vm_result = self.call_export(name);
 
@@ -483,7 +498,7 @@ where
     }
 
     /// Consume instance object and retrieve the [`Context`] object.
-    fn teardown(self) -> Context<S, E> {
+    fn teardown(self) -> Context<S> {
         let WasmerInstance { env, mut store, .. } = self;
 
         let mut env_mut = env.into_mut(&mut store);
@@ -503,7 +518,6 @@ where
             baseline_motes_amount: data.context.baseline_motes_amount,
             transferred_value: data.context.transferred_value,
             tracking_copy: data.context.tracking_copy.fork2(),
-            executor: data.context.executor.clone(),
             transaction_hash: data.context.transaction_hash,
             address_generator: Arc::clone(&data.context.address_generator),
             chain_name: data.context.chain_name.clone(),


### PR DESCRIPTION
Moves the ``executor`` field of the ``Context`` struct into the outer ``WasmerEnv``.