### PR TITLE
[VM2] Allow write FFIs in sandboxed execution, return gas consumption to caller

### DIFF
--- a/binary_port/src/response_type.rs
+++ b/binary_port/src/response_type.rs
@@ -18,6 +18,7 @@ use casper_types::{
 use crate::{
     global_state_query_result::GlobalStateQueryResult,
     node_status::NodeStatus,
+    sandboxed_execution::SandboxedExecutionResult,
     speculative_execution_result::SpeculativeExecutionResult,
     type_wrappers::{
         ConsensusStatus, ConsensusValidatorChanges, GetTrieFullResult, LastProgress, NetworkName,
@@ -399,6 +400,10 @@ impl PayloadEntity for GetTrieFullResult {
 
 impl PayloadEntity for SpeculativeExecutionResult {
     const RESPONSE_TYPE: ResponseType = ResponseType::SpeculativeExecutionResult;
+}
+
+impl PayloadEntity for SandboxedExecutionResult {
+    const RESPONSE_TYPE: ResponseType = ResponseType::SandboxedExecutionResult;
 }
 
 impl PayloadEntity for NodeStatus {

--- a/binary_port/src/sandboxed_execution.rs
+++ b/binary_port/src/sandboxed_execution.rs
@@ -4,6 +4,7 @@ use casper_types::{
     bytesrepr::{Bytes, FromBytes, ToBytes},
     BlockHash, BlockTime, Digest, Gas, HashAddr,
 };
+use core::convert::TryFrom;
 
 /// Errors that can occur during sandboxed execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,6 +31,89 @@ pub enum SandboxedExecutionError {
     Api(String),
     /// Input invalid
     InputInvalid,
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum SandboxedExecutionErrorTag {
+    CalleeRolledBack = 0,
+    CalleeTrapped = 1,
+    CalleeGasDepleted = 2,
+    NotCallable = 3,
+    CodeNotFound = 4,
+    InternalHostError = 5,
+    NoActiveContract = 6,
+    EntityNotFound = 7,
+    LockedPackage = 8,
+    Api = 9,
+    InputInvalid = 10,
+}
+
+impl TryFrom<u8> for SandboxedExecutionErrorTag {
+    type Error = bytesrepr::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            x if x == SandboxedExecutionErrorTag::CalleeRolledBack as u8 => {
+                Ok(SandboxedExecutionErrorTag::CalleeRolledBack)
+            }
+            x if x == SandboxedExecutionErrorTag::CalleeTrapped as u8 => {
+                Ok(SandboxedExecutionErrorTag::CalleeTrapped)
+            }
+            x if x == SandboxedExecutionErrorTag::CalleeGasDepleted as u8 => {
+                Ok(SandboxedExecutionErrorTag::CalleeGasDepleted)
+            }
+            x if x == SandboxedExecutionErrorTag::NotCallable as u8 => {
+                Ok(SandboxedExecutionErrorTag::NotCallable)
+            }
+            x if x == SandboxedExecutionErrorTag::CodeNotFound as u8 => {
+                Ok(SandboxedExecutionErrorTag::CodeNotFound)
+            }
+            x if x == SandboxedExecutionErrorTag::InternalHostError as u8 => {
+                Ok(SandboxedExecutionErrorTag::InternalHostError)
+            }
+            x if x == SandboxedExecutionErrorTag::NoActiveContract as u8 => {
+                Ok(SandboxedExecutionErrorTag::NoActiveContract)
+            }
+            x if x == SandboxedExecutionErrorTag::EntityNotFound as u8 => {
+                Ok(SandboxedExecutionErrorTag::EntityNotFound)
+            }
+            x if x == SandboxedExecutionErrorTag::LockedPackage as u8 => {
+                Ok(SandboxedExecutionErrorTag::LockedPackage)
+            }
+            x if x == SandboxedExecutionErrorTag::Api as u8 => Ok(SandboxedExecutionErrorTag::Api),
+            x if x == SandboxedExecutionErrorTag::InputInvalid as u8 => {
+                Ok(SandboxedExecutionErrorTag::InputInvalid)
+            }
+            _ => Err(bytesrepr::Error::Formatting),
+        }
+    }
+}
+
+impl SandboxedExecutionError {
+    fn tag(&self) -> SandboxedExecutionErrorTag {
+        match self {
+            SandboxedExecutionError::CalleeRolledBack => {
+                SandboxedExecutionErrorTag::CalleeRolledBack
+            }
+            SandboxedExecutionError::CalleeTrapped => SandboxedExecutionErrorTag::CalleeTrapped,
+            SandboxedExecutionError::CalleeGasDepleted => {
+                SandboxedExecutionErrorTag::CalleeGasDepleted
+            }
+            SandboxedExecutionError::NotCallable => SandboxedExecutionErrorTag::NotCallable,
+            SandboxedExecutionError::CodeNotFound => SandboxedExecutionErrorTag::CodeNotFound,
+            SandboxedExecutionError::InternalHostError => {
+                SandboxedExecutionErrorTag::InternalHostError
+            }
+            SandboxedExecutionError::NoActiveContract => {
+                SandboxedExecutionErrorTag::NoActiveContract
+            }
+            SandboxedExecutionError::EntityNotFound => SandboxedExecutionErrorTag::EntityNotFound,
+            SandboxedExecutionError::LockedPackage => SandboxedExecutionErrorTag::LockedPackage,
+            SandboxedExecutionError::Api(_) => SandboxedExecutionErrorTag::Api,
+            SandboxedExecutionError::InputInvalid => SandboxedExecutionErrorTag::InputInvalid,
+        }
+    }
 }
 
 impl core::fmt::Display for SandboxedExecutionError {
@@ -176,7 +260,7 @@ impl SandboxedExecutionRequest {
 }
 
 /// Result of a sandboxed execution.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxedExecutionResult {
     /// Error while executing, if any.
     pub error: Option<SandboxedExecutionError>,
@@ -205,5 +289,109 @@ impl SandboxedExecutionResult {
     /// Returns true if the query was successful.
     pub fn is_success(&self) -> bool {
         self.error.is_none()
+    }
+}
+
+impl ToBytes for SandboxedExecutionError {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut writer = bytesrepr::allocate_buffer(self)?;
+        let tag: u8 = self.tag() as u8;
+        tag.write_bytes(&mut writer)?;
+        if let SandboxedExecutionError::Api(msg) = self {
+            msg.write_bytes(&mut writer)?;
+        }
+        Ok(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        let base = bytesrepr::U8_SERIALIZED_LENGTH; // tag
+        match self {
+            SandboxedExecutionError::Api(msg) => base + msg.serialized_length(),
+            _ => base,
+        }
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        writer.extend(self.to_bytes()?);
+        Ok(())
+    }
+}
+
+impl FromBytes for SandboxedExecutionError {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag_u8, remainder) = u8::from_bytes(bytes)?;
+        let tag = SandboxedExecutionErrorTag::try_from(tag_u8)?;
+        match tag {
+            SandboxedExecutionErrorTag::CalleeRolledBack => {
+                Ok((SandboxedExecutionError::CalleeRolledBack, remainder))
+            }
+            SandboxedExecutionErrorTag::CalleeTrapped => {
+                Ok((SandboxedExecutionError::CalleeTrapped, remainder))
+            }
+            SandboxedExecutionErrorTag::CalleeGasDepleted => {
+                Ok((SandboxedExecutionError::CalleeGasDepleted, remainder))
+            }
+            SandboxedExecutionErrorTag::NotCallable => {
+                Ok((SandboxedExecutionError::NotCallable, remainder))
+            }
+            SandboxedExecutionErrorTag::CodeNotFound => {
+                Ok((SandboxedExecutionError::CodeNotFound, remainder))
+            }
+            SandboxedExecutionErrorTag::InternalHostError => {
+                Ok((SandboxedExecutionError::InternalHostError, remainder))
+            }
+            SandboxedExecutionErrorTag::NoActiveContract => {
+                Ok((SandboxedExecutionError::NoActiveContract, remainder))
+            }
+            SandboxedExecutionErrorTag::EntityNotFound => {
+                Ok((SandboxedExecutionError::EntityNotFound, remainder))
+            }
+            SandboxedExecutionErrorTag::LockedPackage => {
+                Ok((SandboxedExecutionError::LockedPackage, remainder))
+            }
+            SandboxedExecutionErrorTag::Api => {
+                let (msg, rem) = String::from_bytes(remainder)?;
+                Ok((SandboxedExecutionError::Api(msg), rem))
+            }
+            SandboxedExecutionErrorTag::InputInvalid => {
+                Ok((SandboxedExecutionError::InputInvalid, remainder))
+            }
+        }
+    }
+}
+
+impl ToBytes for SandboxedExecutionResult {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let mut writer = bytesrepr::allocate_buffer(self)?;
+        self.write_bytes(&mut writer)?;
+        Ok(writer)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.error.serialized_length()
+            + self.output.serialized_length()
+            + self.gas_usage.serialized_length()
+    }
+
+    fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
+        self.error.write_bytes(writer)?;
+        self.output.write_bytes(writer)?;
+        self.gas_usage.write_bytes(writer)
+    }
+}
+
+impl FromBytes for SandboxedExecutionResult {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (error, bytes) = Option::<SandboxedExecutionError>::from_bytes(bytes)?;
+        let (output, bytes) = Option::<Bytes>::from_bytes(bytes)?;
+        let (gas_usage, bytes) = Gas::from_bytes(bytes)?;
+        Ok((
+            SandboxedExecutionResult {
+                error,
+                output,
+                gas_usage,
+            },
+            bytes,
+        ))
     }
 }

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -85,10 +85,6 @@ fn metered_write<S: GlobalStateReader>(
     key: Key,
     value: StoredValue,
 ) -> VMResult<()> {
-    if caller.context().sandboxed {
-        return Err(VMError::Execute(ExecuteError::AttemptWriteInRestricted));
-    }
-
     charge_gas_storage(caller, value.serialized_length())?;
     caller.context_mut().tracking_copy.write(key, value);
     Ok(())
@@ -144,9 +140,6 @@ pub fn casper_ffi<S: GlobalStateReader + 'static>(
             return Err(VMError::Execute(ExecuteError::InvalidFFIOption(ffi_opt)));
         }
     };
