### PR TITLE
Update host function costs for vm2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "casper-executor-wasm-interface",
  "casper-storage",
  "casper-types",
+ "criterion",
  "either",
  "keccak-asm",
  "num-derive",

--- a/executor/wasm_host/Cargo.toml
+++ b/executor/wasm_host/Cargo.toml
@@ -29,3 +29,10 @@ num-traits = { workspace = true }
 parking_lot = "0.12"
 thiserror = "2"
 tracing = "0.1"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "host_crypto"
+harness = false

--- a/executor/wasm_host/benches/host_crypto.rs
+++ b/executor/wasm_host/benches/host_crypto.rs
@@ -1,0 +1,179 @@
+use std::str::FromStr;
+
+use bytes::Bytes;
+use casper_types::{
+    bytesrepr::{self, Bytes as BytesreprBytes, ToBytes},
+    crypto::{SecretKey, Signature},
+    HashAlgorithm, U256,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+#[path = "../src/host/crypto.rs"]
+mod crypto;
+
+fn u256_to_le_bytes(value: U256) -> [u8; 32] {
+    let mut buf = [0u8; 32];
+    value.to_little_endian(&mut buf);
+    buf
+}
+
+fn generic_hash_input() -> Bytes {
+    let message = b"benchmark-generic-hash-payload";
+    let payload = BytesreprBytes::from(message.to_vec());
+    let data = (HashAlgorithm::Blake2b as u32, payload);
+    let serialized = bytesrepr::serialize(&data).expect("serialize generic_hash input");
+    Bytes::from(serialized)
+}
+
+fn recover_secp256k1_input() -> (Bytes, u32) {
+    let message = b"benchmark-secp256k1-message";
+    let secret_key = SecretKey::generate_secp256k1().expect("generate secp256k1 key");
+    let (signature, recovery_id) = match secret_key {
+        SecretKey::Secp256k1(signing_key) => signing_key.sign_recoverable(message).unwrap(),
+        _ => unreachable!(),
+    };
+    let signature = Signature::Secp256k1(signature);
+    let recovery_id = recovery_id.to_byte() as u32;
+    let signature_bytes = signature.to_bytes().expect("signature bytes");
+
+    let input = (
+        recovery_id,
+        BytesreprBytes::from(message.to_vec()),
+        BytesreprBytes::from(signature_bytes),
+    );
+    let serialized = bytesrepr::serialize(&input).expect("serialize recover_secp256k1 input");
+    (Bytes::from(serialized), recovery_id)
+}
+
+fn alt_bn128_add_input() -> Bytes {
+    let x1 = U256::from_str(
+        "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9",
+    )
+    .expect("u256 x1");
+    let y1 = U256::from_str(
+        "063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
+    )
+    .expect("u256 y1");
+    let x2 = U256::from_str(
+        "07c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed",
+    )
+    .expect("u256 x2");
+    let y2 = U256::from_str(
+        "06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7",
+    )
+    .expect("u256 y2");
+
+    let data = (
+        u256_to_le_bytes(x1),
+        u256_to_le_bytes(y1),
+        u256_to_le_bytes(x2),
+        u256_to_le_bytes(y2),
+    );
+    let serialized = bytesrepr::serialize(&data).expect("serialize alt_bn128_add input");
+    Bytes::from(serialized)
+}
+
+fn alt_bn128_mul_input() -> Bytes {
+    let x = U256::from_str(
+        "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7",
+    )
+    .expect("u256 x");
+    let y = U256::from_str(
+        "21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
+    )
+    .expect("u256 y");
+    let scalar = U256::from_str(
+        "00000000000000000000000000000000000000000000000011138ce750fa15c2",
+    )
+    .expect("u256 scalar");
+
+    let data = (
+        u256_to_le_bytes(x),
+        u256_to_le_bytes(y),
+        u256_to_le_bytes(scalar),
+    );
+    let serialized = bytesrepr::serialize(&data).expect("serialize alt_bn128_mul input");
+    Bytes::from(serialized)
+}
+
+fn alt_bn128_pairing_input() -> Bytes {
+    let zero = [0u8; 32];
+    let pair = crypto::Pair {
+        ax: zero,
+        ay: zero,
+        bax: zero,
+        bay: zero,
+        bbx: zero,
+        bby: zero,
+    };
+    // Manual bytesrepr-style serialization of Vec<Pair>.
+    let mut buf = Vec::with_capacity(4 + 6 * 32);
+    buf.extend_from_slice(&(1u32).to_le_bytes());
+    buf.extend_from_slice(&pair.ax);
+    buf.extend_from_slice(&pair.ay);
+    buf.extend_from_slice(&pair.bax);
+    buf.extend_from_slice(&pair.bay);
+    buf.extend_from_slice(&pair.bbx);
+    buf.extend_from_slice(&pair.bby);
+    Bytes::from(buf)
+}
+
+fn bench_generic_hash(c: &mut Criterion) {
+    let input = generic_hash_input();
+    c.bench_function("host_generic_hash", |b| {
+        b.iter(|| {
+            let res = crypto::host_generic_hash(black_box(input.clone())).expect("host call");
+            black_box(res)
+        })
+    });
+}
+
+fn bench_recover_secp256k1(c: &mut Criterion) {
+    let (input, _recovery_id) = recover_secp256k1_input();
+    c.bench_function("host_recover_secp256k1", |b| {
+        b.iter(|| {
+            let res = crypto::host_recover_secp256k1(black_box(input.clone())).expect("host call");
+            black_box(res)
+        })
+    });
+}
+
+fn bench_alt_bn128_add(c: &mut Criterion) {
+    let input = alt_bn128_add_input();
+    c.bench_function("host_alt_bn128_add", |b| {
+        b.iter(|| {
+            let res = crypto::host_alt_bn128_add(black_box(input.clone())).expect("host call");
+            black_box(res)
+        })
+    });
+}
+
+fn bench_alt_bn128_mul(c: &mut Criterion) {
+    let input = alt_bn128_mul_input();
+    c.bench_function("host_alt_bn128_mul", |b| {
+        b.iter(|| {
+            let res = crypto::host_alt_bn128_mul(black_box(input.clone())).expect("host call");
+            black_box(res)
+        })
+    });
+}
+
+fn bench_alt_bn128_pairing(c: &mut Criterion) {
+    let input = alt_bn128_pairing_input();
+    c.bench_function("host_alt_bn128_pairing", |b| {
+        b.iter(|| {
+            let res = crypto::host_alt_bn128_pairing(black_box(input.clone())).expect("host call");
+            black_box(res)
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_generic_hash,
+    bench_recover_secp256k1,
+    bench_alt_bn128_add,
+    bench_alt_bn128_mul,
+    bench_alt_bn128_pairing
+);
+criterion_main!(benches);

--- a/executor/wasm_host/benches/host_crypto.rs
+++ b/executor/wasm_host/benches/host_crypto.rs
@@ -46,22 +46,14 @@ fn recover_secp256k1_input() -> (Bytes, u32) {
 }
 
 fn alt_bn128_add_input() -> Bytes {
-    let x1 = U256::from_str(
-        "18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9",
-    )
-    .expect("u256 x1");
-    let y1 = U256::from_str(
-        "063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266",
-    )
-    .expect("u256 y1");
-    let x2 = U256::from_str(
-        "07c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed",
-    )
-    .expect("u256 x2");
-    let y2 = U256::from_str(
-        "06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7",
-    )
-    .expect("u256 y2");
+    let x1 = U256::from_str("18b18acfb4c2c30276db5411368e7185b311dd124691610c5d3b74034e093dc9")
+        .expect("u256 x1");
+    let y1 = U256::from_str("063c909c4720840cb5134cb9f59fa749755796819658d32efc0d288198f37266")
+        .expect("u256 y1");
+    let x2 = U256::from_str("07c2b7f58a84bd6145f00c9c2bc0bb1a187f20ff2c92963a88019e7c6a014eed")
+        .expect("u256 x2");
+    let y2 = U256::from_str("06614e20c147e940f2d70da3f74c9a17df361706a4485c742bd6788478fa17d7")
+        .expect("u256 y2");
 
     let data = (
         u256_to_le_bytes(x1),
@@ -74,18 +66,12 @@ fn alt_bn128_add_input() -> Bytes {
 }
 
 fn alt_bn128_mul_input() -> Bytes {
-    let x = U256::from_str(
-        "2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7",
-    )
-    .expect("u256 x");
-    let y = U256::from_str(
-        "21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204",
-    )
-    .expect("u256 y");
-    let scalar = U256::from_str(
-        "00000000000000000000000000000000000000000000000011138ce750fa15c2",
-    )
-    .expect("u256 scalar");
+    let x = U256::from_str("2bd3e6d0f3b142924f5ca7b49ce5b9d54c4703d7ae5648e61d02268b1a0a9fb7")
+        .expect("u256 x");
+    let y = U256::from_str("21611ce0a6af85915e2f1d70300909ce2e49dfad4a4619c8390cae66cefdb204")
+        .expect("u256 y");
+    let scalar = U256::from_str("00000000000000000000000000000000000000000000000011138ce750fa15c2")
+        .expect("u256 scalar");
 
     let data = (
         u256_to_le_bytes(x),

--- a/executor/wasm_host/src/host/crypto.rs
+++ b/executor/wasm_host/src/host/crypto.rs
@@ -23,17 +23,17 @@ use tracing::debug;
 #[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
 pub struct Pair {
     /// G1 point x-coordinate. 32 bytes little-endian encoded unsigned integer
-    ax: [u8; 32],
+    pub ax: [u8; 32],
     /// G1 point y-coordinate. 32 bytes little-endian encoded unsigned integer
-    ay: [u8; 32],
+    pub ay: [u8; 32],
     /// G2 point x-coordinate. 32 bytes little-endian encoded unsigned integer
-    bax: [u8; 32],
+    pub bax: [u8; 32],
     /// G2 point y-coordinate. 32 bytes little-endian encoded unsigned integer
-    bay: [u8; 32],
+    pub bay: [u8; 32],
     /// G1 point x-coordinate. 32 bytes little-endian encoded unsigned integer
-    bbx: [u8; 32],
+    pub bbx: [u8; 32],
     /// G1 point x-coordinate. 32 bytes little-endian encoded unsigned integer
-    bby: [u8; 32],
+    pub bby: [u8; 32],
 }
 
 impl FromBytes for Pair {

--- a/resources/devnet/chainspec.toml
+++ b/resources/devnet/chainspec.toml
@@ -424,7 +424,7 @@ copy_input = { base_cost = 20_000, per_byte = 0 }
 ret = { base_cost = 20_000, per_byte = 0 }
 revert = { base_cost = 20_000, per_byte = 150 }
 create = { base_cost = 120_000, per_byte = 10 }
-transfer = { base_cost = 100_000, per_byte = 100 }
+transfer = { base_cost = 2_500_000_000, per_byte = 0 }
 env_balance = { base_cost = 200_000, per_byte = 50 }
 upgrade = { base_cost = 420_000, per_byte = 20 }
 call = { base_cost = 100_000, per_byte = 100 }

--- a/resources/devnet/chainspec.toml
+++ b/resources/devnet/chainspec.toml
@@ -417,24 +417,25 @@ cost = 150
 size_multiplier = 100
 
 [wasm.v2.host_ffi_opt_costs]
-read = { base_cost = 1_000_000, per_byte = 2_000 }
-write = { base_cost = 1_000_000, per_byte = 2_000 }
-remove = { base_cost = 1_000_000, per_byte = 2_000 }
-copy_input = { base_cost = 1_000_000, per_byte = 2_000 }
-ret = { base_cost = 1_000_000, per_byte = 2_000 }
-create = { base_cost = 1_000_000, per_byte = 2_000 }
-transfer = { base_cost = 1_000_000, per_byte = 2_000 }
-env_balance = { base_cost = 1_000_000, per_byte = 2_000 }
-upgrade = { base_cost = 1_000_000, per_byte = 2_000 }
-call = { base_cost = 1_000_000, per_byte = 2_000 }
-print = { base_cost = 1_000_000, per_byte = 2_000 }
-emit = { base_cost = 1_000_000, per_byte = 2_000 }
-env_info = { base_cost = 1_000_000, per_byte = 2_000 }
-generic_hash = { base_cost = 1_000_000, per_byte = 2_000 }
-recover_secp256k1 = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_add = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_mul = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_pairing = { base_cost = 1_000_000, per_byte = 2_000 }
+read = { base_cost = 150_000, per_byte = 500 }
+write = { base_cost = 240_000, per_byte = 1_000 }
+remove = { base_cost = 280_000, per_byte = 250 }
+copy_input = { base_cost = 20_000, per_byte = 0 }
+ret = { base_cost = 20_000, per_byte = 0 }
+revert = { base_cost = 20_000, per_byte = 150 }
+create = { base_cost = 120_000, per_byte = 10 }
+transfer = { base_cost = 100_000, per_byte = 100 }
+env_balance = { base_cost = 200_000, per_byte = 50 }
+upgrade = { base_cost = 420_000, per_byte = 20 }
+call = { base_cost = 100_000, per_byte = 100 }
+print = { base_cost = 20_000, per_byte = 50 }
+emit = { base_cost = 380_000, per_byte = 50 }
+env_info = { base_cost = 20_000, per_byte = 0 }
+generic_hash = { base_cost = 500_000, per_byte = 1_000 }
+recover_secp256k1 = { base_cost = 4_000_000, per_byte = 2_000 }
+alt_bn128_add = { base_cost = 1_200_000, per_byte = 1_000 }
+alt_bn128_mul = { base_cost = 3_000_000, per_byte = 1_000 }
+alt_bn128_pairing = { base_cost = 2_000_000, per_byte = 1_500 }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/resources/integration-test/chainspec.toml
+++ b/resources/integration-test/chainspec.toml
@@ -424,7 +424,7 @@ copy_input = { base_cost = 20_000, per_byte = 0 }
 ret = { base_cost = 20_000, per_byte = 0 }
 revert = { base_cost = 20_000, per_byte = 150 }
 create = { base_cost = 120_000, per_byte = 10 }
-transfer = { base_cost = 100_000, per_byte = 100 }
+transfer = { base_cost = 2_500_000_000, per_byte = 0 }
 env_balance = { base_cost = 200_000, per_byte = 50 }
 upgrade = { base_cost = 420_000, per_byte = 20 }
 call = { base_cost = 100_000, per_byte = 100 }

--- a/resources/integration-test/chainspec.toml
+++ b/resources/integration-test/chainspec.toml
@@ -417,24 +417,25 @@ cost = 150
 size_multiplier = 100
 
 [wasm.v2.host_ffi_opt_costs]
-read = { base_cost = 1_000_000, per_byte = 2_000 }
-write = { base_cost = 1_000_000, per_byte = 2_000 }
-remove = { base_cost = 1_000_000, per_byte = 2_000 }
-copy_input = { base_cost = 1_000_000, per_byte = 2_000 }
-ret = { base_cost = 1_000_000, per_byte = 2_000 }
-create = { base_cost = 1_000_000, per_byte = 2_000 }
-transfer = { base_cost = 1_000_000, per_byte = 2_000 }
-env_balance = { base_cost = 1_000_000, per_byte = 2_000 }
-upgrade = { base_cost = 1_000_000, per_byte = 2_000 }
-call = { base_cost = 1_000_000, per_byte = 2_000 }
-print = { base_cost = 1_000_000, per_byte = 2_000 }
-emit = { base_cost = 1_000_000, per_byte = 2_000 }
-env_info = { base_cost = 1_000_000, per_byte = 2_000 }
-generic_hash = { base_cost = 1_000_000, per_byte = 2_000 }
-recover_secp256k1 = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_add = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_mul = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_pairing = { base_cost = 1_000_000, per_byte = 2_000 }
+read = { base_cost = 150_000, per_byte = 500 }
+write = { base_cost = 240_000, per_byte = 1_000 }
+remove = { base_cost = 280_000, per_byte = 250 }
+copy_input = { base_cost = 20_000, per_byte = 0 }
+ret = { base_cost = 20_000, per_byte = 0 }
+revert = { base_cost = 20_000, per_byte = 150 }
+create = { base_cost = 120_000, per_byte = 10 }
+transfer = { base_cost = 100_000, per_byte = 100 }
+env_balance = { base_cost = 200_000, per_byte = 50 }
+upgrade = { base_cost = 420_000, per_byte = 20 }
+call = { base_cost = 100_000, per_byte = 100 }
+print = { base_cost = 20_000, per_byte = 50 }
+emit = { base_cost = 380_000, per_byte = 50 }
+env_info = { base_cost = 20_000, per_byte = 0 }
+generic_hash = { base_cost = 500_000, per_byte = 1_000 }
+recover_secp256k1 = { base_cost = 4_000_000, per_byte = 2_000 }
+alt_bn128_add = { base_cost = 1_200_000, per_byte = 1_000 }
+alt_bn128_mul = { base_cost = 3_000_000, per_byte = 1_000 }
+alt_bn128_pairing = { base_cost = 2_000_000, per_byte = 1_500 }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -410,25 +410,25 @@ cost = 150
 size_multiplier = 100
 
 [wasm.v2.host_ffi_opt_costs]
-read = { base_cost = 1_000_000, per_byte = 2_000 }
-write = { base_cost = 1_000_000, per_byte = 2_000 }
-remove = { base_cost = 1_000_000, per_byte = 2_000 }
-copy_input = { base_cost = 1_000_000, per_byte = 2_000 }
-ret = { base_cost = 1_000_000, per_byte = 2_000 }
-revert = { base_cost = 1_000_000, per_byte = 2_000 }
-create = { base_cost = 1_000_000, per_byte = 2_000 }
-transfer = { base_cost = 1_000_000, per_byte = 2_000 }
-env_balance = { base_cost = 1_000_000, per_byte = 2_000 }
-upgrade = { base_cost = 1_000_000, per_byte = 2_000 }
-call = { base_cost = 1_000_000, per_byte = 2_000 }
-print = { base_cost = 1_000_000, per_byte = 2_000 }
-emit = { base_cost = 1_000_000, per_byte = 2_000 }
-env_info = { base_cost = 1_000_000, per_byte = 2_000 }
-generic_hash = { base_cost = 1_000_000, per_byte = 2_000 }
-recover_secp256k1 = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_add = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_mul = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_pairing = { base_cost = 1_000_000, per_byte = 2_000 }
+read = { base_cost = 150_000, per_byte = 500 }
+write = { base_cost = 240_000, per_byte = 1_000 }
+remove = { base_cost = 280_000, per_byte = 250 }
+copy_input = { base_cost = 20_000, per_byte = 0 }
+ret = { base_cost = 20_000, per_byte = 0 }
+revert = { base_cost = 20_000, per_byte = 150 }
+create = { base_cost = 120_000, per_byte = 10 }
+transfer = { base_cost = 100_000, per_byte = 100 }
+env_balance = { base_cost = 200_000, per_byte = 50 }
+upgrade = { base_cost = 420_000, per_byte = 20 }
+call = { base_cost = 100_000, per_byte = 100 }
+print = { base_cost = 20_000, per_byte = 50 }
+emit = { base_cost = 380_000, per_byte = 50 }
+env_info = { base_cost = 20_000, per_byte = 0 }
+generic_hash = { base_cost = 500_000, per_byte = 1_000 }
+recover_secp256k1 = { base_cost = 4_000_000, per_byte = 2_000 }
+alt_bn128_add = { base_cost = 1_200_000, per_byte = 1_000 }
+alt_bn128_mul = { base_cost = 3_000_000, per_byte = 1_000 }
+alt_bn128_pairing = { base_cost = 2_000_000, per_byte = 1_500 }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -417,7 +417,7 @@ copy_input = { base_cost = 20_000, per_byte = 0 }
 ret = { base_cost = 20_000, per_byte = 0 }
 revert = { base_cost = 20_000, per_byte = 150 }
 create = { base_cost = 120_000, per_byte = 10 }
-transfer = { base_cost = 100_000, per_byte = 100 }
+transfer = { base_cost = 2_500_000_000, per_byte = 0 }
 env_balance = { base_cost = 200_000, per_byte = 50 }
 upgrade = { base_cost = 420_000, per_byte = 20 }
 call = { base_cost = 100_000, per_byte = 100 }

--- a/resources/mainnet/chainspec.toml
+++ b/resources/mainnet/chainspec.toml
@@ -424,7 +424,7 @@ copy_input = { base_cost = 20_000, per_byte = 0 }
 ret = { base_cost = 20_000, per_byte = 0 }
 revert = { base_cost = 20_000, per_byte = 150 }
 create = { base_cost = 120_000, per_byte = 10 }
-transfer = { base_cost = 100_000, per_byte = 100 }
+transfer = { base_cost = 2_500_000_000, per_byte = 0 }
 env_balance = { base_cost = 200_000, per_byte = 50 }
 upgrade = { base_cost = 420_000, per_byte = 20 }
 call = { base_cost = 100_000, per_byte = 100 }

--- a/resources/mainnet/chainspec.toml
+++ b/resources/mainnet/chainspec.toml
@@ -417,24 +417,25 @@ cost = 150
 size_multiplier = 100
 
 [wasm.v2.host_ffi_opt_costs]
-read = { base_cost = 1_000_000, per_byte = 2_000 }
-write = { base_cost = 1_000_000, per_byte = 2_000 }
-remove = { base_cost = 1_000_000, per_byte = 2_000 }
-copy_input = { base_cost = 1_000_000, per_byte = 2_000 }
-ret = { base_cost = 1_000_000, per_byte = 2_000 }
-create = { base_cost = 1_000_000, per_byte = 2_000 }
-transfer = { base_cost = 1_000_000, per_byte = 2_000 }
-env_balance = { base_cost = 1_000_000, per_byte = 2_000 }
-upgrade = { base_cost = 1_000_000, per_byte = 2_000 }
-call = { base_cost = 1_000_000, per_byte = 2_000 }
-print = { base_cost = 1_000_000, per_byte = 2_000 }
-emit = { base_cost = 1_000_000, per_byte = 2_000 }
-env_info = { base_cost = 1_000_000, per_byte = 2_000 }
-generic_hash = { base_cost = 1_000_000, per_byte = 2_000 }
-recover_secp256k1 = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_add = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_mul = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_pairing = { base_cost = 1_000_000, per_byte = 2_000 }
+read = { base_cost = 150_000, per_byte = 500 }
+write = { base_cost = 240_000, per_byte = 1_000 }
+remove = { base_cost = 280_000, per_byte = 250 }
+copy_input = { base_cost = 20_000, per_byte = 0 }
+ret = { base_cost = 20_000, per_byte = 0 }
+revert = { base_cost = 20_000, per_byte = 150 }
+create = { base_cost = 120_000, per_byte = 10 }
+transfer = { base_cost = 100_000, per_byte = 100 }
+env_balance = { base_cost = 200_000, per_byte = 50 }
+upgrade = { base_cost = 420_000, per_byte = 20 }
+call = { base_cost = 100_000, per_byte = 100 }
+print = { base_cost = 20_000, per_byte = 50 }
+emit = { base_cost = 380_000, per_byte = 50 }
+env_info = { base_cost = 20_000, per_byte = 0 }
+generic_hash = { base_cost = 500_000, per_byte = 1_000 }
+recover_secp256k1 = { base_cost = 4_000_000, per_byte = 2_000 }
+alt_bn128_add = { base_cost = 1_200_000, per_byte = 1_000 }
+alt_bn128_mul = { base_cost = 3_000_000, per_byte = 1_000 }
+alt_bn128_pairing = { base_cost = 2_000_000, per_byte = 1_500 }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -424,7 +424,7 @@ copy_input = { base_cost = 20_000, per_byte = 0 }
 ret = { base_cost = 20_000, per_byte = 0 }
 revert = { base_cost = 20_000, per_byte = 150 }
 create = { base_cost = 120_000, per_byte = 10 }
-transfer = { base_cost = 100_000, per_byte = 100 }
+transfer = { base_cost = 2_500_000_000, per_byte = 0 }
 env_balance = { base_cost = 200_000, per_byte = 50 }
 upgrade = { base_cost = 420_000, per_byte = 20 }
 call = { base_cost = 100_000, per_byte = 100 }

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -417,25 +417,25 @@ cost = 150
 size_multiplier = 100
 
 [wasm.v2.host_ffi_opt_costs]
-read = { base_cost = 1_000_000, per_byte = 2_000 }
-write = { base_cost = 1_000_000, per_byte = 2_000 }
-remove = { base_cost = 1_000_000, per_byte = 2_000 }
-copy_input = { base_cost = 1_000_000, per_byte = 2_000 }
-ret = { base_cost = 1_000_000, per_byte = 2_000 }
-revert = { base_cost = 1_000_000, per_byte = 2_000 }
-create = { base_cost = 1_000_000, per_byte = 2_000 }
-transfer = { base_cost = 1_000_000, per_byte = 2_000 }
-env_balance = { base_cost = 1_000_000, per_byte = 2_000 }
-upgrade = { base_cost = 1_000_000, per_byte = 2_000 }
-call = { base_cost = 1_000_000, per_byte = 2_000 }
-print = { base_cost = 1_000_000, per_byte = 2_000 }
-emit = { base_cost = 1_000_000, per_byte = 2_000 }
-env_info = { base_cost = 1_000_000, per_byte = 2_000 }
-generic_hash = { base_cost = 1_000_000, per_byte = 2_000 }
-recover_secp256k1 = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_add = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_mul = { base_cost = 1_000_000, per_byte = 2_000 }
-alt_bn128_pairing = { base_cost = 1_000_000, per_byte = 2_000 }
+read = { base_cost = 150_000, per_byte = 500 }
+write = { base_cost = 240_000, per_byte = 1_000 }
+remove = { base_cost = 280_000, per_byte = 250 }
+copy_input = { base_cost = 20_000, per_byte = 0 }
+ret = { base_cost = 20_000, per_byte = 0 }
+revert = { base_cost = 20_000, per_byte = 150 }
+create = { base_cost = 120_000, per_byte = 10 }
+transfer = { base_cost = 100_000, per_byte = 100 }
+env_balance = { base_cost = 200_000, per_byte = 50 }
+upgrade = { base_cost = 420_000, per_byte = 20 }
+call = { base_cost = 100_000, per_byte = 100 }
+print = { base_cost = 20_000, per_byte = 50 }
+emit = { base_cost = 380_000, per_byte = 50 }
+env_info = { base_cost = 20_000, per_byte = 0 }
+generic_hash = { base_cost = 500_000, per_byte = 1_000 }
+recover_secp256k1 = { base_cost = 4_000_000, per_byte = 2_000 }
+alt_bn128_add = { base_cost = 1_200_000, per_byte = 1_000 }
+alt_bn128_mul = { base_cost = 3_000_000, per_byte = 1_000 }
+alt_bn128_pairing = { base_cost = 2_000_000, per_byte = 1_500 }
 
 [wasm.messages_limits]
 max_topic_name_size = 256

--- a/storage/benches/global_state_key_write_bench.rs
+++ b/storage/benches/global_state_key_write_bench.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    cell::Cell,
+    time::{Duration, Instant},
+};
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use pprof::criterion::{Output, PProfProfiler};
@@ -43,6 +46,34 @@ fn write_sequential(
     root_hash
 }
 
+fn record_iteration_stats(
+    total_duration: &Cell<Duration>,
+    total_iterations: &Cell<u64>,
+    iteration_duration: Duration,
+    iteration_count: u64,
+) {
+    total_duration.set(total_duration.get() + iteration_duration);
+    total_iterations.set(total_iterations.get() + iteration_count);
+}
+
+fn report_average_time(label: &str, batch_size: u32, total_duration: Duration, iterations: u64) {
+    if iterations == 0 {
+        println!("{label} (batch size {batch_size}) did not record any timed iterations");
+        return;
+    }
+
+    let avg_secs = total_duration.as_secs_f64() / iterations as f64;
+    let avg_per_key_ns = (avg_secs * 1_000_000_000.0) / batch_size as f64;
+    let throughput = batch_size as f64 / avg_secs;
+
+    println!(
+        "{label} (batch size {batch_size}): average batch time = {:.4} ms | avg per key = {:.2} ns | throughput ≈ {:.2} writes/s",
+        avg_secs * 1_000.0,
+        avg_per_key_ns,
+        throughput
+    );
+}
+
 fn create_empty_store() -> (LmdbEnvironment, LmdbTrieStore) {
     let _temp_dir = tempdir().unwrap();
     let environment = LmdbEnvironment::new(_temp_dir.path(), DB_SIZE, MAX_READERS, true).unwrap();
@@ -73,7 +104,12 @@ fn sequential_write_bench(c: &mut Criterion, rng: &mut TestRng) {
             sequential_write_group.sample_size(30);
         }
 
+        let total_duration = Cell::new(Duration::default());
+        let total_iterations = Cell::new(0u64);
+
         sequential_write_group.bench_function(format!("write_sequential_{}", batch_size), |b| {
+            let total_duration = &total_duration;
+            let total_iterations = &total_iterations;
             b.iter_custom(|iter| {
                 let mut total = Duration::default();
                 for _ in 0..iter {
@@ -88,9 +124,18 @@ fn sequential_write_bench(c: &mut Criterion, rng: &mut TestRng) {
                     total = total.checked_add(start.elapsed()).unwrap();
                 }
 
+                record_iteration_stats(total_duration, total_iterations, total, iter);
+
                 total
             })
         });
+
+        report_average_time(
+            "sequential_write",
+            batch_size,
+            total_duration.get(),
+            total_iterations.get(),
+        );
     }
     sequential_write_group.finish();
 }
@@ -106,7 +151,12 @@ fn batch_write_with_empty_store(c: &mut Criterion, rng: &mut TestRng) {
             batch_write_group.sample_size(30);
         }
 
+        let total_duration = Cell::new(Duration::default());
+        let total_iterations = Cell::new(0u64);
+
         batch_write_group.bench_function(format!("write_batch_{}", batch_size), |b| {
+            let total_duration = &total_duration;
+            let total_iterations = &total_iterations;
             b.iter_custom(|iter| {
                 let mut total = Duration::default();
                 for _ in 0..iter {
@@ -127,9 +177,18 @@ fn batch_write_with_empty_store(c: &mut Criterion, rng: &mut TestRng) {
                     total = total.checked_add(start.elapsed()).unwrap();
                 }
 
+                record_iteration_stats(total_duration, total_iterations, total, iter);
+
                 total
             })
         });
+
+        report_average_time(
+            "batch_write_empty_store",
+            batch_size,
+            total_duration.get(),
+            total_iterations.get(),
+        );
     }
     batch_write_group.finish();
 }
@@ -145,7 +204,12 @@ fn batch_write_with_populated_store(c: &mut Criterion, rng: &mut TestRng) {
             batch_write_group.sample_size(30);
         }
 
+        let total_duration = Cell::new(Duration::default());
+        let total_iterations = Cell::new(0u64);
+
         batch_write_group.bench_function(format!("write_batch_{}", batch_size), |b| {
+            let total_duration = &total_duration;
+            let total_iterations = &total_iterations;
             b.iter_custom(|iter| {
                 let mut total = Duration::default();
                 for _ in 0..iter {
@@ -174,9 +238,18 @@ fn batch_write_with_populated_store(c: &mut Criterion, rng: &mut TestRng) {
                     total = total.checked_add(start.elapsed()).unwrap();
                 }
 
+                record_iteration_stats(total_duration, total_iterations, total, iter);
+
                 total
             })
         });
+
+        report_average_time(
+            "batch_write_populated_store",
+            batch_size,
+            total_duration.get(),
+            total_iterations.get(),
+        );
     }
     batch_write_group.finish();
 }


### PR DESCRIPTION
The approach used here is first, storage ops were benchmarked and a gas figure was computed per single storage operation. Based on that, a manual review of each host function was conducted to determine how many storage ops are happening per host function, and multiplied.

Per byte costs were determined based on the possible size of the serialized length, to ensure that, for example, writing large data will be charged by the bytes, and per byte charge would be lower.

There were few CPU instensive host functions (`generic_hash`, `recover_secp256k1`, `alt_bn128_add`, `alt_bn128_mul`, `alt_bn128_pairing`) which were benchmarked, and a cycle + gas/cycle figures were derived from the results with some additional margin based on how often given host function may be used in practice.

# Reference table

* Host function using storage assume ~60k gas per tracking copy operation (read/write/prune)

| Host function      | base_cost    | per_byte | Rationale (brief) |
|--------------------|--------------|----------|-------------------|
| read               | 150_000      | 500      | 1-2 storage reads; payload length modest. |
| write              | 240_000      | 1_000    | Read + two writes (value + key); size charged separately. |
| remove             | 280_000      | 250      | Read + prune path (may touch named key + uref). |
| copy_input         | 20_000       | 0        | Memory copy only; no storage. |
| ret                | 20_000       | 0        | Decode + trap; no storage. |
| revert             | 20_000       | 150      | Decode-only; message length modest. |
| create             | 120_000      | 10       | Wrapper around `install_contract`; executor charges storage. |
| transfer           | 2_500_000_000| 0        | Routed to system contract via `handle_as_contract_call`; fixed high base. |
| env_balance        | 200_000      | 50       | 2-3 storage reads (entity lookup + purse + balance). |
| upgrade            | 420_000      | 20       | ~5-6 storage ops (package/entity/bytecode) plus size charging. |
| call               | 100_000      | 100      | Thin wrapper around `exec`; actual work in callee. |
| print              | 20_000       | 50       | Log only; lightweight. |
| emit               | 380_000      | 50       | Message topic management with multiple storage ops; size charging applied. |
| env_info           | 20_000       | 0        | Context read-only. |
| generic_hash       | 500_000      | 1_000    | ~582 cycles @ 3GHz -> ~860 gas/cycle to reach base. |
| recover_secp256k1  | 4_000_000    | 2_000    | ~402k cycles @ 3GHz -> ~10 gas/cycle to reach base. |
| alt_bn128_add      | 1_200_000    | 1_000    | ~7,080 cycles @ 3GHz -> ~170 gas/cycle to reach base. |
| alt_bn128_mul      | 3_000_000    | 1_000    | ~61,900 cycles @ 3GHz -> ~49 gas/cycle to reach base. |
| alt_bn128_pairing  | 2_000_000    | 1_500    | ~1,065 cycles @ 3GHz (single pair) -> ~1,880 gas/cycle. |
