### PR TITLE
Execution journal entries on entry point calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "do-nothing-stored-caller-stored"
+version = "0.1.0"
+dependencies = [
+ "casper-contract",
+ "casper-types",
+]
+
+[[package]]
 name = "do-nothing-stored-upgrader"
 version = "0.1.0"
 dependencies = [
@@ -7311,6 +7319,24 @@ name = "vm2-counter"
 version = "0.1.0"
 dependencies = [
  "casper-contract-sdk",
+]
+
+[[package]]
+name = "vm2-counter-caller"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "casper-contract-sdk",
+ "casper-contract-sdk-contrib",
+ "vm2-counter",
+]
+
+[[package]]
+name = "vm2-do-nothing-session"
+version = "0.1.0"
+dependencies = [
+ "casper-contract-sdk",
+ "casper-contract-sdk-contrib",
 ]
 
 [[package]]

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
-- A VM1 contract version install (both new and upgrade) will now produce a native message to system-owned topics:
+- A contract version install (both new and upgrade) will now produce a native message to system-owned topics:
   - in case `addressable_entity` is turned off:
     - `contract_key` topic will receive string-formatted `Key::Hash` containing the address of the new `StoredValue::Contract` value
     - `package_key` topic will receive string-formatted `Key::Hash` containing the address of the new `StoredValue::ContractPackage` value
@@ -29,6 +29,23 @@ All notable changes to this project will be documented in this file. The format 
     - `package_key` topic will receive string-formatted `Key::SmartContract` containing the address of the new `SmartContract::Package` value
     - `bytecode_key` topic will receive string-formatted `Key::ByteCode` containing the address of the new `StoredValue::ByteCode` value
     - `contract_version` topic will receive a string containing the major contract and minor installed contract version (for example "2.1")
+- Calling wasm adds additional execution journal entries. For each session execution there will be a corresponding pair of TransformKindV2::EntryPointCalled and TransformKindV2::Ret written:
+   - For session bytes:
+      - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
+      - The `Option<HashAddr>` of `EntryPointCalled` will be `None`
+      - The `String` of `EntryPointCalled` will be `"call"` (the default function name we expect of session wasm)
+      - The `Ret` will either be `RetValue::Unit` or `RetValue::CLValue` depending on wether or not the code called `casper_return`.
+   - If a session call calls a stored contracts entrypoint:
+      - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
+      - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+      - The `String` of `EntryPointCalled` will be the name of the called entrypoint
+      - The `Ret` will either be `RetValue::Unit` or `RetValue::CLValue` depending on wether or not the code called `casper_return`.
+   - If a stored contract calls another stored contract:
+      - the key under which both transforms will be stored is the key of the contract which is executing the call.
+      - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+      - The `String` of `EntryPointCalled` will be the name of the called entrypoint
+      - The `Ret` will either be `RetValue::Unit` or `RetValue::CLValue` depending on wether or not the code called `casper_return`.
+    - the above also applies to `payment` bytecode if supplied
 
 ## 8.0.0
 

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -718,13 +718,13 @@ where
                 self.host_buffer = bytesrepr::deserialize_from_slice(buf).ok();
 
                 // Emit Ret transform to the execution journal
-                if let Some(cl_value) = &self.host_buffer {
-                    let key = self.context.get_context_key();
-                    self.context
-                        .state()
-                        .borrow_mut()
-                        .ret(key, RetValue::CLValue(cl_value.clone()));
-                }
+                let ret_val = if let Some(cl_value) = &self.host_buffer {
+                    RetValue::CLValue(cl_value.clone())
+                } else {
+                    RetValue::Unit
+                };
+                let key = self.context.get_context_key();
+                self.context.state().borrow_mut().ret(key, ret_val);
 
                 let urefs = match &self.host_buffer {
                     Some(buf) => utils::extract_urefs(buf),
@@ -1455,6 +1455,11 @@ where
         let protocol_version = self.context.protocol_version();
         let engine_config = self.context.engine_config();
         let wasm_config = engine_config.wasm_config();
+        self.context.state().borrow_mut().entry_point_called(
+            self.context.get_context_key(),
+            None,
+            DEFAULT_ENTRY_POINT_NAME.to_string(),
+        );
         #[cfg(feature = "test-support")]
         let max_stack_height = wasm_config.v1().max_stack_height();
         let module = preprocess(*wasm_config, module_bytes)?;
@@ -1483,6 +1488,10 @@ where
             // returned the unit type `()` as per Rust functions which don't specify a
             // return value.
             Ok(_) => {
+                self.context
+                    .state()
+                    .borrow_mut()
+                    .ret(self.context.get_context_key(), RetValue::Unit);
                 return Ok(self.take_host_buffer().unwrap_or(CLValue::from_t(())?));
             }
         };
@@ -1892,6 +1901,12 @@ where
             }
         };
 
+        self.context.state().borrow_mut().entry_point_called(
+            self.context.get_context_key(),
+            Some(entity_addr.value()),
+            entry_point_name.to_string(),
+        );
+
         if let EntityKind::Account(_) = footprint.entity_kind() {
             return Err(ExecError::InvalidContext);
         }
@@ -1915,6 +1930,11 @@ where
                 return Err(ExecError::NoSuchMethod(entry_point_name.to_owned()));
             }
         };
+
+        // if session the caller's context
+        // else the called contract's context
+        let context_entity_key =
+            self.get_context_key_for_contract_call(entity_addr, entry_point)?;
 
         let entry_point_type = entry_point.entry_point_type();
 
@@ -1970,11 +1990,6 @@ where
         {
             return Err(ExecError::DisabledEntity(entity_hash));
         }
-
-        // if session the caller's context
-        // else the called contract's context
-        let context_entity_key =
-            self.get_context_key_for_contract_call(entity_addr, entry_point)?;
 
         let context_entity_hash = context_entity_key
             .into_entity_hash_addr()
@@ -2199,7 +2214,6 @@ where
             .set_emit_message_cost(runtime.context.emit_message_cost());
         let transfers = self.context.transfers_mut();
         runtime.context.transfers().clone_into(transfers);
-
         match result {
             Ok(_) => {
                 // If `Ok` and the `host_buffer` is `None`, the contract's execution succeeded but
@@ -2215,6 +2229,8 @@ where
                 }
                 self.context
                     .set_remaining_spending_limit(runtime.context.remaining_spending_limit());
+                let key = self.context.get_context_key();
+                self.context.state().borrow_mut().ret(key, RetValue::Unit);
                 Ok(runtime.take_host_buffer().unwrap_or(CLValue::from_t(())?))
             }
             Err(error) => {

--- a/execution_engine_testing/test_support/src/execute_request_builder.rs
+++ b/execution_engine_testing/test_support/src/execute_request_builder.rs
@@ -223,6 +223,24 @@ impl ExecuteRequestBuilder {
         )
     }
 