-    if caller.context().sandboxed && !option.allowed_in_sandbox() {
-        return Err(VMError::Execute(ExecuteError::AttemptWriteInRestricted));
-    }
 
     let call_cost_definition = match caller.context().ffi_call_costs.get(&ffi_opt) {
         Some(ffi_call_cost) => ffi_call_cost,

--- a/executor/wasm_interface/src/executor.rs
+++ b/executor/wasm_interface/src/executor.rs
@@ -560,8 +560,6 @@ pub enum ExecuteError {
     InvalidKeyForPurse(Key),
     #[error("attempt to call a non-existent ffi option {0}")]
     InvalidFFIOption(u32),
-    #[error("attempted writing in restricted mode")]
-    AttemptWriteInRestricted,
 }
 
 #[derive(Debug, Error)]

--- a/executor/wasm_interface/src/executor.rs
+++ b/executor/wasm_interface/src/executor.rs
@@ -461,54 +461,6 @@ pub enum FFIMenu {
 }
 
 impl FFIMenu {
-    pub fn allowed_in_sandbox(&self) -> bool {
-        match self {
-            FFIMenu::Mint(mint_methods) => match mint_methods {
-                MintMethods::Burn => false,
-                MintMethods::Transfer => false,
-                MintMethods::TransferPurse => false,
-            },
-            FFIMenu::Auction(auction_methods) => match auction_methods {
-                AuctionMethods::Activate => false,
-                AuctionMethods::Bid => false,
-                AuctionMethods::Withdraw => false,
-                AuctionMethods::Delegate => false,
-                AuctionMethods::Undelegate => false,
-                AuctionMethods::Redelegate => false,
-                AuctionMethods::AddReservation => false,
-                AuctionMethods::CancelReservation => false,
-                AuctionMethods::ChangePublicKey => false,
-            },
-            FFIMenu::Crypto(crypto_methods) => match crypto_methods {
-                CryptoMethods::AltBn128Add => true,
-                CryptoMethods::AltBn128Multiply => true,
-                CryptoMethods::AltBn128Pairing => true,
-                CryptoMethods::GenericHash => true,
-                CryptoMethods::RecoverSecp256K1 => true,
-            },
-            FFIMenu::Emit(emit_methods) => match emit_methods {
-                EmitMethods::PrintStd => true,
-                EmitMethods::Native => false,
-            },
-            FFIMenu::GlobalState(global_state_methods) => match global_state_methods {
-                GlobalStateMethods::Read => true,
-                GlobalStateMethods::Write => false,
-                GlobalStateMethods::Remove => false,
-                GlobalStateMethods::GetBalance => true,
-                GlobalStateMethods::GetInfo => true,
-                GlobalStateMethods::Create => false,
-            },
-            FFIMenu::Control(control_methods) => match control_methods {
-                ControlMethods::Call => false,
-                ControlMethods::Upgrade => false,
-            },
-            FFIMenu::IO(iomethods) => match iomethods {
-                IOMethods::Return => true,
-                IOMethods::CopyInput => true,
-            },
-        }
-    }
-
     pub fn all_ffi_options() -> impl Iterator<Item = FFIMenu> {
         FFIPrimitiveValue::iter().map(|raw| FFIMenu::from(&raw))
     }

--- a/node/src/components/binary_port.rs
+++ b/node/src/components/binary_port.rs
@@ -1507,17 +1507,7 @@ where
         .await;
     let result = utils::map_sandbox_result(inner_result);
 
-    if result.is_success() {
-        // Return the output bytes on success
-        if let Some(output) = result.output() {
-            BinaryResponse::from_raw_bytes(ResponseType::SandboxedExecutionResult, output.to_vec())
-        } else {
-            BinaryResponse::from_raw_bytes(ResponseType::SandboxedExecutionResult, vec![])
-        }
-    } else {
-        // Return error message on failure
-        BinaryResponse::new_error(ErrorCode::SandboxedExecutionFailed)
-    }
+    BinaryResponse::from_value(result)
 }
 
 async fn handle_client_loop<REv>(

--- a/node/src/reactor/main_reactor/tests/binary_port.rs
+++ b/node/src/reactor/main_reactor/tests/binary_port.rs
@@ -26,7 +26,7 @@ use casper_binary_port::{
     GetTrieFullResult, GlobalStateEntityQualifier, GlobalStateQueryResult, GlobalStateRequest,
     InformationRequest, InformationRequestTag, KeyPrefix, LastProgress, NetworkName, NodeStatus,
     PackageIdentifier, PurseIdentifier, ReactorStateName, RecordId, ResponseType, RewardResponse,
-    SandboxedExecutionRequest, Uptime, ValueWithProof,
+    SandboxedExecutionRequest, SandboxedExecutionResult, Uptime, ValueWithProof,
 };
 use casper_executor_wasm_common::chain_utils;
 use casper_storage::global_state::state::CommitProvider;
@@ -1543,9 +1543,15 @@ async fn binary_port_sandboxed_execution_request() {
     let response_obj = binary_response_and_request.response();
     assert!(response_obj.is_success());
 
+    let (result, remainder): (SandboxedExecutionResult, _) =
+        FromBytes::from_bytes(response_obj.payload()).expect("should deserialize");
+    assert!(remainder.is_empty());
+    assert!(result.is_success());
+
     // The get entrypoint in flipper should return a single boolean value
     let (flipper_state, remainder) =
-        bool::from_bytes(response_obj.payload()).expect("should deserialize");
+        bool::from_bytes(result.output().expect("should contain output").as_slice())
+            .expect("should deserialize bool from output bytes");
     assert!(remainder.is_empty());
     assert!(!flipper_state);
 


### PR DESCRIPTION
Allows the use of write operations in VM2's sandboxed execution. Additionally, returns the measured gas consumption to the caller.