### PR TITLE
Versioning for 2.1.1 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "2.0.4"
+version = "2.1.1"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "casper-storage"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "casper-types"
-version = "6.0.1"
+version = "6.1.0"
 dependencies = [
  "base16",
  "base64 0.13.1",

--- a/binary_port/Cargo.toml
+++ b/binary_port/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["proptest-regressions"]
 [dependencies]
 bincode = "1.3.3"
 bytes = "1.0.1"
-casper-types = { version = "6.0.1", path = "../types", features = ["datasize", "json-schema", "std"] }
+casper-types = { version = "6.1.0", path = "../types", features = ["datasize", "json-schema", "std"] }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { version = "1.5.2" }

--- a/execution_engine/Cargo.toml
+++ b/execution_engine/Cargo.toml
@@ -17,8 +17,8 @@ bincode = "1.3.1"
 blake2 = { version = "0.10.6", default-features = false }
 blake3 = { version = "1.5.0", default-features = false, features = ["pure"] }
 sha2 = { version = "0.10.8", default-features = false }
-casper-storage = { version = "3.0.0", path = "../storage", default-features = true }
-casper-types = { version = "6.0.1", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema", "std"] }
+casper-storage = { version = "4.0.0", path = "../storage", default-features = true }
+casper-types = { version = "6.1.0", path = "../types", default-features = false, features = ["datasize", "gens", "json-schema", "std"] }
 casper-wasm = { version = "1.0.0", default-features = false, features = ["sign_ext", "call_indirect_overlong"] }
 casper-wasm-utils = { version = "4.0.0", default-features = false, features = ["sign_ext", "call_indirect_overlong"] }
 casper-wasmi = { version = "1.0.0", features = ["sign_ext", "call_indirect_overlong"] }

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 
 [dependencies]
 blake2 = "0.9.0"
-casper-storage = { version = "3.0.0", path = "../../storage" }
-casper-types = { version = "6.0.1", path = "../../types" }
+casper-storage = { version = "4.0.0", path = "../../storage" }
+casper-types = { version = "6.1.0", path = "../../types" }
 env_logger = "0.10.0"
 casper-execution-engine = { version = "8.1.1", path = "../../execution_engine", features = ["test-support"] }
 humantime = "2"
@@ -29,7 +29,7 @@ tempfile = "3.4.0"
 toml = "0.5.6"
 
 [dev-dependencies]
-casper-types = { version = "6.0.1", path = "../../types", features = ["std"] }
+casper-types = { version = "6.1.0", path = "../../types", features = ["std"] }
 version-sync = "0.9.3"
 
 [build-dependencies]

--- a/executor/wasm/Cargo.toml
+++ b/executor/wasm/Cargo.toml
@@ -16,8 +16,8 @@ casper-executor-wasm-common = { version = "0.1.3", path = "../wasm_common" }
 casper-executor-wasm-host = { version = "0.1.3", path = "../wasm_host" }
 casper-executor-wasm-interface = { version = "0.1.3", path = "../wasm_interface" }
 casper-executor-wasmer-backend = { version = "0.1.3", path = "../wasmer_backend" }
-casper-storage = { version = "3.0.0", path = "../../storage" }
-casper-types = { version = "6.0.1", path = "../../types", features = ["std"] }
+casper-storage = { version = "4.0.0", path = "../../storage" }
+casper-types = { version = "6.1.0", path = "../../types", features = ["std"] }
 casper-execution-engine = { version = "8.1.1", path = "../../execution_engine", features = [
     "test-support",
 ] }

--- a/executor/wasm_host/Cargo.toml
+++ b/executor/wasm_host/Cargo.toml
@@ -13,8 +13,8 @@ base16 = "0.2"
 bytes = "1.10"
 casper-executor-wasm-common = { version = "0.1.3", path = "../wasm_common" }
 casper-executor-wasm-interface = { version = "0.1.3", path = "../wasm_interface" }
-casper-storage = { version = "3.0.0", path = "../../storage" }
-casper-types = { version = "6.0.1", path = "../../types" }
+casper-storage = { version = "4.0.0", path = "../../storage" }
+casper-types = { version = "6.1.0", path = "../../types" }
 either = "1.15"
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/executor/wasm_interface/Cargo.toml
+++ b/executor/wasm_interface/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 bytes = "1.10"
 borsh = { version = "1.5", features = ["derive"] }
 casper-executor-wasm-common = { version = "0.1.3", path = "../wasm_common" }
-casper-storage = { version = "3.0.0", path = "../../storage" }
-casper-types = { version = "6.0.1", path = "../../types" }
+casper-storage = { version = "4.0.0", path = "../../storage" }
+casper-types = { version = "6.1.0", path = "../../types" }
 parking_lot = "0.12"
 thiserror = "2"

--- a/executor/wasmer_backend/Cargo.toml
+++ b/executor/wasmer_backend/Cargo.toml
@@ -13,9 +13,9 @@ bytes = "1.10"
 casper-executor-wasm-common = { version = "0.1.3", path = "../wasm_common" }
 casper-executor-wasm-interface = { version = "0.1.3", path = "../wasm_interface" }
 casper-executor-wasm-host = { version = "0.1.0", path = "../wasm_host" }
-casper-storage = { version = "3.0.0", path = "../../storage" }
+casper-storage = { version = "4.0.0", path = "../../storage" }
 casper-contract-sdk-sys = { version = "0.1.3", path = "../../smart_contracts/sdk_sys" }
-casper-types = { version = "6.0.1", path = "../../types" }
+casper-types = { version = "6.1.0", path = "../../types" }
 regex = "1.11"
 wasmer = { version = "5.0.4", default-features = false, features = [
     "singlepass",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-node"
-version = "2.0.4" # when updating, also update 'html_root_url' in lib.rs
+version = "2.1.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Ed Hastings <ed@casper.network>", "Karan Dhareshwar <karan@casper.network>"]
 edition = "2021"
 description = "The Casper blockchain node"
@@ -23,8 +23,8 @@ base64 = "0.13.0"
 bincode = "1"
 bytes = "1.0.1"
 casper-binary-port = { version = "1.1.1", path = "../binary_port" }
-casper-storage = { version = "3.0.0", path = "../storage" }
-casper-types = { version = "6.0.1", path = "../types", features = ["datasize", "json-schema", "std-fs-io"] }
+casper-storage = { version = "4.0.0", path = "../storage" }
+casper-types = { version = "6.1.0", path = "../types", features = ["datasize", "json-schema", "std-fs-io"] }
 casper-execution-engine = { version = "8.1.1", path = "../execution_engine" }
 datasize = { version = "0.2.11", features = ["detailed", "fake_clock-types", "futures-types", "smallvec-types"] }
 derive_more = "0.99.7"

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -8,7 +8,7 @@
 //! While the [`main`](fn.main.html) function is the central entrypoint for the node application,
 //! its core event loop is found inside the [reactor](reactor/index.html).
 
-#![doc(html_root_url = "https://docs.rs/casper-node/2.0.4")]
+#![doc(html_root_url = "https://docs.rs/casper-node/2.1.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon_48.png",
     html_logo_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon.png",

--- a/resources/integration-test/chainspec.toml
+++ b/resources/integration-test/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '2.1.0'
+version = '2.1.1'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '2.0.0'
+version = '2.1.1'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = false
 # This protocol version becomes active at this point.

--- a/resources/mainnet/chainspec.toml
+++ b/resources/mainnet/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '2.1.0'
+version = '2.1.1'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '2.1.0'
+version = '2.1.1'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/resources/testnet/chainspec.toml
+++ b/resources/testnet/chainspec.toml
@@ -1,6 +1,6 @@
 [protocol]
 # Protocol version.
-version = '2.1.0'
+version = '2.1.1'
 # Whether we need to clear latest blocks back to the switch block just before the activation point or not.
 hard_reset = true
 # This protocol version becomes active at this point.

--- a/smart_contracts/contract/Cargo.toml
+++ b/smart_contracts/contract/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/casper-network/casper-node/tree/master/smart_co
 license = "Apache-2.0"
 
 [dependencies]
-casper-types = { version = "6.0.1", path = "../../types" }
+casper-types = { version = "6.1.0", path = "../../types" }
 hex_fmt = "0.3.0"
 version-sync = { version = "0.9", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-storage"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2018"
 authors = ["Ed Hastings <ed@casper.network>"]
 description = "Storage for a node on the Casper network."
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 
 [dependencies]
 bincode = "1.3.1"
-casper-types = { version = "6.0.1", path = "../types", features = ["datasize", "json-schema", "std"] }
+casper-types = { version = "6.1.0", path = "../types", features = ["datasize", "json-schema", "std"] }
 datasize = "0.2.4"
 either = "1.8.1"
 lmdb-rkv = "0.14"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,6 +1,6 @@
 //! Storage for a node on the Casper network.
 
-#![doc(html_root_url = "https://docs.rs/casper-storage/3.0.0")]
+#![doc(html_root_url = "https://docs.rs/casper-storage/4.0.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/casper-network/casper-node/master/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/casper-network/casper-node/master/images/CasperLabs_Logo_Symbol_RGB.png"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-types"
-version = "6.0.1" # when updating, also update 'html_root_url' in lib.rs
+version = "6.1.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Ed Hastings <ed@casper.network>"]
 edition = "2021"
 description = "Types shared by many casper crates for use on the Casper network."

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -10,7 +10,7 @@
     )),
     no_std
 )]
-#![doc(html_root_url = "https://docs.rs/casper-types/6.0.1")]
+#![doc(html_root_url = "https://docs.rs/casper-types/6.1.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon_48.png",
     html_logo_url = "https://raw.githubusercontent.com/casper-network/casper-node/blob/dev/images/Casper_Logo_Favicon.png"


### PR DESCRIPTION
Updating casper-node to 2.1.1, casper-types by minor version and casper-storage by major version.

Updating chainspec.toml files to 2.1.1