### PR TITLE
[BUGFIX] Fix incorrect setting of delegator min max limits on validator bids

### DIFF
--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -1102,6 +1102,8 @@ where
                         minimum_bid_amount,
                         max_delegators_per_validator,
                         reserved_slots,
+                        global_minimum_delegation_amount,
+                        global_maximum_delegation_amount,
                     )
                     .map_err(Self::reverter)?;
 

--- a/execution_engine/src/runtime/mod.rs
+++ b/execution_engine/src/runtime/mod.rs
@@ -1066,23 +1066,15 @@ where
                 let minimum_delegation_amount = Self::try_get_named_argument(
                     runtime_args,
                     auction::ARG_MINIMUM_DELEGATION_AMOUNT,
-                )?
-                .unwrap_or(global_minimum_delegation_amount);
+                )?;
 
                 let global_maximum_delegation_amount =
                     self.context.engine_config().maximum_delegation_amount();
                 let maximum_delegation_amount = Self::try_get_named_argument(
                     runtime_args,
                     auction::ARG_MAXIMUM_DELEGATION_AMOUNT,
-                )?
-                .unwrap_or(global_maximum_delegation_amount);
+                )?;
 
-                if minimum_delegation_amount < global_minimum_delegation_amount
-                    || maximum_delegation_amount > global_maximum_delegation_amount
-                    || minimum_delegation_amount > maximum_delegation_amount
-                {
-                    return Err(ExecError::Revert(ApiError::InvalidDelegationAmountLimits));
-                }
                 let reserved_slots =
                     Self::try_get_named_argument(runtime_args, auction::ARG_RESERVED_SLOTS)?
                         .unwrap_or(0);