+    /// Returns an [`ExecuteRequest`] derived from a deploy with sessiond and payment bytecode.
+    pub fn standard_and_payment(
+        account_hash: AccountHash,
+        session_file: &str,
+        session_args: RuntimeArgs,
+        payment_file: &str,
+        payment_args: RuntimeArgs,
+    ) -> Self {
+        Self::standard_and_payment_with_protocol_version(
+            account_hash,
+            session_file,
+            session_args,
+            payment_file,
+            payment_args,
+            DEFAULT_PROTOCOL_VERSION,
+        )
+    }
+
     /// Returns an [`ExecuteRequest`] derived from a deploy with standard dependencies.
     pub fn standard_with_protocol_version(
         account_hash: AccountHash,
@@ -236,6 +254,24 @@ impl ExecuteRequestBuilder {
             .with_standard_payment(runtime_args! {
                 ARG_AMOUNT => *DEFAULT_PAYMENT
             })
+            .with_authorization_keys(&[account_hash])
+            .build();
+        Self::from_deploy_item_for_protocol_version(&deploy_item, protocol_version)
+    }
+
+    /// Returns an [`ExecuteRequest`] derived from a deploy with standard dependencies.
+    pub fn standard_and_payment_with_protocol_version(
+        account_hash: AccountHash,
+        session_file: &str,
+        session_args: RuntimeArgs,
+        payment_file: &str,
+        payment_args: RuntimeArgs,
+        protocol_version: ProtocolVersion,
+    ) -> Self {
+        let deploy_item = DeployItemBuilder::new()
+            .with_address(account_hash)
+            .with_session_code(session_file, session_args)
+            .with_payment_code(payment_file, payment_args)
             .with_authorization_keys(&[account_hash])
             .build();
         Self::from_deploy_item_for_protocol_version(&deploy_item, protocol_version)

--- a/execution_engine_testing/tests/src/test/entry_point_called.rs
+++ b/execution_engine_testing/tests/src/test/entry_point_called.rs
@@ -1,0 +1,350 @@
+use casper_engine_test_support::{
+    ExecuteRequest, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    LOCAL_GENESIS_REQUEST,
+};
+use casper_execution_engine::engine_state::WasmV1Result;
+use casper_types::{
+    execution::{RetValue, TransformKindV2, TransformV2},
+    runtime_args, AddressableEntityHash, Key, RuntimeArgs, DEFAULT_ENTRY_POINT_NAME,
+};
+
+const DO_NOTHING: &str = "do_nothing.wasm";
+const DO_NOTHING_STORED: &str = "do_nothing_stored.wasm";
+const DO_NOTHING_STORED_CALLER_CONTRACT_NAME: &str = "do_nothing_stored_caller_stored";
+const DO_NOTHING_HASH_KEY_NAME: &str = "do_nothing_hash";
+const DO_NOTHING_PACKAGE_HASH_KEY_NAME: &str = "do_nothing_package_hash";
+const DO_NOTHING_STORED_CALLER_HASH_KEY_NAME: &str = "do_nothing_stored_caller_stored_hash";
+
+#[ignore]
+#[test]
+fn vm1_do_nothing_session_should_not_return_entry_point_called() {
+    let mut builder = LmdbWasmTestBuilder::default();
+    builder.run_genesis(LOCAL_GENESIS_REQUEST.clone());
+
+    // Execute the contract that calls casper_ret directly
+    let exec_request = ExecuteRequestBuilder::standard_and_payment(
+        *DEFAULT_ACCOUNT_ADDR,
+        DO_NOTHING,
+        RuntimeArgs::default(),
+        DO_NOTHING,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    let builder_after_success = builder.exec(exec_request).expect_success();
+    assert_eq!(builder_after_success.get_exec_results_count(), 2);
+    for i in 0..=1 {
+        let results = builder_after_success
+            .get_exec_result_owned(i)
+            .clone()
+            .unwrap();
+        let ep_calls_and_rets = get_ep_calls_and_rets(results);
+        assert_eq!(ep_calls_and_rets.len(), 2);
+        let call_called = TransformV2::new(
+            Key::Account(*DEFAULT_ACCOUNT_ADDR),
+            TransformKindV2::EntryPointCalled(None, DEFAULT_ENTRY_POINT_NAME.to_string()),
+        );
+        let ret = TransformV2::new(
+            Key::Account(*DEFAULT_ACCOUNT_ADDR),
+            TransformKindV2::Ret(RetValue::Unit),
+        );
+        assert_eq!(ep_calls_and_rets, vec![call_called, ret]);
+    }
+}
+
+#[ignore]
+#[test]
+fn call_and_ret_when_by_hash() {
+    run_test_do_nothing_call(|_contract_hash, package_hash| {
+        ExecuteRequestBuilder::contract_call_by_hash_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            package_hash.into(),
+            None,
+            None,
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+    run_test_do_nothing_call(|_contract_hash, package_hash| {
+        ExecuteRequestBuilder::contract_call_by_hash_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            package_hash.into(),
+            None,
+            Some(2),
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+    run_test_do_nothing_call(|_contract_hash, package_hash| {
+        ExecuteRequestBuilder::contract_call_by_hash_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            package_hash.into(),
+            Some(1),
+            None,
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+    run_test_do_nothing_call(|_contract_hash, package_hash| {
+        ExecuteRequestBuilder::contract_call_by_hash_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            package_hash.into(),
+            Some(1),
+            Some(2),
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+    run_test_do_nothing_call(|_, _| {
+        ExecuteRequestBuilder::contract_call_by_name_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            DO_NOTHING_PACKAGE_HASH_KEY_NAME,
+            None,
+            None,
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+    run_test_do_nothing_call(|_, _| {
+        ExecuteRequestBuilder::contract_call_by_name_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            DO_NOTHING_PACKAGE_HASH_KEY_NAME,
+            None,
+            Some(2),
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+    run_test_do_nothing_call(|_, _| {
+        ExecuteRequestBuilder::contract_call_by_name_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            DO_NOTHING_PACKAGE_HASH_KEY_NAME,
+            Some(1),
+            None,
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+    run_test_do_nothing_call(|_, _| {
+        ExecuteRequestBuilder::contract_call_by_name_versioned_with_major(
+            *DEFAULT_ACCOUNT_ADDR,
+            DO_NOTHING_PACKAGE_HASH_KEY_NAME,
+            Some(1),
+            Some(2),
+            "delegate",
+            RuntimeArgs::new(),
+        )
+        .build()
+    });
+}
+
+fn run_test_do_nothing_call<F>(build_request: F)
+where
+    F: FnOnce([u8; 32], [u8; 32]) -> ExecuteRequest,
+{
+    let mut builder = install_do_nothing();
+
+    let default_account_entity = builder
+        .get_entity_with_named_keys_by_account_hash(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+
+    let contract_hash = default_account_entity
+        .named_keys()
+        .get(DO_NOTHING_HASH_KEY_NAME)
+        .cloned()
+        .and_then(Key::into_hash_addr)
+        .expect("should have hash");
+
+    let package_hash = default_account_entity
+        .named_keys()
+        .get(DO_NOTHING_PACKAGE_HASH_KEY_NAME)
+        .cloned()
+        .and_then(Key::into_hash_addr)
+        .expect("should have package hash");
+
+    let request = build_request(contract_hash, package_hash);
+
+    let results = builder
+        .exec(request)
+        .expect_success()
+        .commit()
+        .get_exec_result_owned(1)
+        .unwrap();
+
+    let ep_calls_and_rets = get_ep_calls_and_rets(results);
+    assert_eq!(ep_calls_and_rets.len(), 2);
+    let delegate_called = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_ADDR),
+        TransformKindV2::EntryPointCalled(Some(contract_hash), "delegate".to_string()),
+    );
+    let delegate_ret = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_ADDR),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+    assert_eq!(ep_calls_and_rets, vec![delegate_called, delegate_ret]);
+}
+
+#[ignore]
+#[test]
+fn vm1_do_nothing_stored_should_return_entry_point_called() {
+    let mut builder = install_do_nothing();
+
+    let default_account_entity = builder
+        .get_entity_with_named_keys_by_account_hash(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have default account");
+    let contract_hash = default_account_entity
+        .named_keys()
+        .get(DO_NOTHING_HASH_KEY_NAME)
+        .cloned()
+        .and_then(Key::into_hash_addr)
+        .expect("should have hash");
+
+    let call_do_nothing_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        AddressableEntityHash::new(contract_hash),
+        "delegate",
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    let results = builder
+        .exec(call_do_nothing_request)
+        .expect_success()
+        .commit()
+        .get_exec_result_owned(1)
+        .unwrap();
+
+    let ep_calls_and_rets = get_ep_calls_and_rets(results);
+    assert_eq!(ep_calls_and_rets.len(), 2);
+    let delegate_called = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_ADDR),
+        TransformKindV2::EntryPointCalled(Some(contract_hash), "delegate".to_string()),
+    );
+    let delegate_ret = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_ADDR),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+    assert_eq!(ep_calls_and_rets, vec![delegate_called, delegate_ret]);
+}
+
+#[ignore]
+#[test]
+fn vm1_nested_call_should_produce_entry_point_calls_and_rets() {
+    // 1. install do nothing stored contract
+    let mut builder = install_do_nothing();
+    let account = builder
+        .get_entity_with_named_keys_by_account_hash(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should get account");
+
+    let contract_hash = account
+        .named_keys()
+        .get(DO_NOTHING_HASH_KEY_NAME)
+        .expect("should have key of do_nothing_hash")
+        .into_entity_hash_addr()
+        .expect("should have into hash");
+
+    // 2. install caller
+    let install_do_nothing_caller_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        &format!("{}.wasm", DO_NOTHING_STORED_CALLER_CONTRACT_NAME),
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder
+        .exec(install_do_nothing_caller_request)
+        .expect_success()
+        .commit();
+    let account = builder
+        .get_entity_with_named_keys_by_account_hash(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should get account");
+    let caller_hash = account
+        .named_keys()
+        .get(DO_NOTHING_STORED_CALLER_HASH_KEY_NAME)
+        .expect("should have key of DO_NOTHING_STORED_CALLER_HASH_KEY_NAME")
+        .into_entity_hash_addr()
+        .expect("should have into hash");
+
+    // 3. Call the caller
+    let call_do_nothing_caller_request = ExecuteRequestBuilder::contract_call_by_hash(
+        *DEFAULT_ACCOUNT_ADDR,
+        AddressableEntityHash::new(caller_hash),
+        "call_stored",
+        runtime_args! {
+            "contract_addr" => contract_hash
+        },
+    )
+    .build();
+
+    let builder_after_success = builder
+        .exec(call_do_nothing_caller_request)
+        .expect_success()
+        .commit();
+    assert_eq!(builder_after_success.get_exec_results_count(), 3);
+    let exec_owned = builder_after_success.get_exec_result_owned(2).unwrap();
+    let ep_calls_and_rets = get_ep_calls_and_rets(exec_owned);
+    assert_eq!(ep_calls_and_rets.len(), 4);
+    let caller_called = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_ADDR),
+        TransformKindV2::EntryPointCalled(Some(caller_hash), "call_stored".to_string()),
+    );
+    let delegate_called = TransformV2::new(
+        Key::Hash(caller_hash),
+        TransformKindV2::EntryPointCalled(Some(contract_hash), "delegate".to_string()),
+    );
+    let delegate_ret =
+        TransformV2::new(Key::Hash(caller_hash), TransformKindV2::Ret(RetValue::Unit));
+    let caller_ret = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_ADDR),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+    assert_eq!(
+        ep_calls_and_rets,
+        vec![caller_called, delegate_called, delegate_ret, caller_ret]
+    );
+}
+
+fn get_ep_calls_and_rets(results: WasmV1Result) -> Vec<TransformV2> {
+    let transforms = results.effects().transforms();
+    transforms
+        .iter()
+        .filter(|transform| {
+            matches!(
+                transform.kind(),
+                casper_types::execution::TransformKindV2::EntryPointCalled(_, _)
+            ) || matches!(
+                transform.kind(),
+                casper_types::execution::TransformKindV2::Ret(_)
+            )
+        })
+        .cloned()
+        .collect()
+}
+
+fn install_do_nothing() -> casper_engine_test_support::WasmTestBuilder<
+    casper_storage::data_access_layer::DataAccessLayer<
+        casper_storage::global_state::state::lmdb::LmdbGlobalState,
+    >,
+> {
+    let mut builder = LmdbWasmTestBuilder::default();
+    builder.run_genesis(LOCAL_GENESIS_REQUEST.clone());
+    let install_do_nothing_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        DO_NOTHING_STORED,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder
+        .exec(install_do_nothing_request)
+        .expect_success()
+        .commit();
+    builder
+}

--- a/execution_engine_testing/tests/src/test/mod.rs
+++ b/execution_engine_testing/tests/src/test/mod.rs
@@ -6,6 +6,7 @@ mod contract_context;
 mod contract_messages;
 mod counter_factory;
 mod deploy;
+mod entry_point_called;
 mod explorer;
 mod get_balance;
 mod groups;

--- a/execution_engine_testing/tests/src/test/ret.rs
+++ b/execution_engine_testing/tests/src/test/ret.rs
@@ -43,6 +43,7 @@ fn vm1_casper_ret_emits_ret_transforms() {
     });
 
     let (_, value) = ret_transform.expect("Expected to find a Ret transform in the effects");
+
     let RetValue::CLValue(value) = value else {
         panic!("Expected VM1 return value to be a CLValue");
     };

--- a/executor/wasm/CHANGELOG.md
+++ b/executor/wasm/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog].
+
+[comment]: <> (Added: new features)
+
+[comment]: <> (Changed: changes in existing functionality)
+
+[comment]: <> (Deprecated: soon-to-be removed features)
+
+[comment]: <> (Removed: now removed features)
+
+[comment]: <> (Fixed: any bug fixes)
+
+[comment]: <> (Security: in case of vulnerabilities)
+
+## [Unreleased]
+
+### Added
+
+- Calling wasm adds additional execution journal entries. For each session execution there will be a corresponding pair of TransformKindV2::EntryPointCalled and TransformKindV2::Ret written:
+  - For session bytes:
+    - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
+    - The `Option<HashAddr>` of `EntryPointCalled` will be `None`
+    - The `String` of `EntryPointCalled` will be `"call"` (the default function name we expect of session wasm)
+    - The `Ret` will either be `RetValue::Unit` or `RetValue::Bytes` depending on wether or not the code called `casper_return`.
+  - If a session call calls a stored contracts entrypoint:
+    - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
+    - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+    - The `String` of `EntryPointCalled` will be the name of the called entrypoint
+    - The `Ret` will either be `RetValue::Unit` or `RetValue::Bytes` depending on wether or not the code called `casper_return`.
+  - If a stored contract calls another stored contract:
+    - the key under which both transforms will be stored is the key of the contract which is executing the call.
+    - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+    - The `String` of `EntryPointCalled` will be the name of the called entrypoint
+    - The `Ret` will either be `RetValue::Unit` or `RetValue::Bytes` depending on wether or not the code called `casper_return`.

--- a/executor/wasm/src/lib.rs
+++ b/executor/wasm/src/lib.rs
@@ -52,6 +52,7 @@ use casper_types::{
         ContractHash, ContractPackage, ContractPackageHash, ContractPackageStatus,
         EntryPoints as ContractEntryPoints,
     },
+    execution::RetValue,
     AddressableEntity, AuctionCosts, ByteCode, ByteCodeAddr, ByteCodeHash, ByteCodeKind, CLType,
     CLValue, Contract, ContractRuntimeTag, ContractWasmHash, Digest, EntityAddr, EntityKind,
     EntryPointAccess, EntryPointAddr, EntryPointPayment, EntryPointType, EntryPointValue, Gas,
@@ -68,6 +69,9 @@ pub mod chainspec_config;
 #[cfg(any(feature = "testing", test))]
 pub mod testing;
 
+// If calculating the wasm entry point for session bytecode ever changes we need
+// to revisit the code that produces EntyPointCalled journal entries for session
+// code (both for VM1 and VM2)
 const DEFAULT_WASM_ENTRY_POINT: &str = "call";
 
 #[derive(Copy, Clone, Debug)]
@@ -450,7 +454,7 @@ impl ExecutorV2 {
                     .with_caller_key(caller_key)
                     .with_execution_kind(ExecutionKind::Stored {
                         address: package_addr,
-                        entry_point: entry_point_name,
+                        entry_point: entry_point_name.clone(),
                     })
                     .with_gas_limit(gas_limit)
                     .with_input(input)
@@ -468,7 +472,6 @@ impl ExecutorV2 {
                     .map_err(InstallContractError::FailedBuildingExecuteRequest)?;
 
                 let mut forked_tc = tracking_copy.fork2();
-
                 match forked_tc.emit_messages_for_new_installed_version(
                     key_of_package,
                     key_of_contract,
@@ -567,8 +570,13 @@ impl ExecutorV2 {
         mut tracking_copy: TrackingCopy<R>,
         execute_request: ExecuteRequest,
     ) -> Result<ExecuteResult, ExecuteError> {
-        if let Some(ffi_menu_selection) = execute_request.execution_kind.ffi_selection() {
-            return self.execute_ffi(ffi_menu_selection, tracking_copy, execute_request);
+        if let Some(system_contract_menu_selection) = execute_request.execution_kind.ffi_selection()
+        {
+            return self.execute_ffi(
+                system_contract_menu_selection,
+                tracking_copy,
+                execute_request,
+            );
         }
 
         let ExecuteRequest {
@@ -958,23 +966,30 @@ impl ExecutorV2 {
         let mut initial_tracking_copy = tracking_copy.fork2();
 
         // Derive callee key from the execution target.
-        let callee_key = match &execution_kind {
+        let (callee_key, entry_point_name, contract_addr) = match &execution_kind {
             ExecutionKind::Stored {
                 address: smart_contract_package_addr,
+                entry_point,
                 ..
             } => {
-                if initial_tracking_copy.addressable_entity_enabled() {
+                let key = if tracking_copy.addressable_entity_enabled() {
                     Key::Package((*smart_contract_package_addr).into())
                 } else {
                     Key::Hash(*smart_contract_package_addr)
-                }
+                };
+                (key, entry_point.clone(), Some(*smart_contract_package_addr))
             }
-            ExecutionKind::SessionBytes(_wasm_bytes) => Key::Account(initiator),
+            ExecutionKind::SessionBytes(_wasm_bytes) => (
+                Key::Account(initiator),
+                DEFAULT_WASM_ENTRY_POINT.to_string(),
+                None,
+            ),
             ExecutionKind::System(_) => {
                 error!("System executions are not called in this way. This should be unreachable.");
                 return Err(ExecuteError::Fatal(FatalHostError::DispatchSystemContract));
             }
         };
+        tracking_copy.entry_point_called(caller_key, contract_addr, entry_point_name);
         let ffi_call_costs = self.build_ffi_call_costs(&self.config);
         let context = Context {
             initiator,
@@ -1043,19 +1058,23 @@ impl ExecutorV2 {
         let context = instance.teardown();
 
         let Context {
-            tracking_copy: final_tracking_copy,
+            tracking_copy: mut final_tracking_copy,
             ..
         } = context;
 
         match vm_result {
-            Ok(()) => Ok(ExecuteResult {
-                host_error: None,
-                output: None,
-                gas_usage,
-                effects: final_tracking_copy.effects(),
-                cache: final_tracking_copy.cache(),
-                messages: final_tracking_copy.messages(),
-            }),
+            Ok(()) => {
+                // We put a Ret in if the function ended successfully
+                final_tracking_copy.ret(caller_key, RetValue::Unit);
+                Ok(ExecuteResult {
+                    host_error: None,
+                    output: None,
+                    gas_usage,
+                    effects: final_tracking_copy.effects(),
+                    cache: final_tracking_copy.cache(),
+                    messages: final_tracking_copy.messages(),
+                })
+            }
             Err(VMError::Return { flags, data }) => {
                 if flags.contains(ReturnFlags::REVERT) {
                     let message = data
@@ -1082,6 +1101,11 @@ impl ExecutorV2 {
                         final_tracking_copy.cache(),
                         final_tracking_copy.messages(),
                     );
+                    let ret_val = match &data {
+                        None => RetValue::Unit,
+                        Some(data) => RetValue::Bytes(data.to_vec().into()),
+                    };
+                    initial_tracking_copy.ret(caller_key, ret_val);
 
                     None
                 };

--- a/executor/wasm/tests/integration.rs
+++ b/executor/wasm/tests/integration.rs
@@ -48,10 +48,10 @@ use casper_types::{
     account::AccountHash,
     bytesrepr::ToBytes,
     contract_messages::{Message, MessageChecksum, MessagePayload},
-    execution::RetValue,
+    execution::{RetValue, TransformKindV2, TransformV2},
     system::auction::{BidAddr, BidKind},
     BlockHash, BlockTime, ByteCodeAddr, Digest, EntityAddr, Key, KeyTag, PublicKey, RuntimeArgs,
-    StoredValue, Timestamp,
+    StoredValue, Timestamp, DEFAULT_ENTRY_POINT_NAME,
 };
 use fs_extra::dir;
 use itertools::Itertools;
@@ -1483,21 +1483,22 @@ fn casper_return_writes_to_execution_journal() {
     let effects = execute_result.effects();
     let transforms = effects.transforms();
 
-    let ret_transform = transforms.iter().find(|transform| {
-        matches!(
-            transform.kind(),
-            casper_types::execution::TransformKindV2::Ret(_)
-        )
-    });
+    let ret_transforms: Vec<&TransformV2> = transforms
+        .into_iter()
+        .filter(|transform| {
+            matches!(
+                transform.kind(),
+                casper_types::execution::TransformKindV2::Ret(_)
+            )
+        })
+        .collect();
+    assert_eq!(ret_transforms.len(), 1);
+    let ret_transform = ret_transforms
+        .get(0)
+        .expect("Expected to find a Ret transform in the effects");
 
-    assert!(
-        ret_transform.is_some(),
-        "Expected to find a Ret transform in the effects"
-    );
-
-    let ret_transform = ret_transform.unwrap();
     match ret_transform.kind() {
-        casper_types::execution::TransformKindV2::Ret(RetValue::Bytes(bytes)) => {
+        TransformKindV2::Ret(RetValue::Bytes(bytes)) => {
             // The ret function in the test contract calls casper::ret with [1, 2, 3] data
             assert_eq!(
                 bytes.as_slice(),
@@ -1507,16 +1508,9 @@ fn casper_return_writes_to_execution_journal() {
         }
         _ => panic!("Expected Ret transform kind"),
     }
-
-    // Verify the key is the contract address
-    let expected_key = if chainspec_config.core_config.addressable_entity_enabled {
-        Key::AddressableEntity(EntityAddr::SmartContract(contract_address))
-    } else {
-        Key::Hash(contract_address)
-    };
     assert_eq!(
         ret_transform.key(),
-        &expected_key,
+        &Key::Account(*DEFAULT_ACCOUNT_HASH),
         "Ret transform should be under the contract key"
     );
 }
@@ -1991,6 +1985,338 @@ fn installing_contract_should_produce_system_messages_after_upgrade() {
     );
 }
 
+#[test]
+fn calling_upgrade_contract_should_produce_ret_and_call_result() {
+    let chainspec_config = ChainspecConfig::from_chainspec_path(&*CHAINSPEC_SYMLINK)
+        .expect("must get chainspec config");
+
+    let mut executor = make_executor(&chainspec_config);
+    let upgradable_address;
+    let (global_state, mut state_root_hash, _tempdir) = make_global_state_with_genesis();
+
+    let address_generator = make_address_generator();
+    let input_data = borsh::to_vec(&(0u8,)).map(Bytes::from).unwrap();
+
+    let create_request = base_install_request_builder(&chainspec_config)
+        .with_wasm_bytes(read_wasm("vm2_upgradable.wasm"))
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_gas_limit(DEFAULT_GAS_LIMIT)
+        .with_transferred_value(0)
+        .with_entry_point("new".to_string())
+        .with_input(input_data)
+        .build()
+        .expect("should build");
+
+    let create_result = run_create_contract(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        create_request,
+    );
+
+    upgradable_address = *create_result.smart_contract_addr();
+
+    state_root_hash = global_state
+        .commit_effects(state_root_hash, create_result.effects().clone())
+        .expect("Should commit");
+    let binding = read_wasm("vm2_upgradable_v2.wasm");
+    let new_code = binding.as_ref();
+
+    let execute_request = base_execute_builder(&chainspec_config)
+        .with_transferred_value(0)
+        .with_execution_kind(ExecutionKind::Stored {
+            address: upgradable_address,
+            entry_point: "perform_upgrade".to_string(),
+        })
+        .with_gas_limit(DEFAULT_GAS_LIMIT * 10)
+        .with_serialized_input((new_code,))
+        .expect("expected serialized input to be correct")
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .build()
+        .expect("should build");
+    let upgrade_result = expect_successful_execution(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        execute_request,
+    );
+
+    let transforms = upgrade_result.effects().transforms();
+    let ep_calls_and_rets = get_ep_calls_and_rets(transforms);
+    assert_eq!(ep_calls_and_rets.len(), 4);
+
+    let expected_call_1 = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::EntryPointCalled(
+            Some(*create_result.smart_contract_addr()),
+            "perform_upgrade".to_string(),
+        ),
+    );
+    let expected_call_2 = TransformV2::new(
+        Key::Hash(*create_result.smart_contract_addr()),
+        TransformKindV2::EntryPointCalled(
+            Some(*create_result.smart_contract_addr()),
+            "migrate".to_string(),
+        ),
+    );
+    let ret_1 = TransformV2::new(
+        Key::Hash(*create_result.smart_contract_addr()),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+    let ret_2 = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+    assert_eq!(
+        ep_calls_and_rets,
+        vec![expected_call_1, expected_call_2, ret_1, ret_2]
+    );
+}
+
+#[test]
+fn calling_constructor_method_should_produce_ret_and_call_result() {
+    let chainspec_config = ChainspecConfig::from_chainspec_path(&*CHAINSPEC_SYMLINK)
+        .expect("must get chainspec config");
+
+    let mut executor = make_executor(&chainspec_config);
+
+    let (global_state, state_root_hash, _tempdir) = make_global_state_with_genesis();
+
+    let address_generator = make_address_generator();
+
+    let block_time_1 = Timestamp::now().into();
+
+    let create_request = base_install_request_builder(&chainspec_config)
+        .with_initiator(*DEFAULT_ACCOUNT_HASH)
+        .with_transaction_hash(TRANSACTION_HASH)
+        .with_wasm_bytes(read_wasm("vm2_counter.wasm").clone())
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_transferred_value(0)
+        .with_entry_point("default".to_string())
+        .with_block_time(block_time_1)
+        .with_state_hash(Digest::from_raw([0; 32]))
+        .with_block_height(1)
+        .with_parent_block_hash(BlockHash::new(Digest::from_raw([0; 32])))
+        .build()
+        .expect("should build");
+
+    let create_result = run_create_contract(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        create_request,
+    );
+    let transforms = create_result.effects().transforms();
+    let ep_calls_and_rets = get_ep_calls_and_rets(transforms);
+    assert_eq!(ep_calls_and_rets.len(), 2);
+    let constructor_called = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::EntryPointCalled(
+            Some(*create_result.smart_contract_addr()),
+            "default".to_string(),
+        ),
+    );
+    let ret = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+    assert_eq!(ep_calls_and_rets, vec![constructor_called, ret]);
+}
+
+#[test]
+fn contract_calling_different_contract_should_produce_ret_and_call_result() {
+    let chainspec_config = ChainspecConfig::from_chainspec_path(&*CHAINSPEC_SYMLINK)
+        .expect("must get chainspec config");
+
+    let mut executor = make_executor(&chainspec_config);
+
+    let (global_state, mut state_root_hash, _tempdir) = make_global_state_with_genesis();
+
+    let address_generator = make_address_generator();
+
+    let block_time_1 = Timestamp::now().into();
+    let input = borsh::to_vec(&(0u32,)).map(Bytes::from).unwrap();
+    let counter_create_request = base_install_request_builder(&chainspec_config)
+        .with_initiator(*DEFAULT_ACCOUNT_HASH)
+        .with_transaction_hash(TRANSACTION_HASH)
+        .with_wasm_bytes(read_wasm("vm2_counter.wasm").clone())
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_transferred_value(0)
+        .with_entry_point("new".to_string())
+        .with_block_time(block_time_1)
+        .with_state_hash(Digest::from_raw([0; 32]))
+        .with_block_height(1)
+        .with_parent_block_hash(BlockHash::new(Digest::from_raw([0; 32])))
+        .with_input(input)
+        .build()
+        .expect("should build");
+
+    let counter_create_result = run_create_contract(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        counter_create_request,
+    );
+
+    state_root_hash = global_state
+        .commit_effects(state_root_hash, counter_create_result.effects().clone())
+        .expect("Should commit");
+
+    let caller_create_request = base_install_request_builder(&chainspec_config)
+        .with_initiator(*DEFAULT_ACCOUNT_HASH)
+        .with_transaction_hash(TRANSACTION_HASH)
+        .with_wasm_bytes(read_wasm("vm2_counter_caller.wasm").clone())
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_transferred_value(0)
+        .with_entry_point("create".to_string())
+        .with_block_time(block_time_1)
+        .with_state_hash(Digest::from_raw([0; 32]))
+        .with_block_height(1)
+        .with_parent_block_hash(BlockHash::new(Digest::from_raw([0; 32])))
+        .build()
+        .expect("should build");
+
+    let caller_create_result = run_create_contract(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        caller_create_request,
+    );
+
+    state_root_hash = global_state
+        .commit_effects(state_root_hash, caller_create_result.effects().clone())
+        .expect("Should commit");
+
+    let execute_caller_request = base_execute_builder(&chainspec_config)
+        .with_initiator(*DEFAULT_ACCOUNT_HASH)
+        .with_caller_key(Key::Account(*DEFAULT_ACCOUNT_HASH))
+        .with_gas_limit(DEFAULT_GAS_LIMIT)
+        .with_transaction_hash(TRANSACTION_HASH)
+        .with_execution_kind(ExecutionKind::Stored {
+            address: *caller_create_result.smart_contract_addr(),
+            entry_point: "inc_and_get".to_string(),
+        })
+        .with_transferred_value(0)
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_block_time(Timestamp::now().into())
+        .with_state_hash(state_root_hash)
+        .with_block_height(2)
+        .with_parent_block_hash(BlockHash::new(Digest::hash(b"block")))
+        .with_serialized_input((counter_create_result.smart_contract_addr(),))
+        .expect("expected serialized input to be correct")
+        .with_runtime_native_config(make_runtime_config(&chainspec_config))
+        .build()
+        .expect("should build");
+
+    let result = expect_successful_execution(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        execute_caller_request,
+    );
+    let b = 1_u32.to_le_bytes();
+    assert_eq!(result.output().unwrap().iter().as_slice(), b.as_slice());
+    let transforms = result.effects().transforms();
+    let ep_calls_and_rets = get_ep_calls_and_rets(transforms);
+    assert_eq!(ep_calls_and_rets.len(), 6);
+
+    let inc_and_get_call = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::EntryPointCalled(
+            Some(*caller_create_result.smart_contract_addr()),
+            "inc_and_get".to_string(),
+        ),
+    );
+    let increment_call = TransformV2::new(
+        Key::Hash(*caller_create_result.smart_contract_addr()),
+        TransformKindV2::EntryPointCalled(
+            Some(*counter_create_result.smart_contract_addr()),
+            "increment".to_string(),
+        ),
+    );
+    let increment_return = TransformV2::new(
+        Key::Hash(*caller_create_result.smart_contract_addr()),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+    let get_call = TransformV2::new(
+        Key::Hash(*caller_create_result.smart_contract_addr()),
+        TransformKindV2::EntryPointCalled(
+            Some(*counter_create_result.smart_contract_addr()),
+            "get".to_string(),
+        ),
+    );
+    let get_return = TransformV2::new(
+        Key::Hash(*caller_create_result.smart_contract_addr()),
+        TransformKindV2::Ret(RetValue::Bytes(b.as_slice().into())),
+    );
+
+    let inc_and_get_return = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::Ret(RetValue::Bytes(b.as_slice().into())),
+    );
+
+    assert_eq!(
+        ep_calls_and_rets,
+        vec![
+            inc_and_get_call,
+            increment_call,
+            increment_return,
+            get_call,
+            get_return,
+            inc_and_get_return
+        ]
+    );
+}
+
+#[test]
+fn calling_session_should_produce_entry_point_called_and_ret() {
+    let chainspec_config = ChainspecConfig::from_chainspec_path(&*CHAINSPEC_SYMLINK)
+        .expect("must get chainspec config");
+
+    let mut executor = make_executor(&chainspec_config);
+
+    let (global_state, state_root_hash, _tempdir) = make_global_state_with_genesis();
+
+    let address_generator = make_address_generator();
+
+    let execute_request = base_execute_builder(&chainspec_config)
+        .with_initiator(*DEFAULT_ACCOUNT_HASH)
+        .with_caller_key(Key::Account(*DEFAULT_ACCOUNT_HASH))
+        .with_gas_limit(DEFAULT_GAS_LIMIT)
+        .with_transaction_hash(TRANSACTION_HASH)
+        .with_execution_kind(ExecutionKind::SessionBytes(read_wasm(
+            "vm2_do_nothing_session.wasm",
+        )))
+        .with_transferred_value(0)
+        .with_shared_address_generator(Arc::clone(&address_generator))
+        .with_state_hash(Digest::from_raw([0; 32]))
+        .with_block_height(1)
+        .with_parent_block_hash(BlockHash::new(Digest::from_raw([0; 32])))
+        .with_runtime_native_config(make_runtime_config(&chainspec_config))
+        .build()
+        .expect("should build");
+    let result = expect_successful_execution(
+        &mut executor,
+        &global_state,
+        state_root_hash,
+        execute_request,
+    );
+
+    let transforms = result.effects().transforms();
+    let ep_calls_and_rets = get_ep_calls_and_rets(transforms);
+    assert_eq!(ep_calls_and_rets.len(), 2);
+    let call = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::EntryPointCalled(None, DEFAULT_ENTRY_POINT_NAME.to_string()),
+    );
+    let session_return = TransformV2::new(
+        Key::Account(*DEFAULT_ACCOUNT_HASH),
+        TransformKindV2::Ret(RetValue::Unit),
+    );
+
+    assert_eq!(ep_calls_and_rets, vec![call, session_return]);
+}
+
 fn get_contract_package_and_wasms(
     state_hash: Digest,
     global_state: &LmdbGlobalState,
@@ -2065,4 +2391,20 @@ fn expect_message_on_topic_and_index(
     );
     let message_checksum = message.checksum().unwrap();
     assert_eq!(got_message_checksum, message_checksum);
+}
+
+fn get_ep_calls_and_rets(transforms: &[TransformV2]) -> Vec<TransformV2> {
+    transforms
+        .into_iter()
+        .filter(|transform| {
+            matches!(
+                transform.kind(),
+                casper_types::execution::TransformKindV2::EntryPointCalled(_, _)
+            ) || matches!(
+                transform.kind(),
+                casper_types::execution::TransformKindV2::Ret(_)
+            )
+        })
+        .map(|el| el.clone())
+        .collect()
 }

--- a/executor/wasm_host/src/host.rs
+++ b/executor/wasm_host/src/host.rs
@@ -221,7 +221,7 @@ pub fn casper_ffi<S: GlobalStateReader + 'static>(
             }
         },
         FFIMenu::IO(io_methods) => match io_methods {
-            IOMethods::Return => host_return(&mut caller, input_data).map(|code| (None, code)),
+            IOMethods::Return => host_return(input_data).map(|code| (None, code)),
             IOMethods::CopyInput => host_copy_input(&mut caller),
         },
     }?;

--- a/executor/wasm_host/src/host/global_state.rs
+++ b/executor/wasm_host/src/host/global_state.rs
@@ -821,14 +821,13 @@ pub(crate) fn host_create<S: GlobalStateReader + 'static>(
                 .get_remaining_points()?
                 .try_into_remaining()
                 .map_err(|_| FatalHostError::TypeConversion)?;
-
             let execute_request = ExecuteRequestBuilder::default()
                 .with_initiator(caller.context().initiator)
                 .with_caller_key(caller.context().callee)
                 .with_gas_limit(gas_limit)
                 .with_execution_kind(ExecutionKind::Stored {
                     address: package_addr,
-                    entry_point: entry_point_name.clone(),
+                    entry_point: entry_point_name,
                 })
                 .with_input(constructor_data.unwrap_or_default())
                 .with_transferred_value(transferred_value)

--- a/executor/wasm_host/src/host/io.rs
+++ b/executor/wasm_host/src/host/io.rs
@@ -5,17 +5,11 @@ use casper_executor_wasm_common::{
 };
 use casper_executor_wasm_interface::{executor::ExecuteError, Caller, VMError, VMResult};
 use casper_storage::global_state::GlobalStateReader;
-use casper_types::{
-    bytesrepr::{self, Bytes as BytesreprBytes},
-    execution::RetValue,
-};
+use casper_types::bytesrepr::{self, Bytes as BytesreprBytes};
 
 use crate::context::Context;
 
-pub(crate) fn host_return<S: GlobalStateReader + 'static>(
-    caller: &mut impl Caller<Context = Context<S>>,
-    input: Bytes,
-) -> VMResult<u32> {
+pub(crate) fn host_return(input: Bytes) -> VMResult<u32> {
     let (flags, data) =
         match bytesrepr::deserialize_from_slice::<&Bytes, (u32, Option<BytesreprBytes>)>(&input) {
             Ok(res) => res,
@@ -34,14 +28,6 @@ pub(crate) fn host_return<S: GlobalStateReader + 'static>(
     };
 
     let data = data.map(|data| Bytes::from(data.take_inner()));
-    if let Some(data) = &data {
-        let key = caller.context().callee;
-        let bytes = casper_types::bytesrepr::Bytes::from(data.to_vec());
-        caller
-            .context_mut()
-            .tracking_copy
-            .ret(key, RetValue::Bytes(bytes));
-    }
     Err(VMError::Return { flags, data })
 }
 

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -3717,6 +3717,39 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "Registers an entry point called. If the hash addr is none that means that the call was made to session bytes.",
+          "type": "object",
+          "required": [
+            "EntryPointCalled"
+          ],
+          "properties": {
+            "EntryPointCalled": {
+              "type": "array",
+              "items": [
+                {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
+                  "maxItems": 32,
+                  "minItems": 32
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -5038,6 +5071,12 @@
     "RetValue": {
       "description": "Type disambiguating between the formatting of the returned data.",
       "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Unit"
+          ]
+        },
         {
           "description": "The returned data is CLValue.",
           "type": "object",

--- a/smart_contracts/contracts/test/do-nothing-stored-caller-stored/Cargo.toml
+++ b/smart_contracts/contracts/test/do-nothing-stored-caller-stored/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "do-nothing-stored-caller-stored"
+version = "0.1.0"
+authors = ["Jakub Zajkowski <jakub@casper.network>"]
+edition = "2021"
+
+[[bin]]
+name = "do_nothing_stored_caller_stored"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[dependencies]
+casper-contract = { path = "../../../contract" }
+casper-types = { path = "../../../../types" }

--- a/smart_contracts/contracts/test/do-nothing-stored-caller-stored/src/main.rs
+++ b/smart_contracts/contracts/test/do-nothing-stored-caller-stored/src/main.rs
@@ -1,0 +1,49 @@
+#![no_std]
+#![no_main]
+
+use casper_contract::contract_api::{runtime, storage};
+use casper_types::{
+    addressable_entity::{EntityEntryPoint, EntryPoints, Parameters},
+    runtime_args, CLType, EntryPointAccess, EntryPointPayment, EntryPointType, Key,
+};
+
+const ENTRY_FUNCTION_NAME: &str = "call_stored";
+const HASH_KEY_NAME: &str = "do_nothing_stored_caller_stored_hash";
+const PACKAGE_HASH_KEY_NAME: &str = "do_nothing_caller_stored_package_hash";
+const ACCESS_KEY_NAME: &str = "do_nothing_stored_access";
+const CONTRACT_VERSION: &str = "contract_version";
+const ARG_CONTRACT_ADDR: &str = "contract_addr";
+
+#[no_mangle]
+pub extern "C" fn call_stored() {
+    let contract_hash: [u8; 32] = runtime::get_named_arg(ARG_CONTRACT_ADDR);
+    runtime::call_contract(contract_hash.into(), "delegate", runtime_args! {})
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let entry_points = {
+        let mut entry_points = EntryPoints::new();
+        let entry_point = EntityEntryPoint::new(
+            ENTRY_FUNCTION_NAME,
+            Parameters::new(),
+            CLType::Unit,
+            EntryPointAccess::Public,
+            EntryPointType::Called,
+            EntryPointPayment::Caller,
+        );
+        entry_points.add_entry_point(entry_point);
+        entry_points
+    };
+
+    let (contract_hash, contract_version) = storage::new_contract(
+        entry_points,
+        None,
+        Some(PACKAGE_HASH_KEY_NAME.into()),
+        Some(ACCESS_KEY_NAME.into()),
+        None,
+    );
+
+    runtime::put_key(CONTRACT_VERSION, storage::new_uref(contract_version).into());
+    runtime::put_key(HASH_KEY_NAME, Key::Hash(contract_hash.value()));
+}

--- a/smart_contracts/contracts/vm2/vm2-counter-caller/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-counter-caller/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vm2-counter-caller"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-contract-sdk = { path = "../../../vm2/sdk" }
+casper-contract-sdk-contrib = { path = "../../../vm2/sdk_contrib" }
+vm2-counter = { path = "../vm2-counter" }
+borsh = { version = "1.5", features = ["derive"] }

--- a/smart_contracts/contracts/vm2/vm2-counter-caller/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-counter-caller/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Check if target arch is wasm32 and set link flags accordingly
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        println!("cargo:rustc-link-arg=--import-memory");
+        println!("cargo:rustc-link-arg=--export-table");
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-counter-caller/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-counter-caller/src/lib.rs
@@ -1,0 +1,31 @@
+use casper_contract_sdk::{prelude::*, types::Address, ContractHandle};
+use vm2_counter::CounterRef;
+
+#[casper(contract_state)]
+pub struct CounterCallerContract {}
+
+#[casper]
+impl CounterCallerContract {
+    #[casper(constructor)]
+    pub fn create() -> Self {
+        Self {}
+    }
+
+    pub fn inc_and_get(&self, address: Address) -> u32 {
+        let handle = ContractHandle::<CounterRef>::from_address(address);
+        // Mint tokens, then check the balance of the account that called this contract
+        handle
+            .call(|contract| contract.increment())
+            .expect("Should call");
+
+        let counter = handle.call(|contract| contract.get()).expect("Should call");
+
+        counter
+    }
+}
+
+impl Default for CounterCallerContract {
+    fn default() -> Self {
+        panic!("nope");
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-do-nothing-session/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-do-nothing-session/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vm2-do-nothing-session"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-contract-sdk = { path = "../../../vm2/sdk" }
+casper-contract-sdk-contrib = { path = "../../../vm2/sdk_contrib" }

--- a/smart_contracts/contracts/vm2/vm2-do-nothing-session/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-do-nothing-session/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Check if target arch is wasm32 and set link flags accordingly
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        println!("cargo:rustc-link-arg=--import-memory");
+        println!("cargo:rustc-link-arg=--export-table");
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-do-nothing-session/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-do-nothing-session/src/lib.rs
@@ -1,0 +1,10 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
+pub mod exports {
+    use casper_contract_sdk::prelude::*;
+
+    #[casper(export)]
+    pub fn call() {
+        let _ = casper::print("hello!");
+    }
+}

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -2836,6 +2836,10 @@ where
                 // Ret transforms are not committed to global state.
                 continue;
             }
+            (_, TransformKindV2::EntryPointCalled(_, _)) => {
+                // EntryPointCalled transforms are not committed to global state.
+                continue;
+            }
             (ReadResult::NotFound, TransformKindV2::Write(new_value)) => {
                 TransformInstruction::store(new_value)
             }

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -40,7 +40,7 @@ use casper_types::{
     },
     global_state::TrieMerkleProof,
     handle_stored_dictionary_value, BlockGlobalAddr, BlockTime, CLType, CLValue, CLValueError,
-    Digest, Key, KeyTag, StoredValue, StoredValueTypeMismatch, U512,
+    Digest, HashAddr, Key, KeyTag, StoredValue, StoredValueTypeMismatch, U512,
 };
 
 use self::meter::{heap_meter::HeapSize, Meter};
@@ -596,6 +596,20 @@ where
         self.effects.push(TransformV2::new(
             normalized_key,
             TransformKindV2::Ret(value),
+        ));
+    }
+
+    /// Registers a contract entry point call
+    pub fn entry_point_called(
+        &mut self,
+        key: Key,
+        key_value: Option<HashAddr>,
+        entrypoint_name: String,
+    ) {
+        let normalized_key = key.normalize();
+        self.effects.push(TransformV2::new(
+            normalized_key,
+            TransformKindV2::EntryPointCalled(key_value, entrypoint_name),
         ));
     }
 

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file. The format 
 - in struct `WasmV2Config`:
   - field `host_ffi_opt_costs` (replacing `host_function_costs`)
 - type `HostFFIFunctionCosts` (which replaces `HostFunctionCostsV2`)
+- in enum TransformKindV2:
+  - new variant `EntryPointCalled`
 
 ### Changed
 

--- a/types/src/execution/ret_value.rs
+++ b/types/src/execution/ret_value.rs
@@ -21,6 +21,7 @@ pub enum RetValue {
     CLValue(CLValue),
     /// The returned data is serialized bytes.
     Bytes(Bytes),
+    Unit,
 }
 
 impl ToBytes for RetValue {
@@ -34,6 +35,7 @@ impl ToBytes for RetValue {
                 (RetValueTag::Bytes as u8).write_bytes(writer)?;
                 bytes.write_bytes(writer)
             }
+            RetValue::Unit => (RetValueTag::Unit as u8).write_bytes(writer),
         }
     }
 
@@ -48,6 +50,7 @@ impl ToBytes for RetValue {
             + match self {
                 RetValue::CLValue(bytes) => bytes.serialized_length(),
                 RetValue::Bytes(bytes) => bytes.serialized_length(),
+                RetValue::Unit => 0,
             }
     }
 }
@@ -64,6 +67,7 @@ impl FromBytes for RetValue {
                 let (bytes, remainder) = Bytes::from_bytes(remainder)?;
                 Ok((RetValue::Bytes(bytes), remainder))
             }
+            tag if tag == RetValueTag::Unit as u8 => Ok((RetValue::Unit, remainder)),
             _ => Err(bytesrepr::Error::Formatting),
         }
     }
@@ -73,4 +77,5 @@ impl FromBytes for RetValue {
 enum RetValueTag {
     CLValue = 0,
     Bytes = 1,
+    Unit = 2,
 }

--- a/types/src/execution/transform_kind.rs
+++ b/types/src/execution/transform_kind.rs
@@ -1,4 +1,7 @@
-use alloc::{string::ToString, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::{any, convert::TryFrom};
 
 #[cfg(feature = "datasize")]
@@ -16,7 +19,8 @@ use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     contracts::NamedKeys,
     execution::ret_value::RetValue,
-    CLType, CLTyped, CLValue, Key, StoredValue, StoredValueTypeMismatch, U128, U256, U512,
+    CLType, CLTyped, CLValue, HashAddr, Key, StoredValue, StoredValueTypeMismatch, U128, U256,
+    U512,
 };
 
 /// Taxonomy of Transform.
@@ -92,6 +96,9 @@ pub enum TransformKindV2 {
     Failure(TransformError),
     /// Registers a value return from the contract
     Ret(RetValue),
+    /// Registers an entry point called. If the hash addr is none that means that the call was
+    /// made to session bytes.
+    EntryPointCalled(Option<HashAddr>, String),
 }
 
 impl TransformKindV2 {
@@ -209,6 +216,7 @@ impl TransformKindV2 {
             },
             TransformKindV2::Failure(error) => Err(error),
             TransformKindV2::Ret(_) => Ok(store(stored_value)),
+            TransformKindV2::EntryPointCalled(_, _) => Ok(store(stored_value)),
         }
     }
 
@@ -260,6 +268,9 @@ impl ToBytes for TransformKindV2 {
                 TransformKindV2::Failure(error) => error.serialized_length(),
                 TransformKindV2::Prune(value) => value.serialized_length(),
                 TransformKindV2::Ret(value) => value.serialized_length(),
+                TransformKindV2::EntryPointCalled(addr, entry_point_name) => {
+                    addr.serialized_length() + entry_point_name.serialized_length()
+                }
             }
     }
 
@@ -305,6 +316,11 @@ impl ToBytes for TransformKindV2 {
             TransformKindV2::Ret(value) => {
                 (TransformTag::Ret as u8).write_bytes(writer)?;
                 value.write_bytes(writer)
+            }
+            TransformKindV2::EntryPointCalled(addr, entry_point_name) => {
+                (TransformTag::EntryPointCalled as u8).write_bytes(writer)?;
+                addr.write_bytes(writer)?;
+                entry_point_name.write_bytes(writer)
             }
         }
     }
@@ -361,6 +377,18 @@ impl FromBytes for TransformKindV2 {
             tag if tag == TransformTag::Prune as u8 => {
                 let (key, remainder) = Key::from_bytes(remainder)?;
                 Ok((TransformKindV2::Prune(key), remainder))
+            }
+            tag if tag == TransformTag::Ret as u8 => {
+                let (ret_val, remainder) = RetValue::from_bytes(remainder)?;
+                Ok((TransformKindV2::Ret(ret_val), remainder))
+            }
+            tag if tag == TransformTag::EntryPointCalled as u8 => {
+                let (addr, remainder) = Option::<HashAddr>::from_bytes(remainder)?;
+                let (entrypoint_name, remainder) = String::from_bytes(remainder)?;
+                Ok((
+                    TransformKindV2::EntryPointCalled(addr, entrypoint_name),
+                    remainder,
+                ))
             }
             _ => {
                 error!(%tag, rem_len = remainder.len(), "FromBytes for TransformKindV2: unknown tag");
@@ -434,6 +462,7 @@ enum TransformTag {
     Failure = 8,
     Prune = 9,
     Ret = 10,
+    EntryPointCalled = 11,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The node now produces:
* `TransformKindV2::EntryPointCalled` execute result whenever wasm session code or a contract attempts to do an entry point call. This also applies to VM2 constructor and upgrade method calls.
* `TransformKindV2::EntryPointCalled` is not stored to global state
* if an entry point call is successful there will be a `TransformKindV2::Ret(RetValue::Unit)` execution journal entry if the contract didn't call the `return` functionality on it's own.
* if a contract (or session code) called the `return` functionality and passed no output, there will be a `TransformKindV2::Ret(RetValue::Unit)` execution journal entry