### PR TITLE
[BUGFIX] Tally delegator stake at genesis

### DIFF
--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -20,6 +20,10 @@ const ACCOUNT_2_BONDED_AMOUNT: u64 = 2_000_000;
 const ACCOUNT_1_BALANCE: u64 = 1_000_000_000;
 const ACCOUNT_2_BALANCE: u64 = 2_000_000_000;
 
+const ACCOUNT_3_BONDED_AMOUNT: u64 = 3_000_000;
+
+const ACCOUNT_3_BALANCE: u64 = 3_000_000_000;
+
 static ACCOUNT_1_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
     let secret_key = SecretKey::ed25519_from_bytes([42; SecretKey::ED25519_LENGTH]).unwrap();
     PublicKey::from(&secret_key)
@@ -30,6 +34,12 @@ static ACCOUNT_2_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
     PublicKey::from(&secret_key)
 });
 static ACCOUNT_2_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_2_PUBLIC_KEY));
+
+static ACCOUNT_3_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
+    let secret_key = SecretKey::ed25519_from_bytes([45; SecretKey::ED25519_LENGTH]).unwrap();
+    PublicKey::from(&secret_key)
+});
+static ACCOUNT_3_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_3_PUBLIC_KEY));
 
 static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
     let account_1 = {
@@ -56,7 +66,18 @@ static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
             )),
         )
     };
-    vec![account_1, account_2]
+    let account_3 = {
+        let account_3_balance = Motes::new(ACCOUNT_3_BALANCE);
+        let account_3_bonded_amount = Motes::new(ACCOUNT_3_BONDED_AMOUNT);
+        GenesisAccount::Delegator {
+            validator_public_key: ACCOUNT_1_PUBLIC_KEY.clone(),
+            delegator_public_key: ACCOUNT_3_PUBLIC_KEY.clone(),
+            balance: account_3_balance,
+            delegated_amount: account_3_bonded_amount,
+        }
+    };
+
+    vec![account_1, account_2, account_3]
 });
 
 #[ignore]

--- a/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
+++ b/execution_engine_testing/tests/src/test/system_contracts/genesis.rs
@@ -39,7 +39,6 @@ static ACCOUNT_3_PUBLIC_KEY: Lazy<PublicKey> = Lazy::new(|| {
     let secret_key = SecretKey::ed25519_from_bytes([45; SecretKey::ED25519_LENGTH]).unwrap();
     PublicKey::from(&secret_key)
 });
-static ACCOUNT_3_ADDR: Lazy<AccountHash> = Lazy::new(|| AccountHash::from(&*ACCOUNT_3_PUBLIC_KEY));
 
 static GENESIS_CUSTOM_ACCOUNTS: Lazy<Vec<GenesisAccount>> = Lazy::new(|| {
     let account_1 = {
@@ -139,6 +138,16 @@ fn should_run_genesis() {
 #[ignore]
 #[test]
 fn should_track_total_token_supply_in_mint() {
+    should_track_total_token(false)
+}
+
+#[ignore]
+#[test]
+fn should_track_total_token_supply_in_mint_with_enable_addressable_entity() {
+    should_track_total_token(true)
+}
+
+fn should_track_total_token(enable_ae: bool) {
     let accounts = GENESIS_CUSTOM_ACCOUNTS.clone();
     let wasm_config = *DEFAULT_WASM_CONFIG;
     let system_config = *DEFAULT_SYSTEM_CONFIG;
@@ -160,6 +169,7 @@ fn should_track_total_token_supply_in_mint() {
         .with_unbonding_delay(unbonding_delay)
         .with_genesis_timestamp_millis(genesis_timestamp)
         .with_storage_costs(*DEFAULT_STORAGE_COSTS)
+        .with_enable_addressable_entity(enable_ae)
         .build();
 
     let genesis_request = GenesisRequest::new(
@@ -169,7 +179,9 @@ fn should_track_total_token_supply_in_mint() {
         DEFAULT_CHAINSPEC_REGISTRY.clone(),
     );
 
-    let mut builder = LmdbWasmTestBuilder::default();
+    let chainspec_config = ChainspecConfig::default().with_enable_addressable_entity(enable_ae);
+
+    let mut builder = LmdbWasmTestBuilder::new_temporary_with_config(chainspec_config);
 
     builder.run_genesis(genesis_request);
 

--- a/storage/src/system/genesis/account_contract_installer.rs
+++ b/storage/src/system/genesis/account_contract_installer.rs
@@ -357,6 +357,8 @@ where
                     ) in genesis_delegators.iter()
                     {
                         if (*validator_public_key).clone() == public_key.clone() {
+                            total_staked_amount += delegator_delegated_amount.value();
+
                             let purse_uref =
                                 self.create_purse(delegator_delegated_amount.value())?;
 

--- a/storage/src/system/genesis/entity_installer.rs
+++ b/storage/src/system/genesis/entity_installer.rs
@@ -356,6 +356,7 @@ where
                     ) in genesis_delegators.iter()
                     {
                         if (*validator_public_key).clone() == public_key.clone() {
+                            total_staked_amount += delegator_delegated_amount.value();
                             let purse_uref =
                                 self.create_purse(delegator_delegated_amount.value())?;
 


### PR DESCRIPTION
CHANGELOG:

- Fixed a bug introduced during 2.0 that did not tally the total supply at genesis correctly. This did not affect pre-existing production networks but was discovered running a test network with a fresh genesis.