### PR TITLE
Changes to EntryPointCalled journaling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,6 +7400,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "vm2-returner"
+version = "0.1.0"
+dependencies = [
+ "casper-contract-sdk",
+ "casper-contract-sdk-contrib",
+]
+
+[[package]]
+name = "vm2-returner-caller"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "casper-contract-sdk",
+ "casper-contract-sdk-contrib",
+]
+
+[[package]]
+name = "vm2-returner-proxy"
+version = "0.1.0"
+dependencies = [
+ "casper-contract-sdk",
+ "casper-contract-sdk-contrib",
+]
+
+[[package]]
 name = "vm2-system-caller"
 version = "0.1.0"
 dependencies = [

--- a/execution_engine/CHANGELOG.md
+++ b/execution_engine/CHANGELOG.md
@@ -32,17 +32,17 @@ All notable changes to this project will be documented in this file. The format 
 - Calling wasm adds additional execution journal entries. For each session execution there will be a corresponding pair of TransformKindV2::EntryPointCalled and TransformKindV2::Ret written:
    - For session bytes:
       - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
-      - The `Option<HashAddr>` of `EntryPointCalled` will be `None`
+      - The `Key` of `EntryPointCalled` will be the Account of the caller
       - The `String` of `EntryPointCalled` will be `"call"` (the default function name we expect of session wasm)
       - The `Ret` will either be `RetValue::Unit` or `RetValue::CLValue` depending on wether or not the code called `casper_return`.
    - If a session call calls a stored contracts entrypoint:
       - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
-      - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+      - The `Key` of `EntryPointCalled` will be the key of the contract that holds the called entry point
       - The `String` of `EntryPointCalled` will be the name of the called entrypoint
       - The `Ret` will either be `RetValue::Unit` or `RetValue::CLValue` depending on wether or not the code called `casper_return`.
    - If a stored contract calls another stored contract:
       - the key under which both transforms will be stored is the key of the contract which is executing the call.
-      - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+      - The `Key` of `EntryPointCalled` will be the key of the contract that holds the called entry point
       - The `String` of `EntryPointCalled` will be the name of the called entrypoint
       - The `Ret` will either be `RetValue::Unit` or `RetValue::CLValue` depending on wether or not the code called `casper_return`.
     - the above also applies to `payment` bytecode if supplied

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -1455,9 +1455,10 @@ where
         let protocol_version = self.context.protocol_version();
         let engine_config = self.context.engine_config();
         let wasm_config = engine_config.wasm_config();
+        let context_key = self.context.get_context_key();
         self.context.state().borrow_mut().entry_point_called(
+            context_key,
             self.context.get_context_key(),
-            None,
             DEFAULT_ENTRY_POINT_NAME.to_string(),
         );
         #[cfg(feature = "test-support")]
@@ -1755,7 +1756,7 @@ where
         entry_point_name: &str,
         args: RuntimeArgs,
     ) -> Result<CLValue, ExecError> {
-        let (footprint, entity_addr, package) = match identifier {
+        let (footprint, entity_addr, package, contract_key) = match identifier {
             CallContractIdentifier::Contract { contract_hash } => {
                 let entity_addr = if self.context.is_system_addressable_entity(&contract_hash)? {
                     EntityAddr::new_system(contract_hash)
@@ -1812,7 +1813,13 @@ where
                     return Err(ExecError::DisabledEntity(entity_hash));
                 }
 
-                (footprint, entity_addr, package)
+                let contract_key = if self.context.engine_config().enable_entity {
+                    Key::AddressableEntity(entity_addr)
+                } else {
+                    Key::Hash(contract_hash)
+                };
+
+                (footprint, entity_addr, package, contract_key)
             }
             CallContractIdentifier::ContractPackage {
                 contract_package_hash,
@@ -1896,14 +1903,18 @@ where
                         )
                     }
                 };
-
-                (footprint, entity_addr, package)
+                let contract_key = if self.context.engine_config().enable_entity {
+                    Key::AddressableEntity(entity_addr)
+                } else {
+                    Key::Hash(hash_addr)
+                };
+                (footprint, entity_addr, package, contract_key)
             }
         };
 
         self.context.state().borrow_mut().entry_point_called(
             self.context.get_context_key(),
-            Some(entity_addr.value()),
+            contract_key,
             entry_point_name.to_string(),
         );
 

--- a/execution_engine_testing/tests/src/test/entry_point_called.rs
+++ b/execution_engine_testing/tests/src/test/entry_point_called.rs
@@ -42,7 +42,10 @@ fn vm1_do_nothing_session_should_not_return_entry_point_called() {
         assert_eq!(ep_calls_and_rets.len(), 2);
         let call_called = TransformV2::new(
             Key::Account(*DEFAULT_ACCOUNT_ADDR),
-            TransformKindV2::EntryPointCalled(None, DEFAULT_ENTRY_POINT_NAME.to_string()),
+            TransformKindV2::EntryPointCalled(
+                Key::Account(*DEFAULT_ACCOUNT_ADDR),
+                DEFAULT_ENTRY_POINT_NAME.to_string(),
+            ),
         );
         let ret = TransformV2::new(
             Key::Account(*DEFAULT_ACCOUNT_ADDR),
@@ -182,7 +185,7 @@ where
     assert_eq!(ep_calls_and_rets.len(), 2);
     let delegate_called = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_ADDR),
-        TransformKindV2::EntryPointCalled(Some(contract_hash), "delegate".to_string()),
+        TransformKindV2::EntryPointCalled(Key::Hash(contract_hash), "delegate".to_string()),
     );
     let delegate_ret = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_ADDR),
@@ -225,7 +228,7 @@ fn vm1_do_nothing_stored_should_return_entry_point_called() {
     assert_eq!(ep_calls_and_rets.len(), 2);
     let delegate_called = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_ADDR),
-        TransformKindV2::EntryPointCalled(Some(contract_hash), "delegate".to_string()),
+        TransformKindV2::EntryPointCalled(Key::Hash(contract_hash), "delegate".to_string()),
     );
     let delegate_ret = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_ADDR),
@@ -293,11 +296,11 @@ fn vm1_nested_call_should_produce_entry_point_calls_and_rets() {
     assert_eq!(ep_calls_and_rets.len(), 4);
     let caller_called = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_ADDR),
-        TransformKindV2::EntryPointCalled(Some(caller_hash), "call_stored".to_string()),
+        TransformKindV2::EntryPointCalled(Key::Hash(caller_hash), "call_stored".to_string()),
     );
     let delegate_called = TransformV2::new(
         Key::Hash(caller_hash),
-        TransformKindV2::EntryPointCalled(Some(contract_hash), "delegate".to_string()),
+        TransformKindV2::EntryPointCalled(Key::Hash(contract_hash), "delegate".to_string()),
     );
     let delegate_ret =
         TransformV2::new(Key::Hash(caller_hash), TransformKindV2::Ret(RetValue::Unit));

--- a/executor/wasm/CHANGELOG.md
+++ b/executor/wasm/CHANGELOG.md
@@ -21,16 +21,16 @@ All notable changes to this project will be documented in this file. The format 
 - Calling wasm adds additional execution journal entries. For each session execution there will be a corresponding pair of TransformKindV2::EntryPointCalled and TransformKindV2::Ret written:
   - For session bytes:
     - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
-    - The `Option<HashAddr>` of `EntryPointCalled` will be `None`
+    - The `Key` of `EntryPointCalled` will be the Account of the caller
     - The `String` of `EntryPointCalled` will be `"call"` (the default function name we expect of session wasm)
     - The `Ret` will either be `RetValue::Unit` or `RetValue::Bytes` depending on wether or not the code called `casper_return`.
   - If a session call calls a stored contracts entrypoint:
     - the key under which both transforms will be stored is the Key::Account that initiated the transaction.
-    - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+    - The `Key` of `EntryPointCalled` will be the key of the contract that holds the called entry point
     - The `String` of `EntryPointCalled` will be the name of the called entrypoint
     - The `Ret` will either be `RetValue::Unit` or `RetValue::Bytes` depending on wether or not the code called `casper_return`.
   - If a stored contract calls another stored contract:
     - the key under which both transforms will be stored is the key of the contract which is executing the call.
-    - The `Option<HashAddr>` of `EntryPointCalled` will be `Some(<called_contract_hash>)`
+    - The `Key` of `EntryPointCalled` will be the key of the contract that holds the called entry point
     - The `String` of `EntryPointCalled` will be the name of the called entrypoint
     - The `Ret` will either be `RetValue::Unit` or `RetValue::Bytes` depending on wether or not the code called `casper_return`.

--- a/executor/wasm/src/install.rs
+++ b/executor/wasm/src/install.rs
@@ -7,8 +7,8 @@ use casper_storage::{
     global_state::error::Error as GlobalStateError, AddressGenerator, RuntimeNativeConfig,
 };
 use casper_types::{
-    account::AccountHash, execution::Effects, BlockHash, BlockTime, CLValueError, Digest,
-    TransactionHash,
+    account::AccountHash, contract_messages::Messages, execution::Effects, BlockHash, BlockTime,
+    CLValueError, Digest, TransactionHash,
 };
 use parking_lot::RwLock;
 use thiserror::Error;
@@ -216,6 +216,8 @@ pub struct InstallContractResult {
     pub(crate) effects: Effects,
     /// Post state hash after installation.
     pub(crate) post_state_hash: Digest,
+    /// Messages emitted during execution
+    pub(crate) messages: Messages,
 }
 
 impl InstallContractResult {
@@ -233,6 +235,10 @@ impl InstallContractResult {
 
     pub fn smart_contract_addr(&self) -> &[u8; 32] {
         &self.smart_contract_addr
+    }
+
+    pub fn messages(&self) -> &Messages {
+        &self.messages
     }
 }
 

--- a/executor/wasm/src/lib.rs
+++ b/executor/wasm/src/lib.rs
@@ -521,6 +521,7 @@ impl ExecutorV2 {
         };
 
         let effects = tracking_copy.effects();
+        let messages = tracking_copy.messages();
 
         match state_provider.commit_effects(state_root_hash, effects.clone()) {
             Ok(post_state_hash) => Ok(InstallContractResult {
@@ -528,6 +529,7 @@ impl ExecutorV2 {
                 gas_usage: ctor_gas_usage,
                 effects,
                 post_state_hash,
+                messages,
             }),
             Err(error) => Err(InstallContractError::GlobalState(error)),
         }
@@ -966,7 +968,7 @@ impl ExecutorV2 {
         let mut initial_tracking_copy = tracking_copy.fork2();
 
         // Derive callee key from the execution target.
-        let (callee_key, entry_point_name, contract_addr) = match &execution_kind {
+        let (callee_key, entry_point_name) = match &execution_kind {
             ExecutionKind::Stored {
                 address: smart_contract_package_addr,
                 entry_point,
@@ -977,19 +979,18 @@ impl ExecutorV2 {
                 } else {
                     Key::Hash(*smart_contract_package_addr)
                 };
-                (key, entry_point.clone(), Some(*smart_contract_package_addr))
+                (key, entry_point.clone())
             }
             ExecutionKind::SessionBytes(_wasm_bytes) => (
                 Key::Account(initiator),
                 DEFAULT_WASM_ENTRY_POINT.to_string(),
-                None,
             ),
             ExecutionKind::System(_) => {
                 error!("System executions are not called in this way. This should be unreachable.");
                 return Err(ExecuteError::Fatal(FatalHostError::DispatchSystemContract));
             }
         };
-        tracking_copy.entry_point_called(caller_key, contract_addr, entry_point_name);
+        tracking_copy.entry_point_called(caller_key, callee_key, entry_point_name);
         let ffi_call_costs = self.build_ffi_call_costs(&self.config);
         let context = Context {
             initiator,

--- a/executor/wasm/tests/integration.rs
+++ b/executor/wasm/tests/integration.rs
@@ -2048,14 +2048,14 @@ fn calling_upgrade_contract_should_produce_ret_and_call_result() {
     let expected_call_1 = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_HASH),
         TransformKindV2::EntryPointCalled(
-            Some(*create_result.smart_contract_addr()),
+            Key::Hash(*create_result.smart_contract_addr()),
             "perform_upgrade".to_string(),
         ),
     );
     let expected_call_2 = TransformV2::new(
         Key::Hash(*create_result.smart_contract_addr()),
         TransformKindV2::EntryPointCalled(
-            Some(*create_result.smart_contract_addr()),
+            Key::Hash(*create_result.smart_contract_addr()),
             "migrate".to_string(),
         ),
     );
@@ -2112,7 +2112,7 @@ fn calling_constructor_method_should_produce_ret_and_call_result() {
     let constructor_called = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_HASH),
         TransformKindV2::EntryPointCalled(
-            Some(*create_result.smart_contract_addr()),
+            Key::Hash(*create_result.smart_contract_addr()),
             "default".to_string(),
         ),
     );
@@ -2223,14 +2223,14 @@ fn contract_calling_different_contract_should_produce_ret_and_call_result() {
     let inc_and_get_call = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_HASH),
         TransformKindV2::EntryPointCalled(
-            Some(*caller_create_result.smart_contract_addr()),
+            Key::Hash(*caller_create_result.smart_contract_addr()),
             "inc_and_get".to_string(),
         ),
     );
     let increment_call = TransformV2::new(
         Key::Hash(*caller_create_result.smart_contract_addr()),
         TransformKindV2::EntryPointCalled(
-            Some(*counter_create_result.smart_contract_addr()),
+            Key::Hash(*counter_create_result.smart_contract_addr()),
             "increment".to_string(),
         ),
     );
@@ -2241,7 +2241,7 @@ fn contract_calling_different_contract_should_produce_ret_and_call_result() {
     let get_call = TransformV2::new(
         Key::Hash(*caller_create_result.smart_contract_addr()),
         TransformKindV2::EntryPointCalled(
-            Some(*counter_create_result.smart_contract_addr()),
+            Key::Hash(*counter_create_result.smart_contract_addr()),
             "get".to_string(),
         ),
     );
@@ -2307,7 +2307,10 @@ fn calling_session_should_produce_entry_point_called_and_ret() {
     assert_eq!(ep_calls_and_rets.len(), 2);
     let call = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_HASH),
-        TransformKindV2::EntryPointCalled(None, DEFAULT_ENTRY_POINT_NAME.to_string()),
+        TransformKindV2::EntryPointCalled(
+            Key::Account(*DEFAULT_ACCOUNT_HASH),
+            DEFAULT_ENTRY_POINT_NAME.to_string(),
+        ),
     );
     let session_return = TransformV2::new(
         Key::Account(*DEFAULT_ACCOUNT_HASH),

--- a/node/src/components/contract_runtime/operations/wasm_v2_request.rs
+++ b/node/src/components/contract_runtime/operations/wasm_v2_request.rs
@@ -23,9 +23,9 @@ use casper_storage::{
     AddressGeneratorBuilder,
 };
 use casper_types::{
-    bytesrepr::ToBytes, execution::Effects, BlockHash, Digest, Gas, Key, TransactionArgs,
-    TransactionEntryPoint, TransactionInvocationTarget, TransactionRuntimeParams,
-    TransactionTarget, U512,
+    bytesrepr::ToBytes, contract_messages::Messages, execution::Effects, BlockHash, Digest, Gas,
+    Key, TransactionArgs, TransactionEntryPoint, TransactionInvocationTarget,
+    TransactionRuntimeParams, TransactionTarget, U512,
 };
 use thiserror::Error;
 use tracing::info;
@@ -44,7 +44,7 @@ pub(crate) enum WasmV2Request {
 pub(crate) enum WasmV2Result {
     /// The result of installing a Wasm contract.
     Install(InstallContractResult),
-    /// The result of executing a Wasm contract.
+    /// Messages produced by the execution.
     Execute(ExecuteWithProviderResult),
 }
 
@@ -77,6 +77,15 @@ impl WasmV2Result {
             WasmV2Result::Install(_) => None,
             WasmV2Result::Execute(execute_with_provider_result) => {
                 execute_with_provider_result.host_error.as_ref()
+            }
+        }
+    }
+
+    pub(crate) fn messages(&self) -> &Messages {
+        match self {
+            WasmV2Result::Install(install_contract_result) => install_contract_result.messages(),
+            WasmV2Result::Execute(execute_with_provider_result) => {
+                execute_with_provider_result.messages()
             }
         }
     }

--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -505,6 +505,7 @@ impl ExecutionArtifactBuilder {
         // TODO: Use system message to notify about contract hash
 
         self.with_appended_effects(result.effects().clone());
+        self.with_appended_messages(&mut result.messages().clone());
 
         self
     }

--- a/resources/devnet/chainspec.toml
+++ b/resources/devnet/chainspec.toml
@@ -199,7 +199,7 @@ max_timestamp_leeway = '5 seconds'
 # Configuration of the transaction runtime.
 [transactions.enabled_runtime]
 vm_casper_v1 = true
-vm_casper_v2 = true
+vm_casper_v2 = false
 
 [transactions.v1]
 # The configuration settings for the lanes of transactions including both native and Wasm based interactions.

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -3719,7 +3719,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Registers an entry point called. If the hash addr is none that means that the call was made to session bytes.",
+          "description": "Registers an entry point called.",
           "type": "object",
           "required": [
             "EntryPointCalled"
@@ -3729,17 +3729,7 @@
               "type": "array",
               "items": [
                 {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "items": {
-                    "type": "integer",
-                    "format": "uint8",
-                    "minimum": 0.0
-                  },
-                  "maxItems": 32,
-                  "minItems": 32
+                  "$ref": "#/definitions/Key"
                 },
                 {
                   "type": "string"

--- a/smart_contracts/contracts/vm2/vm2-returner-caller/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-returner-caller/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vm2-returner-caller"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-contract-sdk = { path = "../../../vm2/sdk" }
+casper-contract-sdk-contrib = { path = "../../../vm2/sdk_contrib" }
+borsh = { version = "1.5", features = ["derive"] }

--- a/smart_contracts/contracts/vm2/vm2-returner-caller/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner-caller/build.rs
@@ -1,0 +1,20 @@
+// use std::{env, fs, path::Path};
+
+// use casper_contract_sdk_codegen::Codegen;
+
+// const SCHEMA: &str = include_str!("cep18_schema.json");
+
+fn main() {
+    // Check if target arch is wasm32 and set link flags accordingly
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        println!("cargo:rustc-link-arg=--import-memory");
+        println!("cargo:rustc-link-arg=--export-table");
+    }
+
+    // let mut codegen = Codegen::from_str(SCHEMA).unwrap();
+    // let source = codegen.gen();
+
+    // let target_dir = env::var_os("OUT_DIR").unwrap();
+    // let target_path = Path::new(&target_dir).join("cep18_schema.rs");
+    // fs::write(&target_path, source).unwrap();
+}

--- a/smart_contracts/contracts/vm2/vm2-returner-caller/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner-caller/src/lib.rs
@@ -1,0 +1,17 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
+pub mod exports {
+    use casper_contract_sdk::{prelude::*, types::Address};
+
+    #[casper(export)]
+    pub fn call(address: Address) {
+        let _ = casper::print(&format!("trying to call address {:?}", address));
+
+        casper::casper_call(&address, 0, "do_return", &[])
+            .1
+            .unwrap();
+        casper::casper_call(&address, 0, "do_not_return", &[])
+            .1
+            .unwrap();
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-returner-proxy/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-returner-proxy/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vm2-returner-proxy"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-contract-sdk = { path = "../../../vm2/sdk" }
+casper-contract-sdk-contrib = { path = "../../../vm2/sdk_contrib" }

--- a/smart_contracts/contracts/vm2/vm2-returner-proxy/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner-proxy/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Check if target arch is wasm32 and set link flags accordingly
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        println!("cargo:rustc-link-arg=--import-memory");
+        println!("cargo:rustc-link-arg=--export-table");
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-returner-proxy/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner-proxy/src/lib.rs
@@ -1,0 +1,37 @@
+use casper_contract_sdk::{prelude::*, serializers::borsh, types::Address};
+#[casper(contract_state)]
+pub struct ReturnerProxyContract {
+    address: Address,
+}
+
+impl Default for ReturnerProxyContract {
+    fn default() -> Self {
+        panic!("nope");
+    }
+}
+
+#[casper]
+impl ReturnerProxyContract {
+    #[casper(constructor)]
+    pub fn new(address: Address) -> Self {
+        Self { address }
+    }
+
+    pub fn do_return(&self) -> u32 {
+        let _ = casper::print(&format!(
+            "Proxy trying to call do_return, address: {:?}",
+            self.address
+        ));
+        let (data, res) = casper::casper_call(&self.address, 0, "do_return", &[]);
+        res.unwrap();
+        borsh::from_slice(&data.unwrap()).unwrap()
+    }
+
+    pub fn do_not_return(&self) {
+        let _ = casper::print(&format!(
+            "Proxy trying to call do_not_return, address: {:?}",
+            self.address
+        ));
+        _ = casper::casper_call(&self.address, 0, "do_not_return", &[]);
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-returner/Cargo.toml
+++ b/smart_contracts/contracts/vm2/vm2-returner/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vm2-returner"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+casper-contract-sdk = { path = "../../../vm2/sdk" }
+casper-contract-sdk-contrib = { path = "../../../vm2/sdk_contrib" }

--- a/smart_contracts/contracts/vm2/vm2-returner/build.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Check if target arch is wasm32 and set link flags accordingly
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        println!("cargo:rustc-link-arg=--import-memory");
+        println!("cargo:rustc-link-arg=--export-table");
+    }
+}

--- a/smart_contracts/contracts/vm2/vm2-returner/src/lib.rs
+++ b/smart_contracts/contracts/vm2/vm2-returner/src/lib.rs
@@ -1,0 +1,27 @@
+use casper_contract_sdk::prelude::*;
+
+#[casper(contract_state)]
+pub struct ReturnerContract {}
+
+impl Default for ReturnerContract {
+    fn default() -> Self {
+        panic!("nope");
+    }
+}
+
+#[casper]
+impl ReturnerContract {
+    #[casper(constructor)]
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn do_return(&self) -> u32 {
+        let _ = casper::print(&format!("returning"));
+        123
+    }
+
+    pub fn do_not_return(&self) {
+        let _ = casper::print("not returning");
+    }
+}

--- a/storage/src/tracking_copy/mod.rs
+++ b/storage/src/tracking_copy/mod.rs
@@ -40,7 +40,7 @@ use casper_types::{
     },
     global_state::TrieMerkleProof,
     handle_stored_dictionary_value, BlockGlobalAddr, BlockTime, CLType, CLValue, CLValueError,
-    Digest, HashAddr, Key, KeyTag, StoredValue, StoredValueTypeMismatch, U512,
+    Digest, Key, KeyTag, StoredValue, StoredValueTypeMismatch, U512,
 };
 
 use self::meter::{heap_meter::HeapSize, Meter};
@@ -602,14 +602,14 @@ where
     /// Registers a contract entry point call
     pub fn entry_point_called(
         &mut self,
-        key: Key,
-        key_value: Option<HashAddr>,
+        context_key: Key,
+        entrypoint_holder: Key,
         entrypoint_name: String,
     ) {
-        let normalized_key = key.normalize();
+        let normalized_key = context_key.normalize();
         self.effects.push(TransformV2::new(
             normalized_key,
-            TransformKindV2::EntryPointCalled(key_value, entrypoint_name),
+            TransformKindV2::EntryPointCalled(entrypoint_holder, entrypoint_name),
         ));
     }
 

--- a/types/src/execution/transform_kind.rs
+++ b/types/src/execution/transform_kind.rs
@@ -19,8 +19,7 @@ use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     contracts::NamedKeys,
     execution::ret_value::RetValue,
-    CLType, CLTyped, CLValue, HashAddr, Key, StoredValue, StoredValueTypeMismatch, U128, U256,
-    U512,
+    CLType, CLTyped, CLValue, Key, StoredValue, StoredValueTypeMismatch, U128, U256, U512,
 };
 
 /// Taxonomy of Transform.
@@ -96,9 +95,8 @@ pub enum TransformKindV2 {
     Failure(TransformError),
     /// Registers a value return from the contract
     Ret(RetValue),
-    /// Registers an entry point called. If the hash addr is none that means that the call was
-    /// made to session bytes.
-    EntryPointCalled(Option<HashAddr>, String),
+    /// Registers an entry point called.
+    EntryPointCalled(Key, String),
 }
 
 impl TransformKindV2 {
@@ -383,10 +381,10 @@ impl FromBytes for TransformKindV2 {
                 Ok((TransformKindV2::Ret(ret_val), remainder))
             }
             tag if tag == TransformTag::EntryPointCalled as u8 => {
-                let (addr, remainder) = Option::<HashAddr>::from_bytes(remainder)?;
+                let (key, remainder) = Key::from_bytes(remainder)?;
                 let (entrypoint_name, remainder) = String::from_bytes(remainder)?;
                 Ok((
-                    TransformKindV2::EntryPointCalled(addr, entrypoint_name),
+                    TransformKindV2::EntryPointCalled(key, entrypoint_name),
                     remainder,
                 ))
             }


### PR DESCRIPTION
This PR changes the following:
* Added `vm2-returner` contract
* Added `vm2-proxy` contract
* Added `vm2-returner-caller` contract
* TransformKindV2::EntryPointCalled now holds (Key, String)
* Fixed bug which caused system messages emitted from VM2 to not get propagated to SSE