--- a/execution_engine_testing/test_support/src/transfer_request_builder.rs
+++ b/execution_engine_testing/test_support/src/transfer_request_builder.rs
@@ -55,6 +55,7 @@ impl TransferRequestBuilder {
         0,
         500_000_000_000,
         500_000_000_000,
+        1_000_000_000_000_000_000,
         DEFAULT_GAS_HOLD_INTERVAL.millis(),
         false,
         Ratio::new_raw(U512::zero(), U512::zero()),
@@ -196,7 +197,12 @@ impl TransferRequestBuilder {
                         .to_bytes()
                         .unwrap(),
                 );
-                hasher.update(self.config.minimum_delegation_amount().to_bytes().unwrap());
+                hasher.update(
+                    self.config
+                        .global_minimum_delegation_amount()
+                        .to_bytes()
+                        .unwrap(),
+                );
                 hasher.update(self.state_hash);
                 hasher.update(self.block_time.to_bytes().unwrap());
                 hasher.update(self.protocol_version.to_bytes().unwrap());

--- a/execution_engine_testing/test_support/src/wasm_test_builder.rs
+++ b/execution_engine_testing/test_support/src/wasm_test_builder.rs
@@ -824,6 +824,7 @@ where
         let max_delegators_per_validator = config.core_config.max_delegators_per_validator;
         let minimum_bid_amount = config.core_config.minimum_bid_amount;
         let minimum_delegation_amount = config.core_config.minimum_delegation_amount;
+        let maximum_delegation_amount = config.core_config.maximum_delegation_amount;
         let balance_hold_interval = config.core_config.gas_hold_interval.millis();
         let include_credits = config.core_config.fee_handling == FeeHandling::NoFee;
         let credit_cap = Ratio::new_raw(
@@ -841,6 +842,7 @@ where
             max_delegators_per_validator,
             minimum_bid_amount,
             minimum_delegation_amount,
+            maximum_delegation_amount,
             balance_hold_interval,
             include_credits,
             credit_cap,
@@ -1010,6 +1012,7 @@ where
             self.chainspec.core_config.max_delegators_per_validator,
             self.chainspec.core_config.minimum_bid_amount,
             self.chainspec.core_config.minimum_delegation_amount,
+            self.chainspec.core_config.maximum_delegation_amount,
             self.chainspec.core_config.gas_hold_interval.millis(),
             include_credits,
             credit_cap,

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/bids.rs
@@ -21,7 +21,7 @@ use casper_execution_engine::{
     engine_state::{engine_config::DEFAULT_MINIMUM_DELEGATION_AMOUNT, Error},
     execution::ExecError,
 };
-use casper_storage::data_access_layer::{GenesisRequest, HandleFeeMode};
+use casper_storage::data_access_layer::{AuctionMethod, GenesisRequest, HandleFeeMode};
 
 use crate::lmdb_fixture;
 use casper_types::{
@@ -836,8 +836,8 @@ fn should_forcibly_undelegate_after_setting_validator_limits() {
             ARG_PUBLIC_KEY => NON_FOUNDER_VALIDATOR_1_PK.clone(),
             ARG_AMOUNT => U512::from(1_000),
             ARG_DELEGATION_RATE => ADD_BID_DELEGATION_RATE_1,
-            ARG_MINIMUM_DELEGATION_AMOUNT => DELEGATE_AMOUNT_2 + 1_000,
-            ARG_MAXIMUM_DELEGATION_AMOUNT => DELEGATE_AMOUNT_1 - 1_000,
+            ARG_MINIMUM_DELEGATION_AMOUNT => DELEGATE_AMOUNT_2 + 1_000,  // 100
+            ARG_MAXIMUM_DELEGATION_AMOUNT => DELEGATE_AMOUNT_1 - 1_000,  // 1000
         },
     )
     .build();
@@ -5960,4 +5960,135 @@ fn should_mark_bids_with_less_than_minimum_bid_amount_as_inactive_via_upgrade() 
         .expect("must have the validator bid record");
 
     assert!(bid.inactive())
+}
+
+#[ignore]
+#[test]
+fn should_correctly_allow_validator_to_change_delegator_min_max_limits() {
+    let validator_1_fund_request = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        runtime_args! {
+            ARG_TARGET => *NON_FOUNDER_VALIDATOR_1_ADDR,
+            ARG_AMOUNT => U512::from(TRANSFER_AMOUNT)
+        },
+    )
+    .build();
+
+    let mut builder = LmdbWasmTestBuilder::default();
+
+    builder.run_genesis(LOCAL_GENESIS_REQUEST.clone());
+
+    builder
+        .exec(validator_1_fund_request)
+        .expect_success()
+        .commit();
+
+    let result = builder.bidding(
+        None,
+        DEFAULT_PROTOCOL_VERSION,
+        (*NON_FOUNDER_VALIDATOR_1_ADDR).into(),
+        AuctionMethod::AddBid {
+            public_key: NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            delegation_rate: 10,
+            amount: U512::from(ADD_BID_AMOUNT_1),
+            minimum_delegation_amount: Some(DEFAULT_MINIMUM_DELEGATION_AMOUNT + 10),
+            maximum_delegation_amount: Some(DEFAULT_MAXIMUM_DELEGATION_AMOUNT - 10),
+            minimum_bid_amount: DEFAULT_MINIMUM_BID_AMOUNT,
+            reserved_slots: 0,
+        },
+    );
+
+    assert!(result.is_success());
+    builder.commit_transforms(builder.get_post_state_hash(), result.effects());
+    let validator_public_key = NON_FOUNDER_VALIDATOR_1_PK.clone();
+
+    let bid = builder
+        .get_bids()
+        .into_iter()
+        .find(|bid| bid.validator_public_key() == validator_public_key)
+        .expect("must have bid for the validator")
+        .as_validator_bid()
+        .expect("must get validator bid");
+
+    assert_eq!(
+        bid.minimum_delegation_amount(),
+        DEFAULT_MINIMUM_DELEGATION_AMOUNT + 10
+    );
+
+    let result = builder.bidding(
+        None,
+        DEFAULT_PROTOCOL_VERSION,
+        (*NON_FOUNDER_VALIDATOR_1_ADDR).into(),
+        AuctionMethod::AddBid {
+            public_key: NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            delegation_rate: 10,
+            amount: U512::from(ADD_BID_AMOUNT_1),
+            minimum_delegation_amount: Some(DEFAULT_MINIMUM_DELEGATION_AMOUNT + 5),
+            maximum_delegation_amount: None,
+            minimum_bid_amount: DEFAULT_MINIMUM_BID_AMOUNT,
+            reserved_slots: 0,
+        },
+    );
+
+    assert!(result.is_success());
+    builder.commit_transforms(builder.get_post_state_hash(), result.effects());
+
+    let validator_public_key = NON_FOUNDER_VALIDATOR_1_PK.clone();
+
+    let bid = builder
+        .get_bids()
+        .into_iter()
+        .find(|bid| bid.validator_public_key() == validator_public_key)
+        .expect("must have bid for the validator")
+        .as_validator_bid()
+        .expect("must get validator bid");
+
+    assert_eq!(
+        bid.minimum_delegation_amount(),
+        DEFAULT_MINIMUM_DELEGATION_AMOUNT + 5
+    );
+
+    assert_eq!(
+        bid.maximum_delegation_amount(),
+        DEFAULT_MAXIMUM_DELEGATION_AMOUNT - 10
+    );
+
+    let result = builder.bidding(
+        None,
+        DEFAULT_PROTOCOL_VERSION,
+        (*NON_FOUNDER_VALIDATOR_1_ADDR).into(),
+        AuctionMethod::AddBid {
+            public_key: NON_FOUNDER_VALIDATOR_1_PK.clone(),
+            delegation_rate: 10,
+            amount: U512::from(ADD_BID_AMOUNT_1),
+            minimum_delegation_amount: None,
+            maximum_delegation_amount: Some(DEFAULT_MAXIMUM_DELEGATION_AMOUNT - 5),
+            minimum_bid_amount: DEFAULT_MINIMUM_BID_AMOUNT,
+            reserved_slots: 0,
+        },
+    );
+
+    assert!(result.is_success());
+    builder.commit_transforms(builder.get_post_state_hash(), result.effects());
+
+    let validator_public_key = NON_FOUNDER_VALIDATOR_1_PK.clone();
+
+    let bid = builder
+        .get_bids()
+        .into_iter()
+        .find(|bid| bid.validator_public_key() == validator_public_key)
+        .expect("must have bid for the validator")
+        .as_validator_bid()
+        .expect("must get validator bid");
+
+    assert_eq!(
+        bid.minimum_delegation_amount(),
+        DEFAULT_MINIMUM_DELEGATION_AMOUNT + 5
+    );
+
+    assert_eq!(
+        bid.maximum_delegation_amount(),
+        DEFAULT_MAXIMUM_DELEGATION_AMOUNT - 5
+    );
 }

