### PR TITLE
[VM2] Add / Cancel Reservation modification

### DIFF
--- a/executor/wasm/tests/integration.rs
+++ b/executor/wasm/tests/integration.rs
@@ -356,7 +356,7 @@ fn exec_system_call(system_menu: SystemMenu, initiator: Option<AccountHash>) {
     let initiator = initiator.unwrap_or(DEFAULT_STABLE_VALIDATOR_PUBLIC_KEY.to_account_hash());
 
     let system_function_option: u32 = system_menu.into();
-    let input_data = borsh::to_vec(&(system_function_option,))
+    let input_data = borsh::to_vec(&(system_function_option, false))
         .map(Bytes::from)
         .unwrap();
     let execute_request = make_execution_request(
@@ -423,7 +423,7 @@ fn should_revert_invalid_system_option() {
     let block_time = Timestamp::now().into();
 
     let account_hash = DEFAULT_STABLE_VALIDATOR_PUBLIC_KEY.to_account_hash();
-    let input_data = borsh::to_vec(&(9999,)).map(Bytes::from).unwrap();
+    let input_data = borsh::to_vec(&(9999, false)).map(Bytes::from).unwrap();
 
     let execute_request = make_execution_request(
         &chainspec_config,
@@ -543,7 +543,7 @@ fn should_handle_reservations() {
     // need to bump the delegator reservation limit up to allow add_reservation to work
     let bid_request = {
         let opt: u32 = SystemMenu::Auction(AuctionMethods::Bid).into();
-        let input_data = borsh::to_vec(&(opt,)).map(Bytes::from).unwrap();
+        let input_data = borsh::to_vec(&(opt, false)).map(Bytes::from).unwrap();
         make_execution_request(
             &chainspec_config,
             Arc::clone(&address_generator),
@@ -579,9 +579,9 @@ fn should_handle_reservations() {
     }
 
     // make a couple of reservations
-    let add_res_request = {
+    let add_res_pubk_request = {
         let opt: u32 = SystemMenu::Auction(AuctionMethods::AddReservation).into();
-        let input_data = borsh::to_vec(&(opt,)).map(Bytes::from).unwrap();
+        let input_data = borsh::to_vec(&(opt, false)).map(Bytes::from).unwrap();
         make_execution_request(
             &chainspec_config,
             Arc::clone(&address_generator),
@@ -594,16 +594,45 @@ fn should_handle_reservations() {
         )
     };
 
-    state_root_hash =
-        match exec_and_commit(&executor, &global_state, &state_root_hash, add_res_request) {
-            Ok(post_state) => post_state,
-            Err(err_str) => panic!("{err_str}"),
-        };
+    state_root_hash = match exec_and_commit(
+        &executor,
+        &global_state,
+        &state_root_hash,
+        add_res_pubk_request,
+    ) {
+        Ok(post_state) => post_state,
+        Err(err_str) => panic!("{err_str}"),
+    };
+
+    let add_res_purse_request = {
+        let opt: u32 = SystemMenu::Auction(AuctionMethods::AddReservation).into();
+        let input_data = borsh::to_vec(&(opt, true)).map(Bytes::from).unwrap();
+        make_execution_request(
+            &chainspec_config,
+            Arc::clone(&address_generator),
+            ExecutionKind::SessionBytes(read_wasm(VM2_SYSTEM_CALLER_WASM)),
+            input_data,
+            0,
+            Some(account_hash),
+            None,
+            Some(block_time),
+        )
+    };
+
+    state_root_hash = match exec_and_commit(
+        &executor,
+        &global_state,
+        &state_root_hash,
+        add_res_purse_request,
+    ) {
+        Ok(post_state) => post_state,
+        Err(err_str) => panic!("{err_str}"),
+    };
 
     // cancel those reservations
-    let cancel_request = {
+    let cancel_pubk_request = {
         let opt: u32 = SystemMenu::Auction(AuctionMethods::CancelReservation).into();
-        let input_data = borsh::to_vec(&(opt,)).map(Bytes::from).unwrap();
+        let input_data = borsh::to_vec(&(opt, false)).map(Bytes::from).unwrap();
         make_execution_request(
             &chainspec_config,
             Arc::clone(&address_generator),
@@ -616,7 +645,37 @@ fn should_handle_reservations() {
         )
     };
 
-    match exec_and_commit(&executor, &global_state, &state_root_hash, cancel_request) {
+    match exec_and_commit(
+        &executor,
+        &global_state,
+        &state_root_hash,
+        cancel_pubk_request,
+    ) {
+        Ok(post_state) => post_state,
+        Err(err_str) => panic!("{err_str}"),
+    };
+
+    let cancel_purse_request = {
+        let opt: u32 = SystemMenu::Auction(AuctionMethods::CancelReservation).into();
+        let input_data = borsh::to_vec(&(opt, true)).map(Bytes::from).unwrap();
+        make_execution_request(
+            &chainspec_config,
+            Arc::clone(&address_generator),
+            ExecutionKind::SessionBytes(read_wasm(VM2_SYSTEM_CALLER_WASM)),
+            input_data,
+            0,
+            Some(account_hash),
+            None,
+            Some(block_time),
+        )
+    };
+
+    match exec_and_commit(
+        &executor,
+        &global_state,
+        &state_root_hash,
+        cancel_purse_request,
+    ) {
         Ok(post_state) => post_state,
         Err(err_str) => panic!("{err_str}"),
     };

--- a/executor/wasm_host/src/system.rs
+++ b/executor/wasm_host/src/system.rs
@@ -534,34 +534,31 @@ pub fn native_exec<A, T: ToBytes, R: GlobalStateReader + 'static>(
                 }
             }
             AuctionMethods::AddReservation => {
-                let ret = bytesrepr::deserialize_from_slice::<&Bytes, (Vec<Reservation>,)>(&input);
+                let ret = bytesrepr::deserialize_from_slice::<&Bytes, (Reservation,)>(&input);
                 if let Err(err) = &ret {
                     debug!(?err, "bytesrepr error in native_exec AddReservation");
                 }
                 let unpacked =
                     ret.map_err(|_err| ExecuteError::Fatal(FatalHostError::TypeConversion))?;
-                let reservations = unpacked.0;
-                for reservation in &reservations {
-                    if reservation.validator_public_key().is_system() {
+                let reservation = unpacked.0;
+                if reservation.validator_public_key().is_system() {
+                    debug!(
+                        ?method,
+                        "attempt to pass system public key from userland AddReservation validator"
+                    );
+                    return Err(ExecuteError::Fatal(FatalHostError::InvalidPublicKey));
+                }
+                if let DelegatorKind::PublicKey(delegator_public_key) = reservation.delegator_kind()
+                {
+                    if delegator_public_key.is_system() {
                         debug!(
-                            ?method,
-                            "attempt to pass system public key from userland AddReservation validator"
-                        );
-                        return Err(ExecuteError::Fatal(FatalHostError::InvalidPublicKey));
-                    }
-                    if let DelegatorKind::PublicKey(delegator_public_key) =
-                        reservation.delegator_kind()
-                    {
-                        if delegator_public_key.is_system() {
-                            debug!(
                             ?method,
                             "attempt to pass system public key from userland AddReservation delegator"
                         );
-                            return Err(ExecuteError::Fatal(FatalHostError::InvalidPublicKey));
-                        }
+                        return Err(ExecuteError::Fatal(FatalHostError::InvalidPublicKey));
                     }
                 }
-                let add_reservations_args = AddReservationsArgs::new(reservations);
+                let add_reservations_args = AddReservationsArgs::new(vec![reservation]);
                 system::add_reservations(
                     &mut tracking_copy,
                     runtime_native_config,
@@ -572,7 +569,7 @@ pub fn native_exec<A, T: ToBytes, R: GlobalStateReader + 'static>(
                 .map(|_| None)
             }
             AuctionMethods::CancelReservation => {
-                let unpacked: (PublicKey, Vec<DelegatorKind>) =
+                let unpacked: (PublicKey, DelegatorKind) =
                     bytesrepr::deserialize_from_slice(&input)
                         .map_err(|_err| ExecuteError::Fatal(FatalHostError::TypeConversion))?;
                 if unpacked.0.is_system() {
@@ -582,11 +579,12 @@ pub fn native_exec<A, T: ToBytes, R: GlobalStateReader + 'static>(
                     );
                     return Err(ExecuteError::Fatal(FatalHostError::InvalidPublicKey));
                 }
+                let reservations = vec![unpacked.1];
                 let cancel_reservations_args = CancelReservationsArgs::new(
                     // validator
                     unpacked.0,
-                    // delegators
-                    unpacked.1,
+                    // delegator
+                    reservations,
                     runtime_native_config.max_delegators_per_validator(),
                 );
                 system::cancel_reservations(

--- a/smart_contracts/contracts/vm2/vm2-system-caller/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-system-caller/src/lib.rs
@@ -9,7 +9,7 @@ pub mod exports {
     };
 
     #[casper(export)]
-    pub fn call(opt: u32) {
+    pub fn call(opt: u32, purse_delegation: bool) {
         use borsh;
 
         let option = match SystemContractOption::try_from(opt) {
@@ -92,23 +92,27 @@ pub mod exports {
             }
             SystemContractOption::AddReservation => {
                 let pub_k = PublicKey::Ed25519([1; 32]);
-                let res_pu = Reservation::new(DelegatorKind::Purse([254; 32]), pub_k, 1);
-                let res_pk = Reservation::new(
-                    DelegatorKind::PublicKey(PublicKey::Ed25519([255; 32])),
-                    pub_k,
-                    1,
-                );
-                let reservations = vec![res_pu, res_pk];
-                let args = (reservations,);
+                let reservation = if purse_delegation {
+                    Reservation::new(DelegatorKind::Purse([254; 32]), pub_k, 1)
+                } else {
+                    Reservation::new(
+                        DelegatorKind::PublicKey(PublicKey::Ed25519([255; 32])),
+                        pub_k,
+                        1,
+                    )
+                };
+
+                let args = (reservation,);
                 let input = borsh::to_vec(&args).expect("Serialization to succeed");
                 Some(input)
             }
             SystemContractOption::CancelReservation => {
-                let reservations = vec![
-                    DelegatorKind::Purse([254; 32]),
-                    DelegatorKind::PublicKey(PublicKey::Ed25519([255; 32])),
-                ];
-                let args = (PublicKey::Ed25519([1; 32]), reservations);
+                let delegator_kind = if purse_delegation {
+                    DelegatorKind::Purse([254; 32])
+                } else {
+                    DelegatorKind::PublicKey(PublicKey::Ed25519([255; 32]))
+                };
+                let args = (PublicKey::Ed25519([1; 32]), delegator_kind);
                 let input = borsh::to_vec(&args).expect("Serialization to succeed");
                 Some(input)
             }


### PR DESCRIPTION
This PR addresses #CORE-186 , changing the add / cancel reservation options of the auction to not allow vecs to be passed from the vm to the host (for scaling reasons).