### PR TITLE
[VM2] Write bytecode indirection for vm2 contracts in upgrade

### DIFF
--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -1796,6 +1796,16 @@ pub fn casper_upgrade<S: GlobalStateReader + 'static>(
                             code.clone().into(),
                         )),
                     )?;
+                    let contract_wasm_key = Key::Hash(new_byte_code_hash);
+                    let byte_code_key_as_cl_value = match CLValue::from_t(bytecode_key) {
+                        Ok(cl_value) => cl_value,
+                        Err(_) => return Ok(HOST_ERROR_CL_VALUE),
+                    };
+                    metered_write(
+                        &mut caller,
+                        contract_wasm_key,
+                        StoredValue::CLValue(byte_code_key_as_cl_value),
+                    )?;
 
                     let entity = Contract::new(
                         package_hash,


### PR DESCRIPTION
- Write the indirection for the wasm record for vm2 contracts during a contract upgrade