--- a/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/auction/distribute.rs
@@ -998,8 +998,8 @@ fn should_distribute_rewards_after_restaking_delegated_funds() {
                     public_key: VALIDATOR_1.clone(),
                     amount,
                     delegation_rate: 0,
-                    minimum_delegation_amount: undelegate_amount.as_u64(),
-                    maximum_delegation_amount: undelegate_amount.as_u64(),
+                    minimum_delegation_amount: Some(undelegate_amount.as_u64()),
+                    maximum_delegation_amount: Some(undelegate_amount.as_u64()),
                     minimum_bid_amount: DEFAULT_MINIMUM_BID_AMOUNT,
                     reserved_slots: 0,
                 }

--- a/node/src/reactor/main_reactor/tests/fixture.rs
+++ b/node/src/reactor/main_reactor/tests/fixture.rs
@@ -103,7 +103,7 @@ impl TestFixture {
             .map(|(secret_key, stake)| {
                 (
                     PublicKey::from(secret_key.as_ref()),
-                    (U512::from(100_000_000_000_000_000u64), stake),
+                    (U512::from(700_000_000_000_000_000u64), stake),
                 )
             })
             .collect();

--- a/storage/src/data_access_layer/auction.rs
+++ b/storage/src/data_access_layer/auction.rs
@@ -56,9 +56,11 @@ pub enum AuctionMethod {
         /// Bid amount.
         amount: U512,
         /// Minimum delegation amount for this validator bid.
-        minimum_delegation_amount: u64,
+        /// if provided by the user is set to Some
+        minimum_delegation_amount: Option<u64>,
         /// Maximum delegation amount for this validator bid.
-        maximum_delegation_amount: u64,
+        /// if provided by the user is set to Some
+        maximum_delegation_amount: Option<u64>,
         /// The minimum bid amount a validator must submit to have
         /// their bid considered as valid.
         minimum_bid_amount: u64,
@@ -145,12 +147,9 @@ impl AuctionMethod {
                 Err(AuctionMethodError::InvalidEntryPoint(entry_point))
             }
             TransactionEntryPoint::ActivateBid => Self::new_activate_bid(runtime_args),
-            TransactionEntryPoint::AddBid => Self::new_add_bid(
-                runtime_args,
-                chainspec.core_config.minimum_delegation_amount,
-                chainspec.core_config.maximum_delegation_amount,
-                chainspec.core_config.minimum_bid_amount,
-            ),
+            TransactionEntryPoint::AddBid => {
+                Self::new_add_bid(runtime_args, chainspec.core_config.minimum_bid_amount)
+            }
             TransactionEntryPoint::WithdrawBid => {
                 Self::new_withdraw_bid(runtime_args, chainspec.core_config.minimum_bid_amount)
             }
@@ -178,19 +177,15 @@ impl AuctionMethod {
 
     fn new_add_bid(
         runtime_args: &RuntimeArgs,
-        global_minimum_delegation: u64,
-        global_maximum_delegation: u64,
         global_minimum_bid_amount: u64,
     ) -> Result<Self, AuctionMethodError> {
         let public_key = Self::get_named_argument(runtime_args, auction::ARG_PUBLIC_KEY)?;
         let delegation_rate = Self::get_named_argument(runtime_args, auction::ARG_DELEGATION_RATE)?;
         let amount = Self::get_named_argument(runtime_args, auction::ARG_AMOUNT)?;
         let minimum_delegation_amount =
-            Self::get_named_argument(runtime_args, auction::ARG_MINIMUM_DELEGATION_AMOUNT)
-                .unwrap_or(global_minimum_delegation);
+            Self::try_get_named_argument(runtime_args, auction::ARG_MINIMUM_DELEGATION_AMOUNT)?;
         let maximum_delegation_amount =
-            Self::get_named_argument(runtime_args, auction::ARG_MAXIMUM_DELEGATION_AMOUNT)
-                .unwrap_or(global_maximum_delegation);
+            Self::try_get_named_argument(runtime_args, auction::ARG_MAXIMUM_DELEGATION_AMOUNT)?;
         let reserved_slots =
             Self::get_named_argument(runtime_args, auction::ARG_RESERVED_SLOTS).unwrap_or(0);
 
@@ -328,6 +323,25 @@ impl AuctionMethod {
             arg: name.to_string(),
             error,
         })
+    }
+
+    fn try_get_named_argument<T: FromBytes + CLTyped>(
+        args: &RuntimeArgs,
+        name: &str,
+    ) -> Result<Option<T>, AuctionMethodError> {
+        match args.get(name) {
+            Some(arg) => {
+                let arg = arg
+                    .clone()
+                    .into_t()
+                    .map_err(|error| AuctionMethodError::CLValue {
+                        arg: name.to_string(),
+                        error,
+                    })?;
+                Ok(Some(arg))
+            }
+            None => Ok(None),
+        }
     }
 }
 

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -1225,6 +1225,9 @@ pub trait StateProvider: Send + Sync + Sized {
         let address_generator = AddressGenerator::new(&id.seed(), phase);
         let max_delegators_per_validator = config.max_delegators_per_validator();
         let minimum_bid_amount = config.minimum_bid_amount();
+
+        let global_minimum_delegation_limit = config.global_minimum_delegation_amount();
+        let global_maximum_delegation_limit = config.global_maximum_delegation_amount();
         let mut runtime = RuntimeNative::new(
             config,
             protocol_version,
@@ -1264,6 +1267,8 @@ pub trait StateProvider: Send + Sync + Sized {
                     minimum_bid_amount,
                     max_delegators_per_validator,
                     reserved_slots,
+                    global_minimum_delegation_limit,
+                    global_maximum_delegation_limit,
                 )
                 .map(AuctionMethodRet::UpdatedAmount)
                 .map_err(TrackingCopyError::Api),

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -73,8 +73,8 @@ pub trait Auction:
         public_key: PublicKey,
         delegation_rate: DelegationRate,
         amount: U512,
-        minimum_delegation_amount: u64,
-        maximum_delegation_amount: u64,
+        minimum_delegation_amount: Option<u64>,
+        maximum_delegation_amount: Option<u64>,
         minimum_bid_amount: u64,
         max_delegators_per_validator: u32,
         reserved_slots: u32,
@@ -105,11 +105,16 @@ pub trait Auction:
             return Err(Error::InvalidContext.into());
         }
 
-        if minimum_delegation_amount < global_minimum_delegation_amount
-            || maximum_delegation_amount > global_maximum_delegation_amount
-            || minimum_delegation_amount > maximum_delegation_amount
-        {
-            return Err(ApiError::InvalidDelegationAmountLimits);
+        if let Some(minimum_delegation_amount) = minimum_delegation_amount {
+            if minimum_delegation_amount < global_minimum_delegation_amount {
+                return Err(ApiError::InvalidDelegationAmountLimits);
+            }
+        }
+
+        if let Some(maximum_delegation_amount) = maximum_delegation_amount {
+            if maximum_delegation_amount > global_maximum_delegation_amount {
+                return Err(ApiError::InvalidDelegationAmountLimits);
+            }
         }
 
         let validator_bid_key = BidAddr::from(public_key.clone()).into();
@@ -122,6 +127,15 @@ pub trait Auction:
             }
             // idempotent
             validator_bid.activate();
+
+            let minimum_delegation_amount =
+                minimum_delegation_amount.unwrap_or(validator_bid.minimum_delegation_amount());
+            let maximum_delegation_amount =
+                maximum_delegation_amount.unwrap_or(validator_bid.maximum_delegation_amount());
+
+            if maximum_delegation_amount < minimum_delegation_amount {
+                return Err(ApiError::InvalidDelegationAmountLimits);
+            }
 
             validator_bid.with_delegation_rate(delegation_rate);
             process_updated_delegator_stake_boundaries(
@@ -141,6 +155,15 @@ pub trait Auction:
             if amount < U512::from(minimum_bid_amount) {
                 return Err(Error::BondTooSmall.into());
             }
+            let minimum_delegation_amount =
+                minimum_delegation_amount.unwrap_or(global_minimum_delegation_amount);
+            let maximum_delegation_amount =
+                maximum_delegation_amount.unwrap_or(global_maximum_delegation_amount);
+
+            if maximum_delegation_amount < minimum_delegation_amount {
+                return Err(ApiError::InvalidDelegationAmountLimits);
+            }
+
             // create new validator bid
             let bonding_purse = self.create_purse()?;
             let validator_bid = ValidatorBid::unlocked(

--- a/storage/src/system/auction.rs
+++ b/storage/src/system/auction.rs
@@ -78,6 +78,8 @@ pub trait Auction:
         minimum_bid_amount: u64,
         max_delegators_per_validator: u32,
         reserved_slots: u32,
+        global_minimum_delegation_amount: u64,
+        global_maximum_delegation_amount: u64,
     ) -> Result<U512, ApiError> {
         if !self.allow_auction_bids() {
             // The validator set may be closed on some side chains,
@@ -102,6 +104,14 @@ pub trait Auction:
         if !self.is_allowed_session_caller(&provided_account_hash) {
             return Err(Error::InvalidContext.into());
         }
+
+        if minimum_delegation_amount < global_minimum_delegation_amount
+            || maximum_delegation_amount > global_maximum_delegation_amount
+            || minimum_delegation_amount > maximum_delegation_amount
+        {
+            return Err(ApiError::InvalidDelegationAmountLimits);
+        }
+
         let validator_bid_key = BidAddr::from(public_key.clone()).into();
         let (target, validator_bid) = if let Some(BidKind::Validator(mut validator_bid)) =
             self.read_bid(&validator_bid_key)?

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -1361,13 +1361,6 @@ pub fn process_updated_delegator_stake_boundaries<P: Auction>(
     minimum_delegation_amount: u64,
     maximum_delegation_amount: u64,
 ) -> Result<(), Error> {
-    // check modified delegation bookends
-    let raised_min = validator_bid.minimum_delegation_amount() < minimum_delegation_amount;
-    let lowered_max = validator_bid.maximum_delegation_amount() > maximum_delegation_amount;
-    if !raised_min && !lowered_max {
-        return Ok(());
-    }
-
     let era_end_timestamp_millis = get_era_end_timestamp_millis(provider)?;
     if validator_bid.is_locked(era_end_timestamp_millis) {
         // cannot increase the min or decrease the max while vesting is locked
@@ -1379,6 +1372,13 @@ pub fn process_updated_delegator_stake_boundaries<P: Auction>(
     // set updated delegation amount range
     validator_bid
         .set_delegation_amount_boundaries(minimum_delegation_amount, maximum_delegation_amount);
+
+    // check modified delegation bookends
+    let raised_min = validator_bid.minimum_delegation_amount() < minimum_delegation_amount;
+    let lowered_max = validator_bid.maximum_delegation_amount() > maximum_delegation_amount;
+    if !raised_min && !lowered_max {
+        return Ok(());
+    }
 
     let validator_public_key = validator_bid.validator_public_key();
     let min_delegation = minimum_delegation_amount.into();

--- a/storage/src/system/auction/detail.rs
+++ b/storage/src/system/auction/detail.rs
@@ -1369,13 +1369,16 @@ pub fn process_updated_delegator_stake_boundaries<P: Auction>(
         return Err(Error::VestingLockout);
     }
 
+    let previous_minimum = validator_bid.minimum_delegation_amount();
+    let previous_maximum = validator_bid.maximum_delegation_amount();
+
     // set updated delegation amount range
     validator_bid
         .set_delegation_amount_boundaries(minimum_delegation_amount, maximum_delegation_amount);
 
     // check modified delegation bookends
-    let raised_min = validator_bid.minimum_delegation_amount() < minimum_delegation_amount;
-    let lowered_max = validator_bid.maximum_delegation_amount() > maximum_delegation_amount;
+    let raised_min = previous_minimum < minimum_delegation_amount;
+    let lowered_max = previous_maximum > maximum_delegation_amount;
     if !raised_min && !lowered_max {
         return Ok(());
     }

--- a/storage/src/system/runtime_native.rs
+++ b/storage/src/system/runtime_native.rs
@@ -25,6 +25,7 @@ pub struct Config {
     max_delegators_per_validator: u32,
     minimum_bid_amount: u64,
     minimum_delegation_amount: u64,
+    maximum_delegation_amount: u64,
     balance_hold_interval: u64,
     include_credits: bool,
     credit_cap: Ratio<U512>,
@@ -45,6 +46,7 @@ impl Config {
         max_delegators_per_validator: u32,
         minimum_bid_amount: u64,
         minimum_delegation_amount: u64,
+        maximum_delegation_amount: u64,
         balance_hold_interval: u64,
         include_credits: bool,
         credit_cap: Ratio<U512>,
@@ -61,6 +63,7 @@ impl Config {
             max_delegators_per_validator,
             minimum_bid_amount,
             minimum_delegation_amount,
+            maximum_delegation_amount,
             balance_hold_interval,
             include_credits,
             credit_cap,
@@ -80,6 +83,7 @@ impl Config {
         let max_delegators_per_validator = chainspec.core_config.max_delegators_per_validator;
         let minimum_bid_amount = chainspec.core_config.minimum_bid_amount;
         let minimum_delegation_amount = chainspec.core_config.minimum_delegation_amount;
+        let maximum_delegation_amount = chainspec.core_config.maximum_delegation_amount;
         let balance_hold_interval = chainspec.core_config.gas_hold_interval.millis();
         let include_credits = chainspec.core_config.fee_handling == FeeHandling::NoFee;
         let credit_cap = Ratio::new_raw(
@@ -98,6 +102,7 @@ impl Config {
             max_delegators_per_validator,
             minimum_bid_amount,
             minimum_delegation_amount,
+            maximum_delegation_amount,
             balance_hold_interval,
             include_credits,
             credit_cap,
@@ -146,9 +151,14 @@ impl Config {
         self.minimum_bid_amount
     }
 
-    /// Returns minimum delegation amount setting.
-    pub fn minimum_delegation_amount(&self) -> u64 {
+    /// Returns the global minimum delegation amount setting.
+    pub fn global_minimum_delegation_amount(&self) -> u64 {
         self.minimum_delegation_amount
+    }
+
+    /// Returns the global maximum delegation amount setting.
+    pub fn global_maximum_delegation_amount(&self) -> u64 {
+        self.maximum_delegation_amount
     }
 
     /// Returns balance hold interval setting.
@@ -182,6 +192,7 @@ impl Config {
             allow_auction_bids: self.allow_auction_bids,
             minimum_bid_amount: self.minimum_bid_amount,
             minimum_delegation_amount: self.minimum_delegation_amount,
+            maximum_delegation_amount: self.maximum_delegation_amount,
             compute_rewards: self.compute_rewards,
             balance_hold_interval: self.balance_hold_interval,
             include_credits: self.include_credits,

--- a/types/src/system/auction/bid_kind.rs
+++ b/types/src/system/auction/bid_kind.rs
@@ -329,6 +329,16 @@ impl BidKind {
             | BidKind::Unbond(_) => None,
         }
     }
+
+    /// Returns a cloned validator bid.
+    #[cfg(any(feature = "testing", test))]
+    pub fn as_validator_bid(&self) -> Option<ValidatorBid> {
+        if let Self::Validator(bid) = self {
+            return Some(*bid.clone());
+        }
+
+        None
+    }
 }
 
 impl CLTyped for BidKind {


### PR DESCRIPTION
CHANGLOG:

- Fixes an issue where an early exit would ignore changes to the minimum and maximum delegation limits on a validators bid
- Fixes an issue where delegation limits on a validator would be incorrectly set to the global chainspec defined value 