### PR TITLE
[BugFix] Fixing a bug which caused the validator matrix to not have e…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ lint-smart-contracts:
 
 .PHONY: audit-rs
 audit-rs:
-	$(CARGO) audit --ignore RUSTSEC-2024-0437 --ignore RUSTSEC-2025-0022 --ignore RUSTSEC-2025-0055 --ignore RUSTSEC-2026-0001 --ignore RUSTSEC-2026-0007
+	$(CARGO) audit --ignore RUSTSEC-2024-0437 --ignore RUSTSEC-2025-0022 --ignore RUSTSEC-2025-0055 --ignore RUSTSEC-2026-0001 --ignore RUSTSEC-2026-0007 --ignore RUSTSEC-2026-0049 --ignore RUSTSEC-2026-0068 --ignore RUSTSEC-2026-0067
 
 .PHONY: audit
 audit: audit-rs

--- a/node/src/reactor/main_reactor/validate.rs
+++ b/node/src/reactor/main_reactor/validate.rs
@@ -148,6 +148,24 @@ impl MainReactor {
             return Ok(None);
         }
 
+        // If the node was validating in the previous era there is a possibility that it didn't get
+        // a chance to apply it's finality signature to the last (or some of the last)
+        // blocks of that era. If that's true - it it might try to do that and for that it
+        // needs to have the validator matrix updated with appropriate era data.
+        // We stop saturating the validator matrix before we get to latest era, because there might
+        // have been a chainspec override of the validators during activation.
+        let number_of_switch_blocks = recent_switch_block_headers.len();
+        for i in 0..(number_of_switch_blocks - 1) {
+            if let Some(block) = recent_switch_block_headers.get(i) {
+                if let Some(validator_weights) = block.next_era_validator_weights() {
+                    self.validator_matrix.register_validator_weights(
+                        block.era_id().successor(),
+                        validator_weights.clone(),
+                    );
+                }
+            }
+        }
+
         if let HighestOrphanedBlockResult::Orphan(highest_orphaned_block_header) =
             self.storage.get_highest_orphaned_block_header()
         {


### PR DESCRIPTION
…nough validator awareness. This happened in case of a node going down in one era and coming back up in a different one, but being able to apply finality signatures to the era in which it went offline.
