### PR TITLE
Align EVM fee accounting with wei-denominated base fees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md
+
+- Use `make lint` for linting; do not run `cargo clippy` directly.
+- Use `make format` for formatting; do not run `cargo fmt` directly.
+- Prefer targeted tests for touched crates or modules when verifying changes.
+- Keep `resources/local/chainspec.toml.in` in sync when editing chainspecs; run `./generate-chainspec.sh` when `resources/local/chainspec.toml` is missing or stale.

--- a/EVM.md
+++ b/EVM.md
@@ -206,9 +206,9 @@ For client-submitted EVM transactions, the acceptor currently validates:
 5. The EVM chain ID must equal `[evm].chain_id`.
 6. The EVM gas limit must not exceed `[evm].block_gas_limit`.
 7. Legacy and [EIP-2930][eip-2930] gas price must be at least
-   `[evm].base_fee`.
+   `[evm].base_fee * [evm].wei_per_mote`.
 8. [EIP-1559][eip-1559] `max_fee_per_gas` must be at least
-   `[evm].base_fee`.
+   `[evm].base_fee * [evm].wei_per_mote`.
 9. [EIP-1559][eip-1559] `max_priority_fee_per_gas` must be zero because
    Casper does not currently prioritize transactions based on transaction gas
    parameters.
@@ -253,7 +253,8 @@ cost is derived directly from `Transaction`. For EVM:
 - the initiator is the EVM sender address, `transaction.from()`,
 - the transaction lane is currently the last configured Wasm lane,
 - the gas limit is the Ethereum transaction gas limit,
-- the maximum cost is `gas_limit * effective_gas_price`,
+- the maximum cost is
+  `ceil(gas_limit * effective_gas_price_wei / [evm].wei_per_mote)`,
 - payment is treated as standard-payment-like,
 - custom payment and refund-purse setup are skipped.
 
@@ -283,10 +284,11 @@ When execution proceeds:
    - block timestamp,
    - deterministic proposer-derived beneficiary,
    - `[evm].block_gas_limit`,
-   - `[evm].base_fee`.
+   - `[evm].base_fee * [evm].wei_per_mote`.
 5. Runtime calls `casper-executor-evm`.
 6. `revm` executes EVM account, nonce, code, storage, log, create, and value
-   transfer semantics.
+   transfer semantics. The `BASEFEE` opcode observes
+   `[evm].base_fee * [evm].wei_per_mote`, denominated in wei per EVM gas.
 7. Runtime commits EVM tracking-copy effects into scratch global state.
 8. `ExecutionArtifactBuilder` records the EVM receipt, EVM effects, and the
    consumed amount.
@@ -306,14 +308,16 @@ rather than silently emulating Ethereum's full gas escrow semantics.
 Runtime computes:
 
 ```text
-effective_gas_price = transaction.effective_gas_price([evm].base_fee)
-max_fee_amount = gas_limit * effective_gas_price
+base_fee_wei = [evm].base_fee * [evm].wei_per_mote
+effective_gas_price_wei = transaction.effective_gas_price(base_fee_wei)
+max_fee_amount_motes = ceil(gas_limit * effective_gas_price_wei / [evm].wei_per_mote)
 ```
 
-The current chainspec base fee is:
+The current chainspec base fee and conversion ratio are:
 
 ```text
 [evm].base_fee = 1_000_000 motes per EVM gas
+[evm].wei_per_mote = 1_000_000_000 wei per mote
 ```
 
 At the current `evm.block_gas_limit` of 30,000,000 gas, filling the EVM block
@@ -328,19 +332,22 @@ For legacy and [EIP-2930][eip-2930] transactions, the effective gas price is
 the signed gas price. For [EIP-1559][eip-1559] transactions, the acceptor
 requires `max_priority_fee_per_gas == 0` because Casper does not currently
 prioritize transactions based on transaction gas parameters. Accepted EIP-1559
-transactions therefore pay `[evm].base_fee`; `max_fee_per_gas` is only a
-sender cap and must be high enough to cover the base fee.
+transactions therefore pay `[evm].base_fee * [evm].wei_per_mote` in
+wei-denominated transaction fee accounting; `max_fee_per_gas` is only a sender
+cap and must be high enough to cover the scaled base fee.
 
 The maximum fee is held from the resolved EVM payer. After execution:
 
-- Successful execution consumes `gas_used * effective_gas_price`.
+- Successful execution consumes
+  `ceil(gas_used * effective_gas_price_wei / [evm].wei_per_mote)`.
 - Failed/reverted/halted execution consumes the full held amount.
 - The unconsumed portion is processed through Casper `RefundHandling`.
 - The final fee is processed through Casper `FeeHandling`.
 
 This keeps EVM transactions aligned with the same chain policy knobs used by
-Deploy and native Transaction::V1 payloads. The EVM gas price is converted to motes before
-calling the balance/fee/refund machinery.
+Deploy and native Transaction::V1 payloads. The EVM gas price is converted to
+motes after multiplying by gas used, before calling the balance/fee/refund
+machinery.
 
 In the shared accounting loop, EVM cost is already expressed as motes. Refund
 calculation therefore uses `cost_to_use()` with an effective runtime gas price
@@ -658,7 +665,7 @@ forge create --broadcast \
     --rpc-url http://127.0.0.1:11101/rpc \
     --private-key 0xb6cc5d5faa7c3c37db4bf9a1566023aaa9a1d716fe78ed1a6fb79a690b9400e8 \
     --legacy \
-    --gas-price 1000000 \
+    --gas-price 1000000000000000 \
     --gas-limit 3000000 \
     --nonce 0 \
     smart_contracts/evm_contracts/Counter.sol:Counter
@@ -668,8 +675,8 @@ The current validation uses `--legacy` because the minimum RPC surface does
 not yet include gas estimation or dynamic-fee helper methods, and Casper only
 accepts [EIP-1559][eip-1559] transactions when
 `max_priority_fee_per_gas == 0`. Passing an explicit legacy gas price equal to
-`[evm].base_fee` keeps the transaction shape simple and avoids underpriced
-transaction rejection.
+`[evm].base_fee * [evm].wei_per_mote` keeps the transaction shape simple and
+avoids underpriced transaction rejection.
 
 Expected output:
 
@@ -715,7 +722,7 @@ cast send "$COUNTER_ADDRESS" \
     --rpc-url http://127.0.0.1:11101/rpc \
     --private-key 0xb6cc5d5faa7c3c37db4bf9a1566023aaa9a1d716fe78ed1a6fb79a690b9400e8 \
     --legacy \
-    --gas-price 1000000 \
+    --gas-price 1000000000000000 \
     --gas-limit 100000 \
     --nonce 1
 ```
@@ -725,7 +732,7 @@ Expected receipt highlights:
 ```text
 status               1 (success)
 type                 0
-effectiveGasPrice    1000000
+effectiveGasPrice    1000000000000000
 gasUsed              <non-zero gas used, including the event LOG cost>
 to                   0x6c0704679CA22b83778Ef815607359cf6F5352B6
 transactionHash      0x042ff975ec4b8fa8012f486bb7bd930e69978782b8b3c107ca2a276a43d7f293
@@ -844,7 +851,7 @@ cast send "$AUTHORITY_ADDRESS" \
     --rpc-url "$RPC_URL" \
     --private-key "$USER_PRIVATE_KEY" \
     --auth "$SET_CODE_AUTH" \
-    --gas-price 1000000 \
+    --gas-price 1000000000000000 \
     --priority-gas-price 0 \
     --gas-limit 300000 \
     --nonce "$USER_NONCE" \
@@ -910,7 +917,7 @@ cast send "$AUTHORITY_ADDRESS" \
     --rpc-url "$RPC_URL" \
     --private-key "$USER_PRIVATE_KEY" \
     --legacy \
-    --gas-price 1000000 \
+    --gas-price 1000000000000000 \
     --gas-limit 100000 \
     --nonce "$USER_NONCE" \
     --json | tee /tmp/casper-eip7702-persisted-delegation.json
@@ -936,8 +943,8 @@ backing purse, not from `user-1`'s Casper account purse:
 casper-cli account balance devnet:user-1
 ```
 
-With `--gas-price 1000000`, every 1,000 gas consumed is 1 CSPR before refund
-policy is applied.
+With `--gas-price 1000000000000000`, every 1,000 gas consumed is 1 CSPR
+before refund policy is applied.
 
 ## Useful Checks
 

--- a/executor/evm/src/executor.rs
+++ b/executor/evm/src/executor.rs
@@ -83,7 +83,7 @@ impl EvmExecutor {
 
         let spec = spec_id(self.config.spec);
         let tx_env = tx::build_tx_env(&self.config, &request.kind)?;
-        let block = request.block.to_revm_block(&self.config);
+        let block = request.block.to_revm_block(&self.config)?;
         let skip_validation = match &request.kind {
             ExecuteKind::Transaction(_) => false,
             ExecuteKind::Call(call) => call.validation.is_unchecked_simulation(),
@@ -127,12 +127,15 @@ fn disabled_fee_transfers(
     result: &RevmExecutionResult,
 ) -> state::DisabledFeeTransfers {
     let gas = result_gas(result);
-    let base_fee = u128::from(request.block.base_fee.unwrap_or(config.base_fee));
+    let base_fee = request
+        .block
+        .base_fee
+        .unwrap_or_else(|| config.base_fee_wei());
     let (caller, gas_limit, effective_gas_price) = match &request.kind {
         ExecuteKind::Transaction(transaction) => (
             tx::to_revm_address(transaction.from()),
             transaction.gas_limit(),
-            transaction.effective_gas_price(base_fee as u64),
+            transaction.effective_gas_price(base_fee),
         ),
         ExecuteKind::Call(call) => (
             tx::to_revm_address(call.from),

--- a/executor/evm/src/request.rs
+++ b/executor/evm/src/request.rs
@@ -2,7 +2,7 @@
 
 use casper_types::{evm, EvmConfig, EvmTransaction, U256};
 
-use crate::tx;
+use crate::{tx, Error};
 
 /// Request passed to [`crate::EvmExecutor::execute`].
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -73,19 +73,57 @@ pub struct BlockContext {
     pub beneficiary: evm::Address,
     /// Optional gas limit override. Defaults to chainspec `[evm].block_gas_limit`.
     pub gas_limit: Option<u64>,
-    /// Optional base-fee override. Defaults to chainspec `[evm].base_fee`.
-    pub base_fee: Option<u64>,
+    /// Optional base-fee override in wei.
+    ///
+    /// Defaults to chainspec `[evm].base_fee * [evm].wei_per_mote`.
+    pub base_fee: Option<u128>,
 }
 
 impl BlockContext {
-    pub(crate) fn to_revm_block(&self, config: &EvmConfig) -> revm::context::BlockEnv {
-        revm::context::BlockEnv {
+    pub(crate) fn to_revm_block(
+        &self,
+        config: &EvmConfig,
+    ) -> Result<revm::context::BlockEnv, Error> {
+        let base_fee = self.base_fee.unwrap_or_else(|| config.base_fee_wei());
+        let basefee = u64::try_from(base_fee).map_err(|_| {
+            Error::Transaction("configured EVM base fee overflows revm u64".to_string())
+        })?;
+        Ok(revm::context::BlockEnv {
             number: revm::primitives::U256::from(self.number),
             beneficiary: tx::to_revm_address(self.beneficiary),
             timestamp: revm::primitives::U256::from(self.timestamp),
             gas_limit: self.gas_limit.unwrap_or(config.block_gas_limit),
-            basefee: self.base_fee.unwrap_or(config.base_fee),
+            basefee,
             ..Default::default()
-        }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use casper_types::DEFAULT_WEI_PER_MOTE;
+
+    use super::*;
+
+    #[test]
+    fn should_use_wei_denominated_base_fee_for_revm_block() {
+        let config = EvmConfig {
+            base_fee: 3,
+            wei_per_mote: DEFAULT_WEI_PER_MOTE,
+            ..Default::default()
+        };
+        let context = BlockContext {
+            number: 1,
+            timestamp: 1,
+            beneficiary: evm::Address::ZERO,
+            gas_limit: None,
+            base_fee: None,
+        };
+        let block = context
+            .to_revm_block(&config)
+            .expect("base fee should fit in revm block context");
+
+        assert_eq!(u128::from(block.basefee), config.base_fee_wei());
+        assert_ne!(block.basefee, config.base_fee);
     }
 }

--- a/executor/evm/tests/executor.rs
+++ b/executor/evm/tests/executor.rs
@@ -27,7 +27,7 @@ use casper_types::{
     evm, AccessRights, Account, BlockHash, CLValue, ChainspecRegistry, Digest, EvmAddr, EvmConfig,
     EvmSpec, EvmTransaction, GenesisAccount, GenesisConfig, HoldBalanceHandling, Key, Motes,
     ProtocolVersion, PublicKey, SecretKey, StorageCosts, StoredValue, SystemConfig, Timestamp,
-    URef, WasmConfig, U256 as CasperU256, U512,
+    URef, WasmConfig, DEFAULT_WEI_PER_MOTE, U256 as CasperU256, U512,
 };
 use revm::bytecode::opcode;
 
@@ -93,6 +93,7 @@ fn executor(spec: EvmSpec) -> EvmExecutor {
         spec,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     })
 }
 
@@ -1099,6 +1100,7 @@ fn signed_transactions_require_configured_chain_id() {
         spec: EvmSpec::Prague,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     });
     let transaction = legacy_transaction(Some(7));
     let request = ExecuteRequest {

--- a/node/src/components/contract_runtime/operations.rs
+++ b/node/src/components/contract_runtime/operations.rs
@@ -86,6 +86,22 @@ fn evm_precondition_receipt(effective_gas_price: u128) -> EvmReceipt {
     }
 }
 
+fn execution_min_cost(
+    is_evm: bool,
+    gas_limit: Gas,
+    cost: U512,
+    baseline_motes_amount: U512,
+) -> U512 {
+    let min_cost = gas_limit.value().min(baseline_motes_amount);
+    // EVM cost is already converted to motes. Do not let the raw EVM gas
+    // limit raise the minimum above the maximum converted fee.
+    if is_evm {
+        min_cost.min(cost)
+    } else {
+        min_cost
+    }
+}
+
 #[derive(Clone, Debug)]
 enum RuntimeOrigin {
     Initiator {
@@ -668,7 +684,9 @@ pub fn execute_finalized_block(
                 }
             };
 
-            // NOTE: this is the actual adjusted cost that we charge for (gas limit * gas price).
+            // NOTE: this is the actual adjusted cost that we charge for.
+            // Native transactions use gas limit * Casper gas price. EVM
+            // transactions convert gas limit * EVM gas price from wei to motes.
             // For accepted EIP-1559 transactions, config compliance has already required
             // `max_priority_fee_per_gas == 0`, so the effective EVM gas price is the
             // configured base fee capped by `max_fee_per_gas`; Casper does not charge an
@@ -701,7 +719,7 @@ pub fn execute_finalized_block(
             };
 
             // this is the minimum we will charge, even if 0 is consumed
-            let min_cost = gas_limit.value().min(baseline_motes_amount);
+            let min_cost = execution_min_cost(is_evm, gas_limit, cost, baseline_motes_amount);
             ExecutionArtifactBuilder::new(
                 &stored_transaction,
                 gas_limit,
@@ -778,7 +796,8 @@ pub fn execute_finalized_block(
                 if let Some(evm_transaction) = evm_transaction {
                     artifact_builder.with_zero_cost().with_evm_receipt(
                         evm_precondition_receipt(
-                            evm_transaction.effective_gas_price(chainspec.evm_config.base_fee),
+                            evm_transaction
+                                .effective_gas_price(chainspec.evm_config.base_fee_wei()),
                         ),
                         U512::zero(),
                         Effects::new(),
@@ -1083,13 +1102,14 @@ pub fn execute_finalized_block(
                 }
                 _ if is_evm => {
                     let evm_transaction = evm_transaction.expect("EVM transaction should exist");
+                    let base_fee_wei = chainspec.evm_config.base_fee_wei();
                     let block_context = EvmBlockContext {
                         number: block_height,
                         timestamp: block_time.value() / 1000,
                         beneficiary: EvmAddress::from_public_key(&proposer)
                             .unwrap_or(EvmAddress::ZERO),
                         gas_limit: Some(chainspec.evm_config.block_gas_limit),
-                        base_fee: Some(chainspec.evm_config.base_fee),
+                        base_fee: Some(base_fee_wei),
                     };
                     let request = EvmExecuteRequest {
                         block: block_context,
@@ -1122,8 +1142,7 @@ pub fn execute_finalized_block(
                     let execution_effects = tracking_copy.effects();
                     state_root_hash =
                         scratch_state.commit_effects(state_root_hash, execution_effects.clone())?;
-                    let effective_gas_price =
-                        evm_transaction.effective_gas_price(chainspec.evm_config.base_fee);
+                    let effective_gas_price = evm_transaction.effective_gas_price(base_fee_wei);
                     let consumed = if matches!(outcome.status, EvmExecutionStatus::Success) {
                         evm_transaction
                             .fee_amount(outcome.gas_used, &chainspec.evm_config)
@@ -1237,7 +1256,7 @@ pub fn execute_finalized_block(
         if is_evm && !allow_execution {
             let effective_gas_price = evm_transaction
                 .expect("EVM transaction should exist")
-                .effective_gas_price(chainspec.evm_config.base_fee);
+                .effective_gas_price(chainspec.evm_config.base_fee_wei());
             artifact_builder.with_zero_cost().with_evm_receipt(
                 evm_precondition_receipt(effective_gas_price),
                 U512::zero(),
@@ -2059,12 +2078,13 @@ where
     let block_time = block_header
         .timestamp()
         .saturating_add(chainspec.core_config.minimum_block_time);
+    let base_fee_wei = chainspec.evm_config.base_fee_wei();
     let block_context = EvmBlockContext {
         number: block_header.height(),
         timestamp: block_time.millis() / 1000,
         beneficiary: EvmAddress::ZERO,
         gas_limit: Some(chainspec.evm_config.block_gas_limit),
-        base_fee: Some(chainspec.evm_config.base_fee),
+        base_fee: Some(base_fee_wei),
     };
     let kind = if evm_transaction.is_unsigned_call() {
         EvmExecuteKind::Call(EvmExecutorCallRequest {
@@ -2073,7 +2093,7 @@ where
             value: evm_transaction.value(),
             input: evm_transaction.input().to_vec(),
             gas_limit: evm_transaction.gas_limit(),
-            gas_price: u128::from(chainspec.evm_config.base_fee),
+            gas_price: base_fee_wei,
             nonce: evm_transaction.nonce(),
             validation: EvmCallValidation::UncheckedSimulation,
         })
@@ -2099,9 +2119,9 @@ where
     };
     let effects = tracking_copy.effects();
     let effective_gas_price = if evm_transaction.is_unsigned_call() {
-        u128::from(chainspec.evm_config.base_fee)
+        base_fee_wei
     } else {
-        evm_transaction.effective_gas_price(chainspec.evm_config.base_fee)
+        evm_transaction.effective_gas_price(base_fee_wei)
     };
     let receipt = outcome.to_receipt(effective_gas_price);
     let error = receipt.status.message().map(str::to_string);
@@ -2235,4 +2255,33 @@ pub(crate) fn compute_execution_results_checksum<'a>(
     serialized.hash().map_err(|_| {
         BlockExecutionError::FailedToComputeExecutionResultsChecksum(bytesrepr::Error::OutOfMemory)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_not_raise_evm_min_cost_above_converted_fee() {
+        let gas_limit = Gas::new(21_000);
+        let cost = U512::from(1);
+        let baseline_motes_amount = U512::from(1_000_000);
+
+        assert_eq!(
+            execution_min_cost(true, gas_limit, cost, baseline_motes_amount),
+            cost
+        );
+    }
+
+    #[test]
+    fn should_keep_native_min_cost_based_on_gas_limit() {
+        let gas_limit = Gas::new(21_000);
+        let cost = U512::from(1);
+        let baseline_motes_amount = U512::from(1_000_000);
+
+        assert_eq!(
+            execution_min_cost(false, gas_limit, cost, baseline_motes_amount),
+            U512::from(21_000)
+        );
+    }
 }

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -79,7 +79,7 @@ use crate::{
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const TIMEOUT: Duration = Duration::from_secs(30);
 const EVM_TEST_CHAIN_ID: u64 = 1_129_533_695;
-const EVM_TEST_GAS_PRICE: u128 = 1_000_000;
+const EVM_TEST_GAS_PRICE: u128 = 1_000_000_000_000_000;
 
 /// Top-level event for the reactor.
 #[derive(Debug, From, Serialize)]

--- a/node/src/reactor/main_reactor/tests/transactions.rs
+++ b/node/src/reactor/main_reactor/tests/transactions.rs
@@ -37,7 +37,7 @@ use casper_types::{
     bytesrepr::{Bytes, ToBytes},
     evm,
     execution::ExecutionResultV1,
-    EvmAddr, EvmConfig, EvmSpec, EvmTransaction,
+    EvmAddr, EvmConfig, EvmSpec, EvmTransaction, DEFAULT_WEI_PER_MOTE,
 };
 
 pub(crate) static ALICE_SECRET_KEY: Lazy<Arc<SecretKey>> = Lazy::new(|| {
@@ -824,7 +824,7 @@ pub fn exec_result_is_success(exec_result: &ExecutionResult) -> bool {
 }
 
 const EVM_TEST_GAS_LIMIT: u64 = 500_000;
-const EVM_TEST_GAS_PRICE: u128 = 1;
+const EVM_TEST_GAS_PRICE: u128 = DEFAULT_WEI_PER_MOTE as u128;
 const EVM_INITIAL_BALANCE: u64 = 10_000_000_000_000;
 const EVM_LOG_TOPIC: evm::Topic = evm::Topic::new([0xAB; evm::HASH_LENGTH]);
 
@@ -1126,6 +1126,7 @@ async fn should_execute_evm_transaction_and_store_receipt() {
         spec: EvmSpec::Prague,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     };
     let config = SingleTransactionTestCase::default_test_config()
         .with_evm_config(evm_config)
@@ -1164,10 +1165,12 @@ async fn should_execute_evm_transaction_and_store_receipt() {
     assert_eq!(execution_result.receipt.status, evm::ReceiptStatus::Success);
     assert_eq!(
         execution_result.receipt.effective_gas_price,
-        evm_transaction.effective_gas_price(evm_config.base_fee)
+        evm_transaction.effective_gas_price(evm_config.base_fee_wei())
     );
     assert!(execution_result.receipt.gas_used > 0);
-    let max_fee_amount = U512::from(evm_transaction.gas_limit()) * U512::from(EVM_TEST_GAS_PRICE);
+    let max_fee_amount = evm_transaction
+        .max_fee_amount(&evm_config)
+        .expect("max EVM fee should fit");
     assert_eq!(execution_result.cost, max_fee_amount);
     assert_eq!(execution_result.refund, U512::zero());
     assert!(execution_result.receipt.contract_address.is_some());
@@ -1202,6 +1205,7 @@ async fn should_apply_casper_refund_handling_to_evm_transaction() {
         spec: EvmSpec::Prague,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     };
     let config = SingleTransactionTestCase::default_test_config()
         .with_evm_config(evm_config)
@@ -1232,9 +1236,12 @@ async fn should_apply_casper_refund_handling_to_evm_transaction() {
         panic!("expected EVM execution result");
     };
 
-    let max_fee_amount = U512::from(evm_transaction.gas_limit()) * U512::from(EVM_TEST_GAS_PRICE);
-    let consumed_fee_amount =
-        U512::from(execution_result.receipt.gas_used) * U512::from(EVM_TEST_GAS_PRICE);
+    let max_fee_amount = evm_transaction
+        .max_fee_amount(&evm_config)
+        .expect("max EVM fee should fit");
+    let consumed_fee_amount = evm_transaction
+        .fee_amount(execution_result.receipt.gas_used, &evm_config)
+        .expect("consumed EVM fee should fit");
 
     assert_eq!(execution_result.receipt.status, evm::ReceiptStatus::Success);
     assert_eq!(execution_result.cost, max_fee_amount);
@@ -1255,6 +1262,7 @@ async fn should_reject_evm_transaction_when_value_and_fee_exceed_balance() {
         spec: EvmSpec::Prague,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     };
     let config = SingleTransactionTestCase::default_test_config()
         .with_evm_config(evm_config)
@@ -1321,6 +1329,7 @@ async fn should_not_seed_evm_accounts_at_genesis() {
         spec: EvmSpec::Prague,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     };
     let config = SingleTransactionTestCase::default_test_config().with_evm_config(evm_config);
     let alice_secret_key = Arc::new(
@@ -1371,6 +1380,7 @@ async fn should_transfer_to_evm_address_with_native_transfer() {
         spec: EvmSpec::Prague,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     };
     let config = SingleTransactionTestCase::default_test_config()
         .with_evm_config(evm_config)
@@ -1443,6 +1453,7 @@ async fn should_reject_native_transfer_to_evm_contract_address() {
         spec: EvmSpec::Prague,
         block_gas_limit: 30_000_000,
         base_fee: 0,
+        wei_per_mote: DEFAULT_WEI_PER_MOTE,
     };
     let config = SingleTransactionTestCase::default_test_config()
         .with_evm_config(evm_config)

--- a/node/src/types/transaction/meta_transaction.rs
+++ b/node/src/types/transaction/meta_transaction.rs
@@ -547,16 +547,19 @@ mod tests {
     use alloy_consensus::{SignableTransaction, TxEip1559, TxEip7702, TxEnvelope, TxLegacy};
     use alloy_eips::{eip2718::Encodable2718, eip7702::Authorization as AlloyAuthorization};
     use alloy_primitives::{Address as AlloyAddress, Signature, TxKind, U256};
-    use casper_types::{evm, EvmTransactionError, InitiatorAddr, TransactionLaneDefinition};
+    use casper_types::{
+        evm, EvmTransactionError, InitiatorAddr, TransactionLaneDefinition, DEFAULT_WEI_PER_MOTE,
+    };
 
     const CHAIN_ID: u64 = 7;
     const BASE_FEE: u64 = 1_000_000;
+    const BASE_FEE_WEI: u128 = BASE_FEE as u128 * DEFAULT_WEI_PER_MOTE as u128;
     const EVM_LANE: u8 = 4;
 
     #[test]
     fn evm_from_transaction_exposes_metadata() {
         let chainspec = chainspec();
-        let evm_transaction = legacy_transaction(Some(CHAIN_ID), BASE_FEE.into(), 21_000);
+        let evm_transaction = legacy_transaction(Some(CHAIN_ID), BASE_FEE_WEI, 21_000);
         let transaction = Transaction::from_evm(evm_transaction.clone());
         let meta = MetaTransaction::from_transaction(
             &transaction,
@@ -588,7 +591,7 @@ mod tests {
 
     #[test]
     fn evm_transaction_header_keeps_initiator_addr() {
-        let evm_transaction = legacy_transaction(Some(CHAIN_ID), BASE_FEE.into(), 21_000);
+        let evm_transaction = legacy_transaction(Some(CHAIN_ID), BASE_FEE_WEI, 21_000);
         let expected_signer = evm_transaction
             .signer()
             .expect("signed EVM transaction should have an approval signer")
@@ -615,7 +618,7 @@ mod tests {
             .transaction_v1_config
             .set_wasm_lanes(vec![]);
         let transaction =
-            Transaction::from_evm(legacy_transaction(Some(CHAIN_ID), BASE_FEE.into(), 21_000));
+            Transaction::from_evm(legacy_transaction(Some(CHAIN_ID), BASE_FEE_WEI, 21_000));
         let error = MetaTransaction::from_transaction(
             &transaction,
             chainspec.core_config.pricing_handling,
@@ -634,7 +637,7 @@ mod tests {
         chainspec.evm_config.enabled = false;
         let meta = evm_meta(
             &chainspec,
-            legacy_transaction(Some(CHAIN_ID), BASE_FEE.into(), 21_000),
+            legacy_transaction(Some(CHAIN_ID), BASE_FEE_WEI, 21_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
@@ -645,10 +648,7 @@ mod tests {
     #[test]
     fn evm_config_compliance_rejects_missing_chain_id() {
         let chainspec = chainspec();
-        let meta = evm_meta(
-            &chainspec,
-            legacy_transaction(None, BASE_FEE.into(), 21_000),
-        );
+        let meta = evm_meta(&chainspec, legacy_transaction(None, BASE_FEE_WEI, 21_000));
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
             Err(InvalidTransaction::Evm(EvmTransactionError::MissingChainId))
@@ -660,7 +660,7 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            legacy_transaction(Some(CHAIN_ID + 1), BASE_FEE.into(), 21_000),
+            legacy_transaction(Some(CHAIN_ID + 1), BASE_FEE_WEI, 21_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
@@ -676,21 +676,21 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            legacy_transaction(Some(CHAIN_ID), (BASE_FEE - 1).into(), 21_000),
+            legacy_transaction(Some(CHAIN_ID), BASE_FEE_WEI - 1, 21_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
             Err(InvalidTransaction::Evm(EvmTransactionError::GasPriceBelowBaseFee {
                 gas_price,
                 base_fee
-            })) if gas_price == u128::from(BASE_FEE - 1) && base_fee == u128::from(BASE_FEE)
+            })) if gas_price == BASE_FEE_WEI - 1 && base_fee == BASE_FEE_WEI
         ));
     }
 
     #[test]
     fn evm_config_compliance_accepts_unsigned_call() {
         let chainspec = chainspec();
-        let meta = evm_meta(&chainspec, unsigned_call(CHAIN_ID, BASE_FEE.into(), 21_000));
+        let meta = evm_meta(&chainspec, unsigned_call(CHAIN_ID, BASE_FEE_WEI, 21_000));
         meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero())
             .expect("unsigned EVM call should be config compliant");
     }
@@ -700,7 +700,7 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            unsigned_call(CHAIN_ID + 1, BASE_FEE.into(), 21_000),
+            unsigned_call(CHAIN_ID + 1, BASE_FEE_WEI, 21_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
@@ -716,44 +716,41 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            unsigned_call(CHAIN_ID, u128::from(BASE_FEE - 1), 21_000),
+            unsigned_call(CHAIN_ID, BASE_FEE_WEI - 1, 21_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
             Err(InvalidTransaction::Evm(EvmTransactionError::GasPriceBelowBaseFee {
                 gas_price,
                 base_fee
-            })) if gas_price == u128::from(BASE_FEE - 1) && base_fee == u128::from(BASE_FEE)
+            })) if gas_price == BASE_FEE_WEI - 1 && base_fee == BASE_FEE_WEI
         ));
     }
 
     #[test]
     fn evm_config_compliance_rejects_max_fee_below_base_fee() {
         let chainspec = chainspec();
-        let meta = evm_meta(
-            &chainspec,
-            eip1559_transaction(u128::from(BASE_FEE - 1), 0, 60_000),
-        );
+        let meta = evm_meta(&chainspec, eip1559_transaction(BASE_FEE_WEI - 1, 0, 60_000));
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
             Err(InvalidTransaction::Evm(EvmTransactionError::MaxFeePerGasBelowBaseFee {
                 max_fee_per_gas,
                 base_fee
-            })) if max_fee_per_gas == u128::from(BASE_FEE - 1) && base_fee == u128::from(BASE_FEE)
+            })) if max_fee_per_gas == BASE_FEE_WEI - 1 && base_fee == BASE_FEE_WEI
         ));
     }
 
     #[test]
     fn evm_config_compliance_rejects_non_zero_priority_fee() {
         let chainspec = chainspec();
-        let meta = evm_meta(&chainspec, eip1559_transaction(BASE_FEE.into(), 1, 60_000));
+        let meta = evm_meta(&chainspec, eip1559_transaction(BASE_FEE_WEI, 1, 60_000));
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
             Err(InvalidTransaction::Evm(
                 EvmTransactionError::NonZeroMaxPriorityFeePerGas {
-                    max_priority_fee_per_gas: 1
+                    max_priority_fee_per_gas
                 }
-            ))
+            )) if max_priority_fee_per_gas == 1
         ));
     }
 
@@ -762,7 +759,7 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            eip7702_transaction(CHAIN_ID, BASE_FEE.into(), 0, 60_000),
+            eip7702_transaction(CHAIN_ID, BASE_FEE_WEI, 0, 60_000),
         );
         meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero())
             .expect("valid EIP-7702 transaction should be config compliant");
@@ -773,7 +770,7 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            eip7702_transaction(CHAIN_ID + 1, BASE_FEE.into(), 0, 60_000),
+            eip7702_transaction(CHAIN_ID + 1, BASE_FEE_WEI, 0, 60_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
@@ -789,14 +786,14 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            eip7702_transaction(CHAIN_ID, u128::from(BASE_FEE - 1), 0, 60_000),
+            eip7702_transaction(CHAIN_ID, BASE_FEE_WEI - 1, 0, 60_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
             Err(InvalidTransaction::Evm(EvmTransactionError::MaxFeePerGasBelowBaseFee {
                 max_fee_per_gas,
                 base_fee
-            })) if max_fee_per_gas == u128::from(BASE_FEE - 1) && base_fee == u128::from(BASE_FEE)
+            })) if max_fee_per_gas == BASE_FEE_WEI - 1 && base_fee == BASE_FEE_WEI
         ));
     }
 
@@ -805,15 +802,15 @@ mod tests {
         let chainspec = chainspec();
         let meta = evm_meta(
             &chainspec,
-            eip7702_transaction(CHAIN_ID, BASE_FEE.into(), 1, 60_000),
+            eip7702_transaction(CHAIN_ID, BASE_FEE_WEI, 1, 60_000),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
             Err(InvalidTransaction::Evm(
                 EvmTransactionError::NonZeroMaxPriorityFeePerGas {
-                    max_priority_fee_per_gas: 1
+                    max_priority_fee_per_gas
                 }
-            ))
+            )) if max_priority_fee_per_gas == 1
         ));
     }
 
@@ -823,7 +820,7 @@ mod tests {
         let gas_limit = chainspec.evm_config.block_gas_limit + 1;
         let meta = evm_meta(
             &chainspec,
-            legacy_transaction(Some(CHAIN_ID), BASE_FEE.into(), gas_limit),
+            legacy_transaction(Some(CHAIN_ID), BASE_FEE_WEI, gas_limit),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
@@ -840,7 +837,7 @@ mod tests {
         let gas_limit = chainspec.evm_config.block_gas_limit + 1;
         let meta = evm_meta(
             &chainspec,
-            eip7702_transaction(CHAIN_ID, BASE_FEE.into(), 0, gas_limit),
+            eip7702_transaction(CHAIN_ID, BASE_FEE_WEI, 0, gas_limit),
         );
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),
@@ -855,7 +852,7 @@ mod tests {
     fn evm_config_compliance_rejects_invalid_approval() {
         let chainspec = chainspec();
         let evm_transaction =
-            legacy_transaction(Some(CHAIN_ID), BASE_FEE.into(), 21_000).with_evm_approval(None);
+            legacy_transaction(Some(CHAIN_ID), BASE_FEE_WEI, 21_000).with_evm_approval(None);
         let meta = evm_meta(&chainspec, evm_transaction);
         assert!(matches!(
             meta.is_config_compliant(&chainspec, TimeDiff::from_seconds(0), Timestamp::zero()),

--- a/node/src/types/transaction/meta_transaction/meta_evm.rs
+++ b/node/src/types/transaction/meta_transaction/meta_evm.rs
@@ -114,7 +114,7 @@ impl MetaEvmTransaction {
             });
         }
 
-        let base_fee = u128::from(evm_config.base_fee);
+        let base_fee = evm_config.base_fee_wei();
         match transaction.kind() {
             EvmTransactionKind::Legacy | EvmTransactionKind::Eip2930 => {
                 let gas_price = transaction

--- a/node/src/utils/chain_specification.rs
+++ b/node/src/utils/chain_specification.rs
@@ -10,7 +10,7 @@ use tracing::{error, info, warn};
 use casper_types::{
     system::auction::VESTING_SCHEDULE_LENGTH_MILLIS, Chainspec, ConsensusProtocolName, CoreConfig,
     ProtocolConfig, TimeDiff, TransactionConfig, AUCTION_LANE_ID, INSTALL_UPGRADE_LANE_ID,
-    MINT_LANE_ID,
+    MINIMUM_WEI_PER_MOTE, MINT_LANE_ID,
 };
 
 use crate::components::network;
@@ -37,6 +37,26 @@ pub fn validate_chainspec(chainspec: &Chainspec) -> bool {
             < chainspec.core_config.minimum_block_time * chainspec.core_config.minimum_era_height
     {
         warn!("era duration is less than minimum era height * block time!");
+    }
+
+    if chainspec.evm_config.wei_per_mote < MINIMUM_WEI_PER_MOTE {
+        error!(
+            wei_per_mote = chainspec.evm_config.wei_per_mote,
+            minimum = MINIMUM_WEI_PER_MOTE,
+            "EVM wei-per-mote ratio must be at least the default mote/wei scale",
+        );
+        return false;
+    }
+
+    // EVM fee accounting uses u128/U512, but the current revm BlockEnv stores
+    // the block base fee as u64. Reject chainspecs this executor cannot run.
+    if u64::try_from(chainspec.evm_config.base_fee_wei()).is_err() {
+        error!(
+            base_fee = chainspec.evm_config.base_fee,
+            wei_per_mote = chainspec.evm_config.wei_per_mote,
+            "EVM base fee converted to wei exceeds the current revm BlockEnv base fee limit",
+        );
+        return false;
     }
 
     if chainspec.core_config.consensus_protocol == ConsensusProtocolName::Highway {
@@ -788,6 +808,22 @@ mod tests {
         fail_validation_with_lane_id(MINT_LANE_ID);
         fail_validation_with_lane_id(AUCTION_LANE_ID);
         fail_validation_with_lane_id(INSTALL_UPGRADE_LANE_ID);
+    }
+
+    #[test]
+    fn should_fail_when_wei_per_mote_is_too_low() {
+        let (mut chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
+        chainspec.evm_config.wei_per_mote = MINIMUM_WEI_PER_MOTE - 1;
+
+        assert!(!validate_chainspec(&chainspec));
+    }
+
+    #[test]
+    fn should_fail_when_scaled_evm_base_fee_exceeds_revm_limit() {
+        let (mut chainspec, _) = <(Chainspec, ChainspecRawBytes)>::from_resources("local");
+        chainspec.evm_config.base_fee = u64::MAX;
+
+        assert!(!validate_chainspec(&chainspec));
     }
 
     fn fail_validation_with_lane_id(lane_id: u8) {

--- a/resources/integration-test/chainspec.toml
+++ b/resources/integration-test/chainspec.toml
@@ -522,3 +522,6 @@ block_gas_limit = 30_000_000
 # cheap enough for testing but expensive enough to discourage fill-block
 # spam with low-value logs or memory-heavy execution.
 base_fee = 1_000_000
+# Number of wei represented by one mote. EVM gas prices are denominated in wei,
+# while Casper fee accounting is denominated in motes.
+wei_per_mote = 1_000_000_000

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -514,3 +514,6 @@ block_gas_limit = 30_000_000
 # cheap enough for testing but expensive enough to discourage fill-block
 # spam with low-value logs or memory-heavy execution.
 base_fee = 1_000_000
+# Number of wei represented by one mote. EVM gas prices are denominated in wei,
+# while Casper fee accounting is denominated in motes.
+wei_per_mote = 1_000_000_000

--- a/resources/mainnet/chainspec.toml
+++ b/resources/mainnet/chainspec.toml
@@ -522,3 +522,6 @@ block_gas_limit = 30_000_000
 # cheap enough for testing but expensive enough to discourage fill-block
 # spam with low-value logs or memory-heavy execution.
 base_fee = 1_000_000
+# Number of wei represented by one mote. EVM gas prices are denominated in wei,
+# while Casper fee accounting is denominated in motes.
+wei_per_mote = 1_000_000_000

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -521,3 +521,6 @@ block_gas_limit = 30_000_000
 # cheap enough for testing but expensive enough to discourage fill-block
 # spam with low-value logs or memory-heavy execution.
 base_fee = 1_000_000
+# Number of wei represented by one mote. EVM gas prices are denominated in wei,
+# while Casper fee accounting is denominated in motes.
+wei_per_mote = 1_000_000_000

--- a/resources/testnet/chainspec.toml
+++ b/resources/testnet/chainspec.toml
@@ -524,3 +524,6 @@ block_gas_limit = 30_000_000
 # cheap enough for testing but expensive enough to discourage fill-block
 # spam with low-value logs or memory-heavy execution.
 base_fee = 1_000_000
+# Number of wei represented by one mote. EVM gas prices are denominated in wei,
+# while Casper fee accounting is denominated in motes.
+wei_per_mote = 1_000_000_000

--- a/types/src/evm.rs
+++ b/types/src/evm.rs
@@ -28,7 +28,7 @@ pub use transaction::{
 // (`casper_types::EvmFoo`), not through `casper_types::evm::EvmFoo`.
 // They are re-exported here so the rest of `casper-types` can import them
 // without going through the crate root.
-pub use config::{EvmConfig, EvmSpec};
+pub use config::{EvmConfig, EvmSpec, DEFAULT_WEI_PER_MOTE, MINIMUM_WEI_PER_MOTE};
 pub use evm_addr::EvmAddr;
 pub use transaction::{
     EvmApproval, EvmTransaction, EvmTransactionError, EvmTransactionHash, EvmTransactionKind,

--- a/types/src/evm/config.rs
+++ b/types/src/evm/config.rs
@@ -2,11 +2,21 @@ use alloc::vec::Vec;
 
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
+use num_rational::Ratio;
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH};
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
+    U512,
+};
+
+/// The default number of wei represented by one mote.
+pub const DEFAULT_WEI_PER_MOTE: u64 = 1_000_000_000;
+
+/// The minimum number of wei represented by one mote.
+pub const MINIMUM_WEI_PER_MOTE: u64 = DEFAULT_WEI_PER_MOTE;
 
 /// Supported EVM hardfork specifications for chainspec configuration.
 #[derive(
@@ -69,8 +79,10 @@ pub struct EvmConfig {
     pub spec: EvmSpec,
     /// Per-block gas limit supplied to the EVM block context.
     pub block_gas_limit: u64,
-    /// Base fee supplied to the EVM block context.
+    /// Base fee denominated in motes per EVM gas.
     pub base_fee: u64,
+    /// Number of wei represented by one mote.
+    pub wei_per_mote: u64,
 }
 
 impl Default for EvmConfig {
@@ -81,7 +93,31 @@ impl Default for EvmConfig {
             spec: EvmSpec::Prague,
             block_gas_limit: 30_000_000,
             base_fee: 0,
+            wei_per_mote: DEFAULT_WEI_PER_MOTE,
         }
+    }
+}
+
+impl EvmConfig {
+    /// Returns the EVM base fee denominated in wei.
+    pub fn base_fee_wei(&self) -> u128 {
+        u128::from(self.base_fee) * u128::from(self.wei_per_mote)
+    }
+
+    /// Converts an EVM gas cost, denominated in wei, to motes by rounding up.
+    ///
+    /// Rounding is applied after multiplying gas by price, so sub-mote totals
+    /// are charged as one mote without overcharging each gas unit separately.
+    pub fn gas_fee_motes(&self, gas: u64, gas_price_wei: u128) -> Option<U512> {
+        if self.wei_per_mote == 0 {
+            return None;
+        }
+        let fee_wei = U512::from(gas).checked_mul(U512::from(gas_price_wei))?;
+        Some(
+            Ratio::new(fee_wei, U512::from(self.wei_per_mote))
+                .ceil()
+                .to_integer(),
+        )
     }
 }
 
@@ -98,6 +134,7 @@ impl ToBytes for EvmConfig {
             + self.spec.serialized_length()
             + self.block_gas_limit.serialized_length()
             + self.base_fee.serialized_length()
+            + self.wei_per_mote.serialized_length()
     }
 
     fn write_bytes(&self, writer: &mut Vec<u8>) -> Result<(), bytesrepr::Error> {
@@ -105,7 +142,8 @@ impl ToBytes for EvmConfig {
         self.chain_id.write_bytes(writer)?;
         self.spec.write_bytes(writer)?;
         self.block_gas_limit.write_bytes(writer)?;
-        self.base_fee.write_bytes(writer)
+        self.base_fee.write_bytes(writer)?;
+        self.wei_per_mote.write_bytes(writer)
     }
 }
 
@@ -116,6 +154,7 @@ impl FromBytes for EvmConfig {
         let (spec, remainder) = EvmSpec::from_bytes(remainder)?;
         let (block_gas_limit, remainder) = u64::from_bytes(remainder)?;
         let (base_fee, remainder) = u64::from_bytes(remainder)?;
+        let (wei_per_mote, remainder) = u64::from_bytes(remainder)?;
         Ok((
             EvmConfig {
                 enabled,
@@ -123,8 +162,41 @@ impl FromBytes for EvmConfig {
                 spec,
                 block_gas_limit,
                 base_fee,
+                wei_per_mote,
             },
             remainder,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_scale_base_fee_to_wei() {
+        let config = EvmConfig {
+            base_fee: 3,
+            ..Default::default()
+        };
+
+        assert_eq!(config.base_fee_wei(), 3_000_000_000u128);
+    }
+
+    #[test]
+    fn should_convert_wei_gas_fee_to_motes() {
+        let config = EvmConfig::default();
+
+        assert_eq!(
+            config.gas_fee_motes(21_000, u128::from(DEFAULT_WEI_PER_MOTE)),
+            Some(U512::from(21_000))
+        );
+    }
+
+    #[test]
+    fn should_round_sub_mote_wei_gas_fee_up_to_one_mote() {
+        let config = EvmConfig::default();
+
+        assert_eq!(config.gas_fee_motes(1, 1), Some(U512::from(1)));
     }
 }

--- a/types/src/evm/transaction.rs
+++ b/types/src/evm/transaction.rs
@@ -1164,6 +1164,10 @@ impl EvmTransaction {
 
     /// Returns the effective gas price at the supplied block base fee.
     ///
+    /// The result follows the denomination of the transaction gas price fields
+    /// and the supplied block base fee. Node fee accounting supplies a
+    /// wei-denominated base fee.
+    ///
     /// Legacy and EIP-2930 transactions use their signed gas price directly.
     /// For EIP-1559, the calculation follows Ethereum's effective price
     /// formula: the lower of `max_fee_per_gas` and block base fee plus
@@ -1174,16 +1178,16 @@ impl EvmTransaction {
     /// prioritize transactions based on transaction gas parameters. For
     /// accepted node transactions, the EIP-1559 effective gas price is
     /// therefore the block base fee capped by `max_fee_per_gas`.
-    pub fn effective_gas_price(&self, base_fee: u64) -> u128 {
+    pub fn effective_gas_price(&self, base_fee: u128) -> u128 {
         match self.kind {
             EvmTransactionKind::Legacy | EvmTransactionKind::Eip2930 => {
                 self.gas_price.unwrap_or(self.max_fee_per_gas)
             }
             EvmTransactionKind::Eip1559 | EvmTransactionKind::Eip7702 => {
                 let max_priority_fee_per_gas = self.max_priority_fee_per_gas.unwrap_or(0);
-                let priority_fee = self.max_fee_per_gas.saturating_sub(u128::from(base_fee));
+                let priority_fee = self.max_fee_per_gas.saturating_sub(base_fee);
                 if priority_fee > max_priority_fee_per_gas {
-                    u128::from(base_fee).saturating_add(max_priority_fee_per_gas)
+                    base_fee.saturating_add(max_priority_fee_per_gas)
                 } else {
                     self.max_fee_per_gas
                 }
@@ -1191,12 +1195,13 @@ impl EvmTransaction {
         }
     }
 
-    /// Returns the fee amount for `gas_used` under the supplied EVM config.
+    /// Returns the fee amount for `gas_used`, denominated in motes.
     pub fn fee_amount(&self, gas_used: u64, evm_config: &EvmConfig) -> Option<U512> {
-        U512::from(gas_used).checked_mul(U512::from(self.effective_gas_price(evm_config.base_fee)))
+        let gas_price_wei = self.effective_gas_price(evm_config.base_fee_wei());
+        evm_config.gas_fee_motes(gas_used, gas_price_wei)
     }
 
-    /// Returns the maximum fee amount this transaction can consume.
+    /// Returns the maximum fee amount this transaction can consume, denominated in motes.
     pub fn max_fee_amount(&self, evm_config: &EvmConfig) -> Option<U512> {
         self.fee_amount(self.gas_limit, evm_config)
     }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -167,7 +167,7 @@ pub use display_iter::DisplayIter;
 pub use era_id::EraId;
 pub use evm::{
     EvmAddr, EvmApproval, EvmConfig, EvmSpec, EvmTransaction, EvmTransactionError,
-    EvmTransactionHash, EvmTransactionKind,
+    EvmTransactionHash, EvmTransactionKind, DEFAULT_WEI_PER_MOTE, MINIMUM_WEI_PER_MOTE,
 };
 pub use gas::Gas;
 #[cfg(feature = "json-schema")]

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -520,9 +520,12 @@ impl Transaction {
                 // checks. Node config compliance separately rejects non-zero
                 // priority fees, so accepted type-2 transactions do not imply
                 // transaction priority based on gas parameters.
-                Ok(Motes::new(txn.gas_limit().saturating_mul(
-                    txn.max_fee_per_gas().min(u64::MAX as u128) as u64,
-                )))
+                let gas_limit = crate::U512::from(txn.gas_limit());
+                let max_fee_per_gas = crate::U512::from(txn.max_fee_per_gas());
+                let fee = gas_limit
+                    .checked_mul(max_fee_per_gas)
+                    .unwrap_or(crate::U512::MAX);
+                Ok(Motes::new(fee))
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes EVM gas fee denomination across Casper’s mote-based accounting and Ethereum’s wei-based gas-price model.

Casper accounts and fee/refund handling operate in **motes**:

```text
1 CSPR = 10^9 motes
```

Ethereum gas prices operate in **wei**:

```text
1 ETH = 10^18 wei
```

To bridge the two:

```text
1 mote = 10^9 wei
```

The PR introduces an explicit `[evm].wei_per_mote` chainspec value and uses it to scale Casper’s EVM base fee into Ethereum-visible wei, then convert consumed EVM gas fees back into motes for Casper balance accounting.

## Ethereum Fee Background

Ethereum’s EVM uses gas prices denominated in wei per gas.

For the transaction variants currently supported:

- Legacy/type 0 and EIP-2930/type 1 use a fixed `gas_price`.
- EIP-1559/type 2 and EIP-7702/type 4 use dynamic-fee fields:
  - `max_fee_per_gas`
  - `max_priority_fee_per_gas`

Under EIP-1559-style rules, the effective gas price is:

```text
effective_gas_price = min(max_fee_per_gas, base_fee + max_priority_fee_per_gas)
```

The `BASEFEE` opcode returns the current block base fee, also denominated in wei.

Relevant specs:
- [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
- [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)
- [EIP-3198](https://eips.ethereum.org/EIPS/eip-3198)
- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)

## Casper Policy Difference

Casper currently does not prioritize EVM transactions by gas-price bidding. Therefore, accepting a fixed-price EVM overbid would charge the user more without giving them any scheduling benefit.

This PR makes that explicit:

```text
Legacy / EIP-2930:
gas_price == base_fee_wei
```

Dynamic-fee transactions still use `max_fee_per_gas` as a sender cap, but priority fees are rejected:

```text
EIP-1559 / EIP-7702:
max_fee_per_gas >= base_fee_wei
max_priority_fee_per_gas == 0
```

This may be revisited later if we introduce EVM gas-price-aware transaction ordering to be closer to the ETH mainnet transaction handling.

## Implementation

`[evm].base_fee` remains a chainspec policy value denominated in motes per EVM gas.

A new chainspec field defines the conversion ratio:

```toml
[evm]
base_fee = 1_000_000
wei_per_mote = 1_000_000_000
```

Runtime derives the EVM-visible base fee as:

```text
base_fee_wei = base_fee * wei_per_mote
```

That wei-denominated value is used for:

- EVM transaction config compliance.
- `revm` block context `basefee`.
- `BASEFEE` opcode behavior.
- receipt `effectiveGasPrice`.

After EVM execution, fees are converted back into motes:

```text
fee_motes = ceil(gas_used * effective_gas_price_wei / wei_per_mote)
```

The ceil is intentional because balances cannot represent fractional motes. Any non-zero sub-mote EVM fee is charged as one mote